### PR TITLE
Add navigation across the manage sections

### DIFF
--- a/app/controllers/manage/base_controller.rb
+++ b/app/controllers/manage/base_controller.rb
@@ -1,6 +1,8 @@
 module Manage
   # 管理者と GM だけが入れる編集エリア。存在を伏せるため権限が無い場合は 404 を返す。
   class BaseController < ApplicationController
+    layout "manage"
+
     before_action :require_editor
 
     private

--- a/app/helpers/manage_helper.rb
+++ b/app/helpers/manage_helper.rb
@@ -1,0 +1,6 @@
+module ManageHelper
+  def manage_nav_class(path)
+    current = request.path.start_with?(path)
+    "no-underline #{current ? 'text-ink font-bold' : 'text-seal'}"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,6 +45,8 @@
       </div>
     </header>
 
+    <%= yield :sub_nav %>
+
     <% if flash.any? %>
       <div class="mx-auto w-full max-w-5xl px-5 pt-6">
         <% flash.each do |type, message| %>

--- a/app/views/layouts/manage.html.erb
+++ b/app/views/layouts/manage.html.erb
@@ -1,0 +1,4 @@
+<% content_for :sub_nav do %>
+  <%= render "manage/nav" %>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/manage/_nav.html.erb
+++ b/app/views/manage/_nav.html.erb
@@ -1,0 +1,16 @@
+<nav class="border-b border-rule bg-surface">
+  <div class="mx-auto flex max-w-5xl flex-wrap gap-x-5 gap-y-2 px-5 py-3 text-xs">
+    <span class="font-display text-muted">編集</span>
+    <%= link_to "シナリオ", manage_scenarios_path, class: manage_nav_class(manage_scenarios_path) %>
+    <%= link_to "セッション", manage_play_sessions_path, class: manage_nav_class(manage_play_sessions_path) %>
+    <%= link_to "システム", manage_game_systems_path, class: manage_nav_class(manage_game_systems_path) %>
+    <%= link_to "作者", manage_authors_path, class: manage_nav_class(manage_authors_path) %>
+
+    <% if current_person&.admin? %>
+      <span class="ml-auto font-display text-muted">管理</span>
+      <%= link_to "メンバー", manage_people_path, class: manage_nav_class(manage_people_path) %>
+      <%= link_to "グループ", manage_groups_path, class: manage_nav_class(manage_groups_path) %>
+      <%= link_to "アカウント", manage_users_path, class: manage_nav_class(manage_users_path) %>
+    <% end %>
+  </div>
+</nav>

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Manage navigation" do
+  let(:sections) do
+    {
+      "シナリオ" => "/manage/scenarios",
+      "セッション" => "/manage/play_sessions",
+      "システム" => "/manage/game_systems",
+      "作者" => "/manage/authors",
+      "メンバー" => "/manage/people",
+      "グループ" => "/manage/groups",
+      "アカウント" => "/manage/users"
+    }
+  end
+
+  describe "an administrator" do
+    before { sign_in_as create(:person, roles: %w[admin]) }
+
+    # 権限の重複付与に頼らず、管理者だけで全操作できることを固定する。
+    it "can open every manage screen without also holding the GM role" do
+      sections.each_value do |path|
+        get path
+        expect(response).to have_http_status(:ok), "#{path} answered #{response.status}"
+      end
+    end
+
+    it "is offered a link to every section" do
+      get "/manage/scenarios"
+
+      sections.each_value { |path| expect(response.body).to include(path) }
+    end
+
+    it "can edit a session" do
+      session = create(:play_session, status: :scheduled)
+
+      patch manage_play_session_path(session), params: { play_session: { status: "played" } }
+
+      expect(session.reload).to be_played
+    end
+  end
+
+  describe "a GM" do
+    before { sign_in_as create(:person, roles: %w[gm]) }
+
+    it "reaches the content sections" do
+      [ "/manage/scenarios", "/manage/play_sessions", "/manage/game_systems", "/manage/authors" ].each do |path|
+        get path
+        expect(response).to have_http_status(:ok), "#{path} answered #{response.status}"
+      end
+    end
+
+    it "is not offered the admin-only sections" do
+      get "/manage/scenarios"
+
+      expect(response.body).not_to include("/manage/people")
+      expect(response.body).not_to include("/manage/groups")
+      expect(response.body).not_to include("/manage/users")
+    end
+  end
+
+  describe "the header" do
+    it "offers the manage area to an editor" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get root_path
+
+      expect(response.body).to include(manage_scenarios_path)
+    end
+
+    it "does not offer it to a person with no role" do
+      sign_in_as create(:person)
+
+      get root_path
+
+      expect(response.body).not_to include("/manage/")
+    end
+  end
+end


### PR DESCRIPTION
The session editing screen had no link anywhere. Neither did master data, members, groups or accounts — the header's 編集 link went to scenarios and stopped there.

Adds a sub-navigation bar across the manage area, shown on every manage screen via a `manage` layout. Content sections (scenarios, sessions, systems, authors) for editors; members, groups and accounts for admins only.

## On the permission question

Administrators could already do everything, including editing sessions, without also holding the GM role — `editor?` is `admin? || gm?`, and `require_editor` accepts either. Verified by request: all seven manage screens answer 200 for an admin with only the admin role, and a session update succeeds.

There is now a spec that fixes this, so the requirement does not depend on someone noticing it later.

## Verification

- [x] `bin/rspec` — 218 examples, 0 failures
- [x] `prek run --all-files`
- [x] Rendered nav inspected: an admin sees all seven links; a GM sees four and none of `/manage/people`, `/manage/groups`, `/manage/users`
