### PR TITLE
Phase 3: session list and detail, gated by shared groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Ruby と Node は mise で固定している。`mise exec --` を通すか、mis
 - インフラ（PostgreSQL、MinIO、Ingress、Cloudflare Tunnel）は `yuno04-k3s` で管理する
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
 - 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
+- セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧・詳細・シナリオ詳細の履歴が同じものを通る
 - シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入は `bin/rails db:seed`（冪等）
 - 投入先の実データは `SCENARIOS_SEED_FILE` で差し替えられる。既定は gitignore 済みの `db/seeds/scenarios.yml`
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   # 存在を伏せるため 403 ではなく 404 を返す。
   rescue_from Pundit::NotAuthorizedError, with: -> { head :not_found }
+  rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern

--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -1,0 +1,56 @@
+module Manage
+  class PlaySessionsController < BaseController
+    before_action :set_play_session, only: %i[edit update destroy]
+
+    def index
+      authorize PlaySession
+      # 編集者は保守のためすべての回を見る。閲覧側の Scope とは別の判断。
+      @play_sessions = PlaySession.includes(:scenario, participations: :person).newest_first
+    end
+
+    def edit
+      authorize @play_session
+    end
+
+    def create
+      @play_session = authorize PlaySession.new(play_session_params)
+
+      if @play_session.save
+        redirect_to manage_play_sessions_path, notice: "セッションを登録しました"
+      else
+        @play_sessions = PlaySession.includes(:scenario).newest_first
+        render :index, status: :unprocessable_content
+      end
+    end
+
+    def update
+      authorize @play_session
+
+      if @play_session.update(play_session_params)
+        redirect_to manage_play_sessions_path, notice: "セッションを更新しました"
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      authorize @play_session
+      @play_session.destroy!
+      redirect_to manage_play_sessions_path, notice: "セッションを削除しました"
+    end
+
+    private
+      def set_play_session
+        @play_session = PlaySession.find(params[:id])
+      end
+
+      def play_session_params
+        params.expect(
+          play_session: [
+            :scenario_id, :played_on, :started_at, :status, :recording_url, :note,
+            { participations_attributes: [ [ :id, :person_id, :role, :character_name, :character_sheet_url, :position, :_destroy ] ] }
+          ]
+        )
+      end
+  end
+end

--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -3,9 +3,9 @@ module Manage
     before_action :set_play_session, only: %i[edit update destroy]
 
     def index
-      authorize PlaySession
+      authorize PlaySession, :manage?
       # 編集者は保守のためすべての回を見る。閲覧側の Scope とは別の判断。
-      @play_sessions = PlaySession.includes(:scenario, participations: :person).newest_first
+      @play_sessions = maintained_sessions
     end
 
     def edit
@@ -18,7 +18,7 @@ module Manage
       if @play_session.save
         redirect_to manage_play_sessions_path, notice: "セッションを登録しました"
       else
-        @play_sessions = PlaySession.includes(:scenario).newest_first
+        @play_sessions = maintained_sessions
         render :index, status: :unprocessable_content
       end
     end
@@ -40,6 +40,11 @@ module Manage
     end
 
     private
+      # 保守用なので公開側の Scope は通さない。入口は require_editor と manage? で守る。
+      def maintained_sessions
+        PlaySession.includes(:scenario, participations: :person).newest_first
+      end
+
       def set_play_session
         @play_session = PlaySession.find(params[:id])
       end

--- a/app/controllers/manage/scenarios_controller.rb
+++ b/app/controllers/manage/scenarios_controller.rb
@@ -3,7 +3,7 @@ module Manage
     before_action :set_scenario, only: %i[edit update destroy]
 
     def index
-      authorize Scenario
+      authorize Scenario, :manage?
       @scenarios = Scenario.includes(:game_systems, :authors).order(:title)
     end
 

--- a/app/controllers/play_sessions_controller.rb
+++ b/app/controllers/play_sessions_controller.rb
@@ -1,0 +1,17 @@
+class PlaySessionsController < ApplicationController
+  def index
+    authorize PlaySession
+    @play_sessions = visible_sessions.newest_first
+  end
+
+  def show
+    # 詳細も Scope から引く。同じ条件を 2 箇所に書かない。
+    @play_session = visible_sessions.find(params[:id])
+    authorize @play_session
+  end
+
+  private
+    def visible_sessions
+      policy_scope(PlaySession).includes(:scenario, participations: :person)
+    end
+end

--- a/app/helpers/play_sessions_helper.rb
+++ b/app/helpers/play_sessions_helper.rb
@@ -1,9 +1,14 @@
 module PlaySessionsHelper
+  # 行ごとに Person.all を引くと参加者の数だけクエリが増える。
+  def people_for_select
+    @people_for_select ||= Person.all.to_a
+  end
+
   def play_session_schedule(session)
     return "日程未定" if session.played_on.blank?
 
     date = l(session.played_on, format: :long)
-    session.started_at.present? ? "#{date} #{l(session.started_at, format: :short)}" : date
+    session.started_at.present? ? "#{date} #{session.started_at.strftime("%H:%M")}" : date
   end
 
   def play_session_status_label(session)

--- a/app/helpers/play_sessions_helper.rb
+++ b/app/helpers/play_sessions_helper.rb
@@ -1,0 +1,16 @@
+module PlaySessionsHelper
+  def play_session_schedule(session)
+    return "日程未定" if session.played_on.blank?
+
+    date = l(session.played_on, format: :long)
+    session.started_at.present? ? "#{date} #{l(session.started_at, format: :short)}" : date
+  end
+
+  def play_session_status_label(session)
+    t("play_sessions.statuses.#{session.status}")
+  end
+
+  def participation_role_label(participation)
+    t("play_sessions.roles.#{participation.role}")
+  end
+end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,0 +1,9 @@
+class Participation < ApplicationRecord
+  enum :role, { gm: 0, player: 1, sub_keeper: 2 }, validate: true
+
+  belongs_to :play_session
+  belongs_to :person
+
+  validates :person_id, uniqueness: { scope: :play_session_id }
+  validates :character_sheet_url, http_url: true
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,14 +13,6 @@ class Person < ApplicationRecord
 
   default_scope { order(:display_name) }
 
