### PR TITLE
Fix the sign-in button doing nothing when pressed

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,12 +27,16 @@
         <nav class="ml-auto flex items-center gap-4 text-xs">
           <% if signed_in? %>
             <% if current_person&.admin? || current_person&.gm? %>
-              <%= link_to "編集", manage_scenarios_path, class: "text-seal" %>
+              <%= link_to "編集", manage_scenarios_path, class: "text-seal underline" %>
             <% end %>
             <span class="text-muted"><%= current_person&.display_name || "未登録" %></span>
-            <%= button_to "ログアウト", session_path, method: :delete, class: "text-muted" %>
+            <%= button_to "ログアウト", session_path, method: :delete,
+                  class: "cursor-pointer text-muted underline" %>
           <% else %>
-            <%= button_to "ログイン", "/auth/google_oauth2", method: :post, class: "text-seal" %>
+            <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
+            <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
+                  data: { turbo: false },
+                  class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
           <% end %>
         </nav>
       </div>

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "The sign-in button" do
+  # Turbo はフォーム送信を fetch に置き換えるため、Google への cross-origin リダイレクトを
+  # 追えず、押しても何も起きなくなる。ブラウザに素の送信をさせる必要がある。
+  it "opts out of Turbo so the browser follows the redirect to Google" do
+    get root_path
+
+    form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
+
+    expect(form).to be_present
+    expect(form).to include('data-turbo="false"')
+  end
+
+  # トークンそのものは test 環境が forgery protection を切っているため出ない。
+  # 開始を POST に限る点は spec/requests/sessions_spec.rb が GET で 404 を返すことで固定している。
+  it "submits over POST, so another site cannot start the flow with a link" do
+    get root_path
+
+    form = response.body[%r{<form[^>]*action="/auth/google_oauth2"[^>]*>}]
+
+    expect(form).to include('method="post"')
+  end
+
+  it "is not shown once signed in" do
+    sign_in_as create(:user, person: nil)
+
+    get root_path
+
+    expect(response.body).not_to include('action="/auth/google_oauth2"')
+  end
+end


### PR DESCRIPTION
The sign-in button did nothing when pressed in production.

The markup was fine. Turbo intercepts form submissions and replaces them with `fetch`, which cannot follow the cross-origin redirect to `accounts.google.com`, so the submission failed silently. `data: { turbo: false }` hands the submission back to the browser.

Also gave the button a border and a hover state — it previously rendered as bare text with no affordance, which is why it did not read as pressable either.

## Verification

- [x] `bin/rspec` — 144 examples, 0 failures, including one asserting the form opts out of Turbo
- [x] `prek run --all-files`

The spec is a markup assertion rather than a behavioural one; the failure mode is invisible without a JavaScript-capable driver, which Phase 0 kept out of CI.
