### PR TITLE
Seed the scenario catalogue from the spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# 実際のシナリオ情報は公開しない。書式は db/seeds/scenarios.example.yml にある。
+/db/seeds/scenarios.yml
+
 # Ignore all environment files.
 /.env*
 !/.env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Ruby と Node は mise で固定している。`mise exec --` を通すか、mis
 - インフラ（PostgreSQL、MinIO、Ingress、Cloudflare Tunnel）は `yuno04-k3s` で管理する
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
 - 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
+- シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入は `bin/rails db:seed`（冪等）
+- 投入先の実データは `SCENARIOS_SEED_FILE` で差し替えられる。既定は gitignore 済みの `db/seeds/scenarios.yml`
 
 ## ドキュメント
 

--- a/app/controllers/manage/scenarios_controller.rb
+++ b/app/controllers/manage/scenarios_controller.rb
@@ -50,7 +50,7 @@ module Manage
         params.expect(
           scenario: [
             :title, :synopsis, :preparation_note, :recommendation_note,
-            :recommendation, :gm_experienced, :character_restriction, :character_sheet_deadline,
+            :recommendation, :gm_experienced, :character_restriction, :character_sheet_deadline, :character_sheet_deadline_note,
             :player_count_min, :player_count_max, :player_count_note,
             :duration_min_minutes, :duration_max_minutes, :jacket,
             { game_system_ids: [], author_ids: [],

--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -25,6 +25,7 @@ module ScenariosHelper
   end
 
   def character_sheet_deadline_label(scenario)
+    return scenario.character_sheet_deadline_note if scenario.character_sheet_deadline_note.present?
     return UNSET if scenario.character_sheet_deadline.blank?
 
     t("scenarios.character_sheet_deadlines.#{scenario.character_sheet_deadline}")

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -73,6 +73,11 @@
         <%= form.text_field :character_restriction, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
       </div>
       <div>
+        <%= form.label :character_sheet_deadline_note, "キャラシ提出期限の補足", class: "block text-xs text-muted" %>
+        <p class="text-xs text-muted">選択肢に当てはまらない場合はここに書く。書くと選択肢より優先して表示される。</p>
+        <%= form.text_field :character_sheet_deadline_note, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
+      </div>
+      <div>
         <%= form.label :character_sheet_deadline, "キャラシ提出期限", class: "block text-xs text-muted" %>
         <%= form.select :character_sheet_deadline,
               Scenario.character_sheet_deadlines.keys.map { |k| [ t("scenarios.character_sheet_deadlines.#{k}"), k ] },

--- a/db/migrate/20260810131131_add_character_sheet_deadline_note_to_scenarios.rb
+++ b/db/migrate/20260810131131_add_character_sheet_deadline_note_to_scenarios.rb
@@ -1,0 +1,5 @@
+class AddCharacterSheetDeadlineNoteToScenarios < ActiveRecord::Migration[8.1]
+  def change
+    add_column :scenarios, :character_sheet_deadline_note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_022944) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_131131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,6 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_022944) do
   create_table "scenarios", force: :cascade do |t|
     t.string "character_restriction"
     t.integer "character_sheet_deadline"
+    t.string "character_sheet_deadline_note"
     t.datetime "created_at", null: false
     t.integer "duration_max_minutes"
     t.integer "duration_min_minutes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,38 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# 初期投入。何度流しても同じ結果になる。
+# 実データは git に置かない。書式は db/seeds/scenarios.example.yml を見る。
+# 投入後はこのサイトが正になり、以後の編集は画面から行う。
+SEED_ATTRIBUTES = %w[
+  player_count_min player_count_max player_count_note
+  duration_min_minutes duration_max_minutes
+  recommendation gm_experienced
+  character_restriction character_sheet_deadline character_sheet_deadline_note
+  recommendation_note
+].freeze
+
+def seed_file
+  explicit = ENV["SCENARIOS_SEED_FILE"].presence
+  return Pathname.new(explicit) if explicit
+
+  real = Rails.root.join("db/seeds/scenarios.yml")
+  real.exist? ? real : Rails.root.join("db/seeds/scenarios.example.yml")
+end
+
+def seed_scenario(row)
+  scenario = Scenario.find_or_initialize_by(title: row.fetch("title"))
+  scenario.assign_attributes(row.slice(*SEED_ATTRIBUTES))
+  scenario.game_systems = Array(row["game_systems"]).map { |name| GameSystem.find_or_create_by!(name:) }
+  scenario.authors = Array(row["authors"]).map { |name| Author.find_or_create_by!(name:) }
+  scenario.save!
+
+  Array(row["purchase_links"]).each_with_index do |link, index|
+    record = scenario.purchase_links.find_or_initialize_by(label: link.fetch("label"))
+    record.update!(url: link["url"], position: index)
+  end
+
+  scenario
+end
+
+path = seed_file
+YAML.load_file(path).each { |row| seed_scenario(row) }
+
+puts "seeded from #{path.basename}: scenarios=#{Scenario.count} systems=#{GameSystem.count} authors=#{Author.count}"

--- a/db/seeds/scenarios.example.yml
+++ b/db/seeds/scenarios.example.yml
@@ -1,0 +1,41 @@
+# db/seeds/scenarios.yml の書式を示すサンプル。実データは git に置かない。
+# 投入するときは、このファイルを scenarios.yml にコピーして中身を差し替えるか、
+# SCENARIOS_SEED_FILE で別のパスを指す。
+- title: 見本シナリオ
+  game_systems:
+    - 見本システム 1版
+    - 見本システム 2版
+  authors:
+    - 見本作者
+    - 共著の見本作者
+  player_count_min: 2
+  player_count_max: 4
+  player_count_note: 程度
+  duration_min_minutes: 180
+  duration_max_minutes: 240
+  recommendation: 4
+  gm_experienced: true
+  character_restriction: HOあり
+  character_sheet_deadline: two_days_before
+  recommendation_note: おすすめポイントをここに書く。公開ページに出る。
+  purchase_links:
+    - label: BOOTH
+      url: https://example.com/items/1
+
+# 人数と時間は片側だけでもよい。両方空なら補足だけを表示する。
+- title: 人数制限のない見本
+  game_systems:
+    - 見本システム 1版
+  authors:
+    - 見本作者
+  player_count_note: 制限なし
+  duration_min_minutes: 30
+  duration_max_minutes: 60
+  gm_experienced: false
+  character_restriction: 制限なし
+  # 選択肢に当てはまらない期限は note に原文を残し、選択肢は see_note にする。
+  character_sheet_deadline: see_note
+  character_sheet_deadline_note: 継続の場合提出不要
+  purchase_links:
+    # URL を持たない入手先も書ける。
+    - label: 書籍購入者限定特典

--- a/spec/fixtures/scenarios_seed.yml
+++ b/spec/fixtures/scenarios_seed.yml
@@ -1,0 +1,70 @@
+# 実データは公開しないため、スペックは架空のシナリオで書式ごとの分岐を検証する。
+- title: 二系統の見本
+  game_systems:
+    - 見本システム 1版
+    - 見本システム 2版
+  authors:
+    - 見本作者
+    - 共著の見本作者
+  player_count_min: 4
+  player_count_max: 5
+  duration_min_minutes: 360
+  duration_max_minutes: 600
+  recommendation: 4
+  gm_experienced: true
+  character_restriction: HOあり
+  character_sheet_deadline: two_days_before
+  recommendation_note: 備考の見本。
+  purchase_links:
+    - label: BOOTH
+      url: https://example.com/items/1
+
+- title: 人数制限のない見本
+  game_systems:
+    - 見本システム 1版
+  authors:
+    - 見本作者
+  player_count_note: 制限なし
+  duration_min_minutes: 30
+  duration_max_minutes: 60
+  recommendation: 3
+  gm_experienced: true
+  character_sheet_deadline: day_before
+
+- title: 未実施の見本
+  game_systems:
+    - 見本システム 1版
+  authors:
+    - 見本作者
+  player_count_min: 4
+  player_count_max: 4
+  duration_min_minutes: 600
+  duration_max_minutes: 900
+  gm_experienced: false
+
+- title: 未評価の見本
+  game_systems:
+    - 見本システム 1版
+  authors:
+    - 見本作者
+  player_count_min: 2
+  player_count_max: 2
+  duration_min_minutes: 240
+  duration_max_minutes: 300
+  gm_experienced: true
+
+- title: 期限が選択肢に無い見本
+  game_systems:
+    - 見本システム 1版
+  authors:
+    - 見本作者
+  player_count_min: 1
+  player_count_max: 1
+  duration_min_minutes: 90
+  duration_max_minutes: 90
+  recommendation: 5
+  gm_experienced: true
+  character_sheet_deadline: see_note
+  character_sheet_deadline_note: 継続の場合提出不要
+  purchase_links:
+    - label: 書籍購入者限定特典

--- a/spec/helpers/scenarios_helper_spec.rb
+++ b/spec/helpers/scenarios_helper_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe ScenariosHelper do
         .to eq("セッション前々日")
     end
 
+    it "prefers the free-text note when the deadline does not fit the enum" do
+      scenario = build(:scenario, character_sheet_deadline: :see_note, character_sheet_deadline_note: "継続の場合提出不要")
+
+      expect(helper.character_sheet_deadline_label(scenario)).to eq("継続の場合提出不要")
+    end
+
     it "says unset for 「-」 and a blank cell" do
       expect(helper.character_sheet_deadline_label(build(:scenario, character_sheet_deadline: nil))).to eq("未設定")
     end

--- a/spec/seeds_spec.rb
+++ b/spec/seeds_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# 実データは公開しないため、書式ごとの分岐だけを架空のシナリオで確かめる。
+RSpec.describe "db/seeds.rb" do
+  let(:fixture) { Rails.root.join("spec/fixtures/scenarios_seed.yml") }
+
+  def load_seeds
+    ClimateControl.modify(SCENARIOS_SEED_FILE: fixture.to_s) { Rails.application.load_seed }
+  end
+
+  before { load_seeds }
+
+  it "loads every row in the file" do
+    expect(Scenario.count).to eq(YAML.load_file(fixture).size)
+  end
+
+  it "can be run twice without duplicating anything" do
+    counts = -> { [ Scenario.count, GameSystem.count, Author.count, PurchaseLink.count ] }
+    before = counts.call
+
+    load_seeds
+
+    expect(counts.call).to eq(before)
+  end
+
+  it "attaches every system a scenario names" do
+    scenario = Scenario.find_by(title: "二系統の見本")
+
+    expect(scenario.game_systems.map(&:name)).to contain_exactly("見本システム 1版", "見本システム 2版")
+  end
+
+  it "attaches every author of a jointly written scenario" do
+    scenario = Scenario.find_by(title: "二系統の見本")
+
+    expect(scenario.authors.map(&:name)).to contain_exactly("見本作者", "共著の見本作者")
+  end
+
+  it "keeps a note instead of inventing a player count" do
+    scenario = Scenario.find_by(title: "人数制限のない見本")
+
+    expect(scenario.player_count_min).to be_nil
+    expect(scenario.player_count_note).to eq("制限なし")
+  end
+
+  it "distinguishes a scenario the GM has never run from an unrated one" do
+    never_run = Scenario.find_by(title: "未実施の見本")
+    unrated = Scenario.find_by(title: "未評価の見本")
+
+    expect(never_run.gm_experienced).to be(false)
+    expect(never_run.recommendation).to be_nil
+    expect(unrated.gm_experienced).to be(true)
+    expect(unrated.recommendation).to be_nil
+  end
+
+  it "keeps a deadline that does not fit the enum as a note" do
+    scenario = Scenario.find_by(title: "期限が選択肢に無い見本")
+
+    expect(scenario.character_sheet_deadline).to eq("see_note")
+    expect(scenario.character_sheet_deadline_note).to eq("継続の場合提出不要")
+  end
+
+  it "records a purchase link that has no URL" do
+    link = Scenario.find_by(title: "期限が選択肢に無い見本").purchase_links.sole
+
+    expect(link.label).to eq("書籍購入者限定特典")
+    expect(link.url).to be_nil
+  end
+
+  it "leaves every row valid" do
+    expect(Scenario.all.reject(&:valid?)).to be_empty
+  end
+
+  it "ships a sample file that the loader accepts" do
+    sample = Rails.root.join("db/seeds/scenarios.example.yml")
+    expect(sample).to exist
+
+    Scenario.destroy_all
+    ClimateControl.modify(SCENARIOS_SEED_FILE: sample.to_s) { Rails.application.load_seed }
+
+    expect(Scenario.count).to eq(YAML.load_file(sample).size)
+  end
+end


### PR DESCRIPTION
Loads the 68 scenarios from the spreadsheet as seed data. `bin/rails db:seed`, idempotent.

Phase 1's plan said hand entry would beat writing a parser, because the column values vary a lot. That reasoning no longer holds: the sheet was read in full during this session, so the rows could be transcribed once and checked rather than parsed heuristically at runtime. `db/seeds/scenarios.yml` is the result; the app itself has no parser.

After this runs, the site is the source of truth and further edits happen through the screens.

## Schema change

`scenarios.character_sheet_deadline_note`. The sheet has 「継続の場合提出不要」, which none of the five enum values covers, and the enum will not keep up with cases like it. The note takes precedence over the enum when present, and the editing form explains that.

## Verification

- [x] `bin/rspec` — 155 examples, 0 failures
- [x] Seeding twice changes no counts
- [x] Spot-checked the awkward rows: two systems on one scenario, joint authors, 「制限なし」 kept as a note instead of a fabricated count, 「回したことない」 distinguished from unrated, a purchase link with a label and no URL, `30分～60分` and `11～18時間` both landing in minutes
- [x] Every seeded row is valid

## Not included

Jacket images. Whether a shop's product image may be redistributed differs by shop, so those go in by hand.

The sheet's other tables ("今後行くかもしれない", "回してほしいと言われている") are out — they are a personal backlog and they name other people, which does not belong in a public repo.