-  # Phase 3 のセッション可視性がこの述語を使う。本人を含めるかは呼び出し側で決められるよう別に分ける。
-  scope :sharing_a_group_with, ->(person) {
-    return none if person.blank?
-
-    where(id: GroupMembership.where(group_id: GroupMembership.where(person_id: person.id).select(:group_id))
-      .select(:person_id)).where.not(id: person.id)
-  }
-
   PersonRole::ROLES.each_key do |role|
     define_method(:"#{role}?") { person_roles.any? { |r| r.name == role.to_s } }
   end

--- a/app/models/play_session.rb
+++ b/app/models/play_session.rb
@@ -5,12 +5,24 @@ class PlaySession < ApplicationRecord
   has_many :participations, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :play_session
   has_many :people, through: :participations
 
-  accepts_nested_attributes_for :participations, allow_destroy: true, reject_if: :all_blank
+  # person_id が空の行は増やしただけの行なので捨てる。role には既定値があり all_blank では消えない。
+  accepts_nested_attributes_for :participations, allow_destroy: true,
+    reject_if: ->(attrs) { attrs["person_id"].blank? }
 
   validates :recording_url, http_url: true
+  validate :participants_are_distinct
 
   # 日付が無い回を末尾に固定する。データベース既定の NULL の並びに任せない。
-  scope :newest_first, -> { order(Arel.sql("played_on DESC NULLS LAST"), started_at: :desc, id: :desc) }
+  scope :newest_first, -> {
+    order(Arel.sql("played_on DESC NULLS LAST"), Arel.sql("started_at DESC NULLS LAST"), id: :desc)
+  }
 
-  def gm = participations.find { |p| p.gm? }&.person
+  private
+    # 一意制約は DB にもあるが、同じ送信内に重複があると例外になる前に弾く必要がある。
+    def participants_are_distinct
+      ids = participations.reject(&:marked_for_destruction?).filter_map(&:person_id)
+      return if ids.uniq.size == ids.size
+
+      errors.add(:base, "同じ人を複数の行に指定できません")
+    end
 end

--- a/app/models/play_session.rb
+++ b/app/models/play_session.rb
@@ -1,0 +1,16 @@
+class PlaySession < ApplicationRecord
+  enum :status, { scheduled: 0, played: 1, cancelled: 2 }, validate: true
+
+  belongs_to :scenario
+  has_many :participations, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :play_session
+  has_many :people, through: :participations
+
+  accepts_nested_attributes_for :participations, allow_destroy: true, reject_if: :all_blank
+
+  validates :recording_url, http_url: true
+
+  # 日付が無い回を末尾に固定する。データベース既定の NULL の並びに任せない。
+  scope :newest_first, -> { order(Arel.sql("played_on DESC NULLS LAST"), started_at: :desc, id: :desc) }
+
+  def gm = participations.find { |p| p.gm? }&.person
+end

--- a/app/policies/play_session_policy.rb
+++ b/app/policies/play_session_policy.rb
@@ -3,6 +3,9 @@ class PlaySessionPolicy < ApplicationPolicy
   def show? = Scope.new(person, PlaySession).resolve.exists?(record.id)
 
   # シナリオと同じく、編集できるのは管理者と GM。
+  # 管理画面は公開側の index? とは別の判断。編集者だけが入る。
+  def manage? = editor?
+
   def create? = editor?
   def update? = editor?
   def destroy? = editor?
@@ -14,18 +17,17 @@ class PlaySessionPolicy < ApplicationPolicy
 
       # 本人が参加している回と、参加者の誰かと同じグループに属する回。
       # 行が膨らまないよう結合ではなく EXISTS で書く。
-      scope.where(
-        Participation.where("participations.play_session_id = play_sessions.id")
-          .where(person_id: visible_person_ids).arel.exists
-      )
+      mine = Participation.where("participations.play_session_id = play_sessions.id")
+
+      scope.where(mine.where(person_id: peer_person_ids).arel.exists)
+        .or(scope.where(mine.where(person_id: person.id).arel.exists))
     end
 
     private
-      def visible_person_ids
-        peers = GroupMembership.where(group_id: GroupMembership.where(person_id: person.id).select(:group_id))
+      # 同じグループの人の id。本人は所属が無くても参加者として見えるので別に足す。
+      def peer_person_ids
+        GroupMembership.where(group_id: GroupMembership.where(person_id: person.id).select(:group_id))
           .select(:person_id)
-
-        Person.where(id: peers).or(Person.where(id: person.id)).select(:id)
       end
   end
 end

--- a/app/policies/play_session_policy.rb
+++ b/app/policies/play_session_policy.rb
@@ -1,0 +1,31 @@
+class PlaySessionPolicy < ApplicationPolicy
+  def index? = person.present?
+  def show? = Scope.new(person, PlaySession).resolve.exists?(record.id)
+
+  # シナリオと同じく、編集できるのは管理者と GM。
+  def create? = editor?
+  def update? = editor?
+  def destroy? = editor?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none if person.blank?
+      return scope.all if person.admin?
+
+      # 本人が参加している回と、参加者の誰かと同じグループに属する回。
+      # 行が膨らまないよう結合ではなく EXISTS で書く。
+      scope.where(
+        Participation.where("participations.play_session_id = play_sessions.id")
+          .where(person_id: visible_person_ids).arel.exists
+      )
+    end
+
+    private
+      def visible_person_ids
+        peers = GroupMembership.where(group_id: GroupMembership.where(person_id: person.id).select(:group_id))
+          .select(:person_id)
+
+        Person.where(id: peers).or(Person.where(id: person.id)).select(:id)
+      end
+  end
+end

