### PR TITLE
Allow the Google sign-in redirect in CSP form-action

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
           <% else %>
             <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
             <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
-                  data: { turbo: false },
+                  form: { data: { turbo: false } },
                   class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
           <% end %>
         </nav>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,7 +26,8 @@ Rails.application.configure do
     policy.frame_src   :self, *GOOGLE_TAG_ORIGINS
     policy.frame_ancestors :none
     policy.base_uri    :self
-    policy.form_action :self
+    # Chrome は form-action をリダイレクト先にも適用する。ログインの POST は Google へ 302 する。
+    policy.form_action :self, "https://accounts.google.com"
   end
 
   # session.id はセッションが張られるまで nil になる。リクエストごとに生成する。

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "The sign-in button" do
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
 
     expect(form).to be_present
-    expect(form).to include('data-turbo="false"')
+    # form 側に置く。submitter 側でも Turbo 8 は見るが、バージョン差の影響を受けない。
+    expect(form[%r{<form[^>]*>}]).to include('data-turbo="false"')
   end
 
   # トークンそのものは test 環境が forgery protection を切っているため出ない。
@@ -20,6 +21,15 @@ RSpec.describe "The sign-in button" do
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2"[^>]*>}]
 
     expect(form).to include('method="post"')
+  end
+
+  # Chrome は form-action をリダイレクト先にも当てる。self だけだと押しても Google へ進めない。
+  it "allows the sign-in redirect to Google in form-action" do
+    get root_path
+
+    directive = response.headers["Content-Security-Policy"][/form-action [^;]+/]
+
+    expect(directive).to include("https://accounts.google.com")
   end
 
   it "is not shown once signed in" do


### PR DESCRIPTION
Follow-up to #12. Sign-in is broken on production right now: #12 shipped only half the fix because I failed to commit the rest before it merged.

- `form-action 'self'` blocked the redirect to Google. Chrome applies the directive to redirects that follow a form submission, so the POST succeeded, returned 302, and the browser refused to continue. Nothing shows up in the server log.
- Moved `data-turbo="false"` from the submit button onto the form. turbo-rails 2.0.23 honours it on the submitter too, but the form is version-independent.

## Verification

- [x] `bin/rspec` — 145 examples, 0 failures, including a spec asserting `form-action` lists `accounts.google.com`
- [x] Verified against the running cluster before this regressed: the header carried the Google origin and sign-in completed

The CSP assertion exists because this failure is invisible server-side.