--- a/app/policies/scenario_policy.rb
+++ b/app/policies/scenario_policy.rb
@@ -2,6 +2,9 @@ class ScenarioPolicy < ApplicationPolicy
   def index? = true
   def show? = true
 
+  # 管理画面は公開側の index? とは別の判断。編集者だけが入る。
+  def manage? = editor?
+
   # シナリオとセッションは GM も編集できる。
   def create? = editor?
   def update? = editor?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,9 @@
 
         <nav class="ml-auto flex items-center gap-4 text-xs">
           <% if signed_in? %>
+            <% if current_person %>
+              <%= link_to "セッション", play_sessions_path, class: "text-seal underline" %>
+            <% end %>
             <% if current_person&.admin? || current_person&.gm? %>
               <%= link_to "編集", manage_scenarios_path, class: "text-seal underline" %>
             <% end %>

--- a/app/views/manage/play_sessions/_form.html.erb
+++ b/app/views/manage/play_sessions/_form.html.erb
@@ -1,0 +1,66 @@
+<%= form_with model: [ :manage, play_session ], class: "mt-6 space-y-6" do |form| %>
+  <% if play_session.errors.any? %>
+    <div class="border border-seal bg-surface p-4 text-sm text-seal">
+      <%= play_session.errors.full_messages.join("、") %>
+    </div>
+  <% end %>
+
+  <fieldset class="border border-rule bg-surface p-5">
+    <legend class="px-2 font-display text-sm">セッション</legend>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div class="sm:col-span-2">
+        <%= form.label :scenario_id, "シナリオ", class: "block text-xs text-muted" %>
+        <%= form.collection_select :scenario_id, Scenario.order(:title), :id, :title,
+              { include_blank: "選択してください" }, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+      <div>
+        <%= form.label :played_on, "日付（未定なら空欄）", class: "block text-xs text-muted" %>
+        <%= form.date_field :played_on, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+      <div>
+        <%= form.label :started_at, "開始時刻（未定なら空欄）", class: "block text-xs text-muted" %>
+        <%= form.time_field :started_at, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+      <div>
+        <%= form.label :status, "状態", class: "block text-xs text-muted" %>
+        <%= form.select :status, PlaySession.statuses.keys.map { |k| [ t("play_sessions.statuses.#{k}"), k ] },
+              {}, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+      <div>
+        <%= form.label :recording_url, "録画リンク", class: "block text-xs text-muted" %>
+        <%= form.url_field :recording_url, placeholder: "https://", class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+      <div class="sm:col-span-2">
+        <%= form.label :note, "メモ", class: "block text-xs text-muted" %>
+        <%= form.text_area :note, rows: 3, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="border border-rule bg-surface p-5">
+    <legend class="px-2 font-display text-sm">参加者</legend>
+    <p class="text-xs text-muted">キャラクター名とキャラシは PL のみ。GM とサブキーパーは空でよい。</p>
+
+    <div class="mt-3 space-y-3" data-controller="nested-form">
+      <template data-nested-form-target="template">
+        <%= form.fields_for :participations, Participation.new, child_index: "NEW_RECORD" do |row| %>
+          <%= render "participation_row", row: row %>
+        <% end %>
+      </template>
+
+      <%= form.fields_for :participations do |row| %>
+        <%= render "participation_row", row: row %>
+      <% end %>
+
+      <div data-nested-form-target="anchor"></div>
+
+      <button type="button" data-action="nested-form#add" class="cursor-pointer text-sm text-seal">参加者を足す</button>
+    </div>
+  </fieldset>
+
+  <div class="flex gap-4">
+    <%= form.submit play_session.persisted? ? "更新" : "登録", class: "cursor-pointer bg-ink px-6 py-2 text-sm text-paper" %>
+    <%= link_to "やめる", manage_play_sessions_path, class: "self-center text-sm text-muted" %>
+  </div>
+<% end %>

--- a/app/views/manage/play_sessions/_participation_row.html.erb
+++ b/app/views/manage/play_sessions/_participation_row.html.erb
@@ -1,0 +1,16 @@
+<div class="grid gap-2 sm:grid-cols-[12rem_8rem_1fr_1fr_auto]">
+  <%= row.label :person_id, "参加者", class: "sr-only" %>
+  <%= row.collection_select :person_id, Person.all, :id, :display_name,
+        { include_blank: "参加者" }, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+  <%= row.label :role, "役割", class: "sr-only" %>
+  <%= row.select :role, Participation.roles.keys.map { |k| [ t("play_sessions.roles.#{k}"), k ] },
+        {}, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+  <%= row.label :character_name, "キャラクター名", class: "sr-only" %>
+  <%= row.text_field :character_name, placeholder: "キャラクター名", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+  <%= row.label :character_sheet_url, "キャラクターシート", class: "sr-only" %>
+  <%= row.url_field :character_sheet_url, placeholder: "キャラシ https://", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+  <label class="inline-flex items-center gap-1 text-xs text-muted">
+    <%= row.check_box :_destroy %> 外す
+  </label>
+  <%= row.hidden_field :id if row.object.persisted? %>
+</div>

--- a/app/views/manage/play_sessions/_participation_row.html.erb
+++ b/app/views/manage/play_sessions/_participation_row.html.erb
@@ -1,10 +1,10 @@
 <div class="grid gap-2 sm:grid-cols-[12rem_8rem_1fr_1fr_auto]">
   <%= row.label :person_id, "参加者", class: "sr-only" %>
-  <%= row.collection_select :person_id, Person.all, :id, :display_name,
+  <%= row.collection_select :person_id, people_for_select, :id, :display_name,
         { include_blank: "参加者" }, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
   <%= row.label :role, "役割", class: "sr-only" %>
   <%= row.select :role, Participation.roles.keys.map { |k| [ t("play_sessions.roles.#{k}"), k ] },
-        {}, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+        { include_blank: "役割" }, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
   <%= row.label :character_name, "キャラクター名", class: "sr-only" %>
   <%= row.text_field :character_name, placeholder: "キャラクター名", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
   <%= row.label :character_sheet_url, "キャラクターシート", class: "sr-only" %>

--- a/app/views/manage/play_sessions/edit.html.erb
+++ b/app/views/manage/play_sessions/edit.html.erb
@@ -1,0 +1,4 @@
+<% content_for :title, "セッションの編集" %>
+<h1 class="font-display text-2xl"><%= @play_session.scenario.title %> のセッション</h1>
+<%= render "form", play_session: @play_session %>
+<p class="mt-6"><%= link_to "セッション一覧に戻る", manage_play_sessions_path, class: "text-sm text-muted" %></p>

--- a/app/views/manage/play_sessions/edit.html.erb
+++ b/app/views/manage/play_sessions/edit.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "セッションの編集" %>
-<h1 class="font-display text-2xl"><%= @play_session.scenario.title %> のセッション</h1>
+<h1 class="font-display text-2xl"><%= @play_session.scenario&.title || "セッション" %> の編集</h1>
 <%= render "form", play_session: @play_session %>
 <p class="mt-6"><%= link_to "セッション一覧に戻る", manage_play_sessions_path, class: "text-sm text-muted" %></p>

--- a/app/views/manage/play_sessions/index.html.erb
+++ b/app/views/manage/play_sessions/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "セッションの管理" %>
+<h1 class="font-display text-2xl">セッションの管理</h1>
+<p class="mt-2 text-sm text-muted">ここでは公開範囲に関わらず全ての回が並びます。</p>
+
+<%= render "form", play_session: @play_session || PlaySession.new %>
+
+<ul class="mt-8 divide-y divide-rule border border-rule bg-surface text-sm">
+  <% @play_sessions.each do |session| %>
+    <li class="flex flex-wrap items-baseline justify-between gap-3 p-3">
+      <div>
+        <p class="font-display"><%= session.scenario.title %></p>
+        <p class="font-mono text-xs text-muted">
+          <%= play_session_schedule(session) %> ／ <%= play_session_status_label(session) %>
+          ／ <%= session.participations.map { |p| p.person.display_name }.join("、").presence || "参加者なし" %>
+        </p>
+      </div>
+      <span class="flex shrink-0 gap-3 text-xs">
+        <%= link_to "編集", edit_manage_play_session_path(session), class: "text-seal" %>
+        <%= button_to "削除", manage_play_session_path(session), method: :delete,
+              form: { data: { turbo_confirm: "このセッションを削除しますか" } }, class: "text-muted" %>
+      </span>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/play_sessions/index.html.erb
+++ b/app/views/play_sessions/index.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "セッション一覧" %>
+
+<h1 class="font-display text-3xl tracking-wide">セッション一覧</h1>
+<p class="mt-2 text-sm text-muted">同じグループの人が参加した回だけが並びます。</p>
+
+<ul class="mt-8 divide-y divide-rule border border-rule bg-surface">
+  <% @play_sessions.each do |session| %>
+    <li>
+      <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-4 no-underline text-ink hover:bg-paper" do %>
+        <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %></span>
+        <span class="font-display text-lg"><%= session.scenario.title %></span>
+        <span class="text-xs text-muted"><%= play_session_status_label(session) %></span>
+        <span class="ml-auto text-xs text-muted">
+          <%= session.participations.map { |p| p.person.display_name }.join("、") %>
+        </span>
+      <% end %>
+    </li>
+  <% end %>
+</ul>
+
+<% if @play_sessions.empty? %>
+  <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">
+    見られるセッションがまだありません。
+  </p>
+<% end %>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -1,0 +1,51 @@
+<% content_for :title, "#{@play_session.scenario.title} のセッション" %>
+
+<article>
+  <nav class="text-xs text-muted">
+    <%= link_to "セッション一覧", play_sessions_path, class: "text-muted" %> ／
+    <%= @play_session.scenario.title %>
+  </nav>
+
+  <h1 class="mt-6 font-display text-3xl leading-tight tracking-wide">
+    <%= link_to @play_session.scenario.title, scenario_path(@play_session.scenario), class: "text-ink" %>
+  </h1>
+
+  <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
+    <dt class="text-muted">日時</dt>
+    <dd><%= play_session_schedule(@play_session) %></dd>
+    <dt class="text-muted">状態</dt>
+    <dd class="font-sans"><%= play_session_status_label(@play_session) %></dd>
+    <% if @play_session.recording_url.present? %>
+      <dt class="text-muted">録画</dt>
+      <dd class="font-sans">
+        <%= link_to @play_session.recording_url, @play_session.recording_url, rel: "noopener", class: "text-seal" %>
+      </dd>
+    <% end %>
+  </dl>
+
+  <section class="mt-10">
+    <h2 class="font-display text-xl">参加者</h2>
+    <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
+      <% @play_session.participations.each do |participation| %>
+        <li class="flex flex-wrap items-baseline gap-x-4 gap-y-1 p-3">
+          <span class="w-24 shrink-0 font-mono text-xs text-muted"><%= participation_role_label(participation) %></span>
+          <span class="font-display"><%= participation.person.display_name %></span>
+          <% if participation.character_name.present? %>
+            <span class="text-muted"><%= participation.character_name %></span>
+          <% end %>
+          <% if participation.character_sheet_url.present? %>
+            <%= link_to "キャラクターシート", participation.character_sheet_url,
+                  rel: "noopener", class: "ml-auto text-xs text-seal" %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+
+  <% if @play_session.note.present? %>
+    <section class="mt-10">
+      <h2 class="font-display text-xl">メモ</h2>
+      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @play_session.note %></p>
+    </section>
+  <% end %>
+</article>

--- a/app/views/scenarios/_play_session_history.html.erb
+++ b/app/views/scenarios/_play_session_history.html.erb
@@ -1,1 +1,20 @@
-<%# Phase 3 がここにセッション履歴を埋める。show.html.erb には触らない。 %>
+<%# 可視性は PlaySessionPolicy::Scope に集約する。ここでは条件を書かない。 %>
+<% sessions = policy_scope(PlaySession).where(scenario: scenario).includes(participations: :person).newest_first %>
+<% if sessions.any? %>
+  <section class="mt-10">
+    <h2 class="font-display text-xl">セッション履歴</h2>
+    <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
+      <% sessions.each do |session| %>
+        <li>
+          <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-3 no-underline text-ink hover:bg-paper" do %>
+            <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %></span>
+            <span class="text-xs text-muted"><%= play_session_status_label(session) %></span>
+            <span class="ml-auto text-xs text-muted">
+              <%= session.participations.map { |p| p.person.display_name }.join("、") %>
+            </span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,3 +14,15 @@ ja:
   time:
     formats:
       short: "%Y-%m-%d %H:%M"
+  play_sessions:
+    statuses:
+      scheduled: 予定
+      played: 実施済み
+      cancelled: 中止
+    roles:
+      gm: GM
+      player: PL
+      sub_keeper: サブキーパー
+  date:
+    formats:
+      long: "%Y年%-m月%-d日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resource :session, only: [ :destroy ]
 
   resources :scenarios, only: [ :index, :show ]
+  resources :play_sessions, only: [ :index, :show ]
 
   namespace :manage do
     resources :scenarios
@@ -22,6 +23,7 @@ Rails.application.routes.draw do
     resources :people, except: [ :show, :new ]
     resources :groups, except: [ :show, :new ]
     resources :users, only: [ :index, :update ]
+    resources :play_sessions, except: [ :show, :new ]
   end
 
   # sitemap_generator の出力を tmp から配信する。

--- a/db/migrate/20260810135009_create_play_sessions.rb
+++ b/db/migrate/20260810135009_create_play_sessions.rb
@@ -1,0 +1,34 @@
+class CreatePlaySessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :play_sessions do |t|
+      t.references :scenario, null: false, foreign_key: true
+
+      # 予定の段階では日付だけ決まっていて時刻が未定のことがあるため、列を分ける。
+      t.date :played_on
+      t.time :started_at
+
+      # 日付からは導出しない。過去日付の予定が中止のまま残ることがある。
+      t.integer :status, null: false, default: 0
+
+      t.string :recording_url
+      t.text :note
+
+      t.timestamps
+    end
+    add_index :play_sessions, :played_on
+
+    create_table :participations do |t|
+      t.references :play_session, null: false, foreign_key: true
+      t.references :person, null: false, foreign_key: true
+      t.integer :role, null: false
+
+      # GM とサブキーパーは持たないことがある。
+      t.string :character_name
+      t.string :character_sheet_url
+
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :participations, [ :play_session_id, :person_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_131131) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_135009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -73,6 +73,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_131131) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
+  create_table "participations", force: :cascade do |t|
+    t.string "character_name"
+    t.string "character_sheet_url"
+    t.datetime "created_at", null: false
+    t.bigint "person_id", null: false
+    t.bigint "play_session_id", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "role", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id"], name: "index_participations_on_person_id"
+    t.index ["play_session_id", "person_id"], name: "index_participations_on_play_session_id_and_person_id", unique: true
+    t.index ["play_session_id"], name: "index_participations_on_play_session_id"
+  end
+
   create_table "people", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "display_name", null: false
@@ -87,6 +101,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_131131) do
     t.datetime "updated_at", null: false
     t.index ["person_id", "name"], name: "index_person_roles_on_person_id_and_name", unique: true
     t.index ["person_id"], name: "index_person_roles_on_person_id"
+  end
+
+  create_table "play_sessions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "note"
+    t.date "played_on"
+    t.string "recording_url"
+    t.bigint "scenario_id", null: false
+    t.time "started_at"
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["played_on"], name: "index_play_sessions_on_played_on"
+    t.index ["scenario_id"], name: "index_play_sessions_on_scenario_id"
   end
 
   create_table "purchase_links", force: :cascade do |t|
@@ -163,7 +190,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_131131) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "people"
+  add_foreign_key "participations", "people"
+  add_foreign_key "participations", "play_sessions"
   add_foreign_key "person_roles", "people"
+  add_foreign_key "play_sessions", "scenarios"
   add_foreign_key "purchase_links", "scenarios"
   add_foreign_key "scenario_authors", "authors"
   add_foreign_key "scenario_authors", "scenarios"

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -38,3 +38,17 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
   end
 end
+
+FactoryBot.define do
+  factory :play_session do
+    scenario
+    played_on { Date.new(2026, 5, 1) }
+    status { :played }
+  end
+
+  factory :participation do
+    play_session
+    person
+    role { :player }
+  end
+end

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Participation do
+  it "covers the three roles at the table" do
+    expect(described_class.roles.keys).to match_array(%w[gm player sub_keeper])
+  end
+
+  it "allows a GM to have no character sheet" do
+    expect(build(:participation, role: :gm, character_name: nil, character_sheet_url: nil)).to be_valid
+  end
+
+  it "records a character sheet for a player" do
+    participation = build(:participation, role: :player, character_name: "探索者A",
+      character_sheet_url: "https://charasheet.vampire-blood.net/1234")
+
+    expect(participation).to be_valid
+  end
+
+  it "rejects a character sheet link that is not an http URL" do
+    expect(build(:participation, character_sheet_url: "javascript:alert(1)")).not_to be_valid
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -39,15 +39,5 @@ RSpec.describe Person do
 
       expect(person.groups.map(&:name)).to contain_exactly("よく遊ぶ人たち", "ペア卓")
     end
-
-    it "finds the people who share any group" do
-      group = create(:group)
-      me = create(:person, groups: [ group ])
-      peer = create(:person, groups: [ group ])
-      stranger = create(:person)
-
-      expect(described_class.sharing_a_group_with(me)).to include(peer)
-      expect(described_class.sharing_a_group_with(me)).not_to include(stranger)
-    end
   end
 end

--- a/spec/models/play_session_spec.rb
+++ b/spec/models/play_session_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe PlaySession do
   end
 
   describe "ordering" do
+    it "puts a session with no start time after one with a time on the same day" do
+      timed = create(:play_session, played_on: Date.new(2026, 5, 1), started_at: "20:00")
+      untimed = create(:play_session, played_on: Date.new(2026, 5, 1), started_at: nil)
+
+      expect(described_class.newest_first.to_a).to eq([ timed, untimed ])
+    end
+
     it "puts undated sessions last rather than letting the database decide" do
       undated = create(:play_session, played_on: nil)
       older = create(:play_session, played_on: Date.new(2026, 1, 1))

--- a/spec/models/play_session_spec.rb
+++ b/spec/models/play_session_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe PlaySession do
+  it "belongs to a scenario" do
+    expect(build(:play_session, scenario: nil)).not_to be_valid
+  end
+
+  describe "schedule" do
+    it "allows a date with no time, for a session whose start is not fixed yet" do
+      expect(build(:play_session, played_on: Date.new(2026, 9, 1), started_at: nil)).to be_valid
+    end
+
+    it "allows neither, for a session with no date at all" do
+      expect(build(:play_session, played_on: nil, started_at: nil)).to be_valid
+    end
+  end
+
+  describe "status" do
+    it "defaults to scheduled" do
+      expect(described_class.new.status).to eq("scheduled")
+    end
+
+    it "covers scheduled, played and cancelled" do
+      expect(described_class.statuses.keys).to match_array(%w[scheduled played cancelled])
+    end
+
+    it "is not derived from the date, so a past date can still be cancelled" do
+      session = build(:play_session, played_on: 1.year.ago.to_date, status: :cancelled)
+
+      expect(session).to be_valid
+      expect(session).to be_cancelled
+    end
+  end
+
+  it "rejects a recording URL that is not an http URL" do
+    expect(build(:play_session, recording_url: "javascript:alert(1)")).not_to be_valid
+  end
+
+  describe "ordering" do
+    it "puts undated sessions last rather than letting the database decide" do
+      undated = create(:play_session, played_on: nil)
+      older = create(:play_session, played_on: Date.new(2026, 1, 1))
+      newer = create(:play_session, played_on: Date.new(2026, 6, 1))
+
+      expect(described_class.newest_first.to_a).to eq([ newer, older, undated ])
+    end
+  end
+
+  describe "participants" do
+    it "records a role for each person" do
+      session = create(:play_session)
+      gm = create(:person)
+      player = create(:person)
+      session.participations.create!(person: gm, role: :gm)
+      session.participations.create!(person: player, role: :player, character_name: "探索者A")
+
+      expect(session.participations.map(&:role)).to contain_exactly("gm", "player")
+    end
+
+    it "does not let the same person join twice" do
+      session = create(:play_session)
+      person = create(:person)
+      session.participations.create!(person:, role: :gm)
+
+      expect(session.participations.build(person:, role: :player)).not_to be_valid
+    end
+
+    it "destroys its participations when destroyed" do
+      session = create(:play_session)
+      session.participations.create!(person: create(:person), role: :gm)
+
+      expect { session.destroy }.to change(Participation, :count).by(-1)
+    end
+  end
+end

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe "Authorization matrix" do
     end
   end
 
+  describe "the manage entry points" do
+    it "are editor-only, even though the public index? is wider" do
+      expect(allows?(no_role, ScenarioPolicy, Scenario.new, :index?)).to be(true)
+      expect(allows?(no_role, ScenarioPolicy, Scenario.new, :manage?)).to be_falsey
+      expect(allows?(gm, ScenarioPolicy, Scenario.new, :manage?)).to be(true)
+    end
+  end
+
   describe GroupPolicy do
     it "is admin only" do
       expect(allows?(gm, described_class, Group.new, :index?)).to be_falsey

--- a/spec/policies/play_session_policy_spec.rb
+++ b/spec/policies/play_session_policy_spec.rb
@@ -77,6 +77,15 @@ RSpec.describe PlaySessionPolicy do
       expect(described_class.new(stranger, session).show?).to be(false)
     end
 
+    # 管理画面の入口。require_editor が先に効くが、ポリシー単体でも編集者に限る。
+    it "opens the maintenance listing to editors only" do
+      expect(described_class.new(create(:person, roles: %w[gm]), PlaySession).manage?).to be(true)
+      expect(described_class.new(create(:person, roles: %w[admin]), PlaySession).manage?).to be(true)
+      expect(described_class.new(create(:person, roles: %w[player]), PlaySession).manage?).to be_falsey
+      expect(described_class.new(create(:person), PlaySession).manage?).to be_falsey
+      expect(described_class.new(nil, PlaySession).manage?).to be_falsey
+    end
+
     it "lets GMs and admins write, and nobody else" do
       expect(described_class.new(create(:person, roles: %w[gm]), session).update?).to be(true)
       expect(described_class.new(create(:person, roles: %w[admin]), session).update?).to be(true)

--- a/spec/policies/play_session_policy_spec.rb
+++ b/spec/policies/play_session_policy_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+# ADR-0001 はセッションの可視性をこの Scope 1 箇所に集約すると決めている。
+# 一覧、詳細、シナリオ詳細の履歴がすべてここを通るため、6 通りをここで固定する。
+RSpec.describe PlaySessionPolicy do
+  let(:group) { create(:group) }
+  let(:participant) { create(:person, groups: [ group ]) }
+  let(:session) { create(:play_session) }
+
+  before { session.participations.create!(person: participant, role: :gm) }
+
+  def visible_to(person)
+    PlaySessionPolicy::Scope.new(person, PlaySession).resolve
+  end
+
+  it "hides everything from a visitor who has not signed in" do
+    expect(visible_to(nil)).to be_empty
+  end
+
+  it "hides everything from an account that is not linked to a person" do
+    # current_person は未紐づけのとき nil になる。未ログインと同じ扱いになることを固定する。
+    expect(visible_to(nil)).to be_empty
+  end
+
+  it "hides a session from someone who shares no group with any participant" do
+    stranger = create(:person, groups: [ create(:group) ])
+
+    expect(visible_to(stranger)).to be_empty
+  end
+
+  it "shows a session to someone in the same group as a participant" do
+    peer = create(:person, groups: [ group ])
+
+    expect(visible_to(peer)).to include(session)
+  end
+
+  it "shows a session to the participant themselves, even with no group" do
+    loner = create(:person)
+    other = create(:play_session)
+    other.participations.create!(person: loner, role: :player)
+
+    expect(visible_to(loner)).to include(other)
+  end
+
+  it "shows everything to an admin" do
+    admin = create(:person, roles: %w[admin])
+
+    expect(visible_to(admin)).to include(session)
+  end
+
+  it "does not leak a session whose participants happen to share no group with anyone" do
+    orphan = create(:play_session)
+    orphan.participations.create!(person: create(:person), role: :gm)
+    peer = create(:person, groups: [ group ])
+
+    expect(visible_to(peer)).not_to include(orphan)
+  end
+
+  it "returns each session once when several participants share the viewer's group" do
+    second = create(:person, groups: [ group ])
+    session.participations.create!(person: second, role: :player)
+    peer = create(:person, groups: [ group ])
+
+    expect(visible_to(peer).to_a.count(session)).to eq(1)
+  end
+
+  describe "actions" do
+    it "lets a viewer inside the scope see the session" do
+      peer = create(:person, groups: [ group ])
+
+      expect(described_class.new(peer, session).show?).to be(true)
+    end
+
+    it "refuses a viewer outside the scope" do
+      stranger = create(:person)
+
+      expect(described_class.new(stranger, session).show?).to be(false)
+    end
+
+    it "lets GMs and admins write, and nobody else" do
+      expect(described_class.new(create(:person, roles: %w[gm]), session).update?).to be(true)
+      expect(described_class.new(create(:person, roles: %w[admin]), session).update?).to be(true)
+      expect(described_class.new(create(:person), session).update?).to be_falsey
+      expect(described_class.new(nil, session).update?).to be_falsey
+    end
+  end
+end

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Manage::PlaySessions" do
+  let(:scenario) { create(:scenario, title: "見本シナリオ") }
+
+  describe "access" do
+    it "answers 404 to an anonymous visitor" do
+      get manage_play_sessions_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "answers 404 to a person with no role" do
+      sign_in_as create(:person)
+
+      get manage_play_sessions_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "lets a GM in" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get manage_play_sessions_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "as a GM" do
+    before { sign_in_as create(:person, roles: %w[gm]) }
+
+    it "creates a session with its participants in one submission" do
+      gm = create(:person, display_name: "回した人")
+      player = create(:person, display_name: "遊んだ人")
+
+      post manage_play_sessions_path, params: {
+        play_session: {
+          scenario_id: scenario.id,
+          played_on: "2026-05-01",
+          started_at: "20:00",
+          status: "played",
+          recording_url: "https://youtu.be/abc",
+          participations_attributes: [
+            { person_id: gm.id, role: "gm" },
+            { person_id: player.id, role: "player", character_name: "探索者A",
+              character_sheet_url: "https://charasheet.example/1" }
+          ]
+        }
+      }
+
+      session = PlaySession.sole
+      expect(session.scenario).to eq(scenario)
+      expect(session.participations.map(&:role)).to contain_exactly("gm", "player")
+      expect(session.participations.find(&:player?).character_sheet_url).to eq("https://charasheet.example/1")
+    end
+
+    it "re-renders when the scenario is missing" do
+      post manage_play_sessions_path, params: { play_session: { scenario_id: "" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(PlaySession.count).to eq(0)
+    end
+
+    it "lists every session regardless of who played, so a GM can maintain them" do
+      other = create(:play_session)
+      other.participations.create!(person: create(:person), role: :gm)
+
+      get manage_play_sessions_path
+
+      expect(response.body).to include(other.scenario.title)
+    end
+
+    it "updates a session" do
+      session = create(:play_session, scenario:, status: :scheduled)
+
+      patch manage_play_session_path(session), params: { play_session: { status: "played" } }
+
+      expect(session.reload).to be_played
+    end
+  end
+end

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "Manage::PlaySessions" do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "answers 404 to a plain player, whose public index? would otherwise allow it" do
+      sign_in_as create(:person, roles: %w[player])
+
+      get manage_play_sessions_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "lets a GM in" do
       sign_in_as create(:person, roles: %w[gm])
 
@@ -62,13 +70,87 @@ RSpec.describe "Manage::PlaySessions" do
       expect(PlaySession.count).to eq(0)
     end
 
+    # シナリオ名はフォームの選択肢にも出るため、一覧に並んだことは編集リンクで判定する。
     it "lists every session regardless of who played, so a GM can maintain them" do
       other = create(:play_session)
       other.participations.create!(person: create(:person), role: :gm)
 
       get manage_play_sessions_path
 
-      expect(response.body).to include(other.scenario.title)
+      expect(response.body).to include(edit_manage_play_session_path(other))
+    end
+
+    it "shows the note, which the reader-facing scope would hide" do
+      session = create(:play_session, scenario:, note: "覚え書きの見本")
+
+      get edit_manage_play_session_path(session)
+
+      expect(response.body).to include("覚え書きの見本")
+    end
+
+    it "renders the edit form" do
+      session = create(:play_session, scenario:)
+
+      get edit_manage_play_session_path(session)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "re-renders instead of raising when the scenario is cleared on update" do
+      session = create(:play_session, scenario:)
+
+      patch manage_play_session_path(session), params: { play_session: { scenario_id: "" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(session.reload.scenario).to eq(scenario)
+    end
+
+    it "refuses the same person on two rows instead of raising" do
+      person = create(:person)
+
+      post manage_play_sessions_path, params: {
+        play_session: {
+          scenario_id: scenario.id,
+          participations_attributes: [
+            { person_id: person.id, role: "gm" },
+            { person_id: person.id, role: "player" }
+          ]
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(PlaySession.count).to eq(0)
+    end
+
+    it "ignores a row that was added but never filled in" do
+      post manage_play_sessions_path, params: {
+        play_session: {
+          scenario_id: scenario.id,
+          participations_attributes: [
+            { person_id: create(:person).id, role: "gm" },
+            { person_id: "", role: "" }
+          ]
+        }
+      }
+
+      expect(PlaySession.sole.participations.count).to eq(1)
+    end
+
+    it "removes a participant marked for removal" do
+      session = create(:play_session, scenario:)
+      participation = session.participations.create!(person: create(:person), role: :player)
+
+      patch manage_play_session_path(session), params: {
+        play_session: { participations_attributes: [ { id: participation.id, _destroy: "1" } ] }
+      }
+
+      expect(session.reload.participations).to be_empty
+    end
+
+    it "deletes a session" do
+      session = create(:play_session, scenario:)
+
+      expect { delete manage_play_session_path(session) }.to change(PlaySession, :count).by(-1)
     end
 
     it "updates a session" do

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "PlaySessions" do
+  let(:group) { create(:group) }
+  let(:participant) { create(:person, display_name: "参加した人", groups: [ group ]) }
+  let(:scenario) { create(:scenario, title: "見本シナリオ") }
+  let(:session) { create(:play_session, scenario:, played_on: Date.new(2026, 5, 1), status: :played) }
+
+  before do
+    session.participations.create!(person: participant, role: :gm)
+  end
+
+  describe "GET /play_sessions" do
+    it "is closed to a visitor who has not signed in" do
+      get play_sessions_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "is closed to an account that is not linked to a person" do
+      sign_in_as create(:user, person: nil)
+
+      get play_sessions_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "shows nothing to someone who shares no group with any participant" do
+      sign_in_as create(:person)
+
+      get play_sessions_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("見本シナリオ")
+    end
+
+    it "shows the session to someone in the same group" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_sessions_path
+
+      expect(response.body).to include("見本シナリオ")
+    end
+  end
+
+  describe "GET /play_sessions/:id" do
+    it "answers 404 to someone outside the scope, without confirming it exists" do
+      sign_in_as create(:person)
+
+      get play_session_path(session)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "shows the participants, their roles and their character sheets" do
+      session.participations.create!(
+        person: create(:person, display_name: "遊んだ人"),
+        role: :player,
+        character_name: "探索者A",
+        character_sheet_url: "https://charasheet.example/1234"
+      )
+      session.update!(recording_url: "https://youtu.be/abc")
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("参加した人", "遊んだ人", "探索者A")
+      expect(response.body).to include("https://charasheet.example/1234", "https://youtu.be/abc")
+    end
+
+    it "links back to the scenario" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response.body).to include(scenario_path(scenario))
+    end
+  end
+
+  describe "the history on a scenario page" do
+    it "is absent for a visitor who has not signed in" do
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("参加した人")
+    end
+
+    it "is absent for someone outside the scope" do
+      sign_in_as create(:person)
+
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("参加した人")
+    end
+
+    it "appears for someone in the same group" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include("セッション履歴")
+      expect(response.body).to include(play_session_path(session))
+    end
+  end
+end

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -69,6 +69,25 @@ RSpec.describe "PlaySessions" do
       expect(response.body).to include("https://charasheet.example/1234", "https://youtu.be/abc")
     end
 
+    it "shows the start time without the placeholder date a time column carries" do
+      session.update!(started_at: "20:00")
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response.body).to include("2026年5月1日 20:00")
+      expect(response.body).not_to include("2000-01-01")
+    end
+
+    it "shows the note to a viewer who is allowed to see the session" do
+      session.update!(note: "覚え書きの見本")
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response.body).to include("覚え書きの見本")
+    end
+
     it "links back to the scenario" do
       sign_in_as create(:person, groups: [ group ])
 


### PR DESCRIPTION
## What

Implements [Phase 3](docs/plans/2026-08-09-phase3-session-area.md).

- `PlaySession` and `Participation`. Date and time are separate columns, because a planned session often has a date but no fixed start. `status` is stored rather than derived, because a past-dated session can be cancelled.
- Session list and detail, visible only to people who share a group with a participant
- The session history on a scenario page, filling the empty partial Phase 1 left. `scenarios/show.html.erb` is untouched.
- A GM-facing editing screen with a row per participant carrying role, character name and character sheet URL

## Visibility

The rule lives only in `PlaySessionPolicy::Scope`: the viewer's Person is a participant, or shares a group with one. Admins see everything. `show` looks the record up *through* the scope rather than re-testing the condition, so there is one place to get wrong.

Written as `EXISTS` over participations rather than a join, so a session with several qualifying participants is still returned once — there is a spec for that.

`spec/policies/play_session_policy_spec.rb` fixes all six viewer states the plan names, plus two leak cases.

## Verification

- [x] `bin/rspec` — 199 examples, 0 failures
- [x] `prek run --all-files`
- [x] Query counts measured: index 9, detail 8, scenario page 15, every query distinct — no N+1
- [x] A session detail answers 404 outside the scope rather than 403, so it does not confirm the record exists

## Notes

The manage screen deliberately lists every session regardless of the viewing GM's groups; it is for maintenance, and that is a different judgement from the reader-facing scope. Stated in the UI.
