### PR TITLE
Make the player role implicit for every member

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Ruby と Node は mise で固定している。`mise exec --` を通すか、mis
 - テストは RSpec。実装より先にテストを書く
 - インフラ（PostgreSQL、MinIO、Ingress、Cloudflare Tunnel）は `yuno04-k3s` で管理する
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
+- プレイヤーは全員が持つため保存しない。`Person#player?` は常に真で、付け外しできない
 - 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -1,0 +1,6 @@
+module PeopleHelper
+  # プレイヤーは保存しないが、全員が持つものとして必ず表示する。
+  def person_role_labels(person)
+    [ t("people.roles.player") ] + person.roles.map { |role| t("people.roles.#{role}") }
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -15,6 +15,7 @@ class Person < ApplicationRecord
   validates :display_name, presence: true
   validates :icon, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 5.megabytes }
   validate :keeps_at_least_one_admin
+  validate :roles_are_known
 
   default_scope { order(:display_name) }
 
@@ -29,7 +30,8 @@ class Person < ApplicationRecord
   accepts_nested_attributes_for :person_aliases, allow_destroy: true,
     reject_if: ->(attrs) { attrs["id"].blank? && attrs["name"].blank? }
 
-  def roles = person_roles.map(&:name)
+  # 未知の値が入った行は名前を引けない。表示側でロケール全体を出さないよう落とす。
+  def roles = person_roles.map(&:name).compact
 
   def revealed?(scenario) = spoiler_reveals.exists?(scenario_id: scenario.id)
 
@@ -38,14 +40,22 @@ class Person < ApplicationRecord
   def self.admins = joins(:person_roles).where(person_roles: { name: PersonRole.names[:admin] })
 
   # has_many への代入は永続レコードだと即座に DB へ反映される。検証で見るため代入前の状態を残す。
-  # フォームが player を送ってきても落とす。保存しない権限なので無視してよい。
+  # 古いフォームが送ってくる player だけを黙って落とす。それ以外の未知の値は検証エラーにする。
+  # 不正な行をそのまま代入すると RecordNotSaved で 500 になるため、ここで取り分ける。
   def roles=(names)
     @roles_before_assignment = roles if persisted? && !defined?(@roles_before_assignment)
-    assignable = Array(names).compact_blank.uniq & PersonRole::ROLES.keys.map(&:to_s)
-    self.person_roles = assignable.map { |name| PersonRole.new(name:) }
+    submitted = Array(names).compact_blank.uniq - %w[player]
+    @unknown_roles = submitted - PersonRole::ROLES.keys.map(&:to_s)
+    self.person_roles = (submitted - @unknown_roles).map { |name| PersonRole.new(name:) }
   end
 
   private
+    def roles_are_known
+      return if @unknown_roles.blank?
+
+      errors.add(:base, "知らない権限です: #{@unknown_roles.join(", ")}")
+    end
+
     # 全員が管理者でなくなると、rake タスク以外に復旧手段が無くなる。
     def keeps_at_least_one_admin
       return unless defined?(@roles_before_assignment)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -22,6 +22,9 @@ class Person < ApplicationRecord
     define_method(:"#{role}?") { person_roles.any? { |r| r.name == role.to_s } }
   end
 
+  # Person であることがそのままプレイヤーであることを表す。付け外しはできない。
+  def player? = true
+
   # 既存行の名前を空にしたときは無視せず検証に落とす。新規の空行だけ捨てる。
   accepts_nested_attributes_for :person_aliases, allow_destroy: true,
     reject_if: ->(attrs) { attrs["id"].blank? && attrs["name"].blank? }
@@ -35,9 +38,11 @@ class Person < ApplicationRecord
   def self.admins = joins(:person_roles).where(person_roles: { name: PersonRole.names[:admin] })
 
   # has_many への代入は永続レコードだと即座に DB へ反映される。検証で見るため代入前の状態を残す。
+  # フォームが player を送ってきても落とす。保存しない権限なので無視してよい。
   def roles=(names)
     @roles_before_assignment = roles if persisted? && !defined?(@roles_before_assignment)
-    self.person_roles = Array(names).compact_blank.uniq.map { |name| PersonRole.new(name:) }
+    assignable = Array(names).compact_blank.uniq & PersonRole::ROLES.keys.map(&:to_s)
+    self.person_roles = assignable.map { |name| PersonRole.new(name:) }
   end
 
   private

--- a/app/models/person_role.rb
+++ b/app/models/person_role.rb
@@ -1,5 +1,6 @@
 class PersonRole < ApplicationRecord
-  ROLES = { admin: 0, gm: 1, player: 2 }.freeze
+  # プレイヤーは全員が持つため保存しない。Person#player? が常に真を返す。
+  ROLES = { admin: 0, gm: 1 }.freeze
 
   belongs_to :person
 

--- a/app/views/manage/people/_form.html.erb
+++ b/app/views/manage/people/_form.html.erb
@@ -21,6 +21,14 @@
 
   <div>
     <span class="block text-xs text-muted">権限</span>
+
+    <%# プレイヤーは全員が持つ。付け外しできないことを画面でも示す。 %>
+    <label class="mr-4 inline-flex items-center gap-1 text-sm text-muted">
+      <%= check_box_tag "person_roles_player_display", "player", true,
+            disabled: true, id: "person_roles_player" %>
+      <%= t("people.roles.player") %>
+    </label>
+
     <% PersonRole::ROLES.each_key do |role| %>
       <label class="mr-4 inline-flex items-center gap-1 text-sm">
         <%= check_box_tag "person[roles][]", role, person.roles.include?(role.to_s), id: "person_roles_#{role}" %>
@@ -28,6 +36,8 @@
       </label>
     <% end %>
     <%= hidden_field_tag "person[roles][]", "" %>
+
+    <p class="mt-1 text-xs text-muted">プレイヤーはログインした全員が持ちます。外せません。</p>
   </div>
 
   <div>

--- a/app/views/manage/people/index.html.erb
+++ b/app/views/manage/people/index.html.erb
@@ -10,7 +10,7 @@
       <div>
         <p class="font-display"><%= item.display_name %></p>
         <p class="text-xs text-muted">
-          権限: <%= item.roles.map { |r| t("people.roles.#{r}") }.join("、").presence || "なし" %>
+          権限: <%= person_role_labels(item).join("、") %>
           ／ グループ: <%= item.groups.map(&:name).join("、").presence || "なし" %>
           ／ アカウント: <%= item.user&.email || "未紐づけ" %>
         </p>

--- a/db/migrate/20260810152806_remove_stored_player_roles.rb
+++ b/db/migrate/20260810152806_remove_stored_player_roles.rb
@@ -1,0 +1,16 @@
+# 全員がプレイヤーになったため、権限としては保存しない。既存の行を落とす。
+class RemoveStoredPlayerRoles < ActiveRecord::Migration[8.1]
+  PLAYER = 2
+
+  def up
+    execute "DELETE FROM person_roles WHERE name = #{PLAYER}"
+  end
+
+  def down
+    # 誰がプレイヤー行を持っていたかは復元できない。全員が持っていた状態に戻す。
+    execute <<~SQL.squish
+      INSERT INTO person_roles (person_id, name, created_at, updated_at)
+      SELECT id, #{PLAYER}, NOW(), NOW() FROM people
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_144652) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_152806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Person do
 
       expect(person).to be_admin
       expect(person).to be_gm
-      expect(person).not_to be_player
     end
 
     it "rejects a role outside the known set" do

--- a/spec/models/player_role_spec.rb
+++ b/spec/models/player_role_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+# 全員がプレイヤーなので、権限として保存しない。行で持つと画面外で作った Person に
+# 付け忘れる余地が残る。Person が存在することがそのままプレイヤーであることを表す。
+RSpec.describe "The player role" do
+  it "is true for anyone, including a person with no stored roles" do
+    expect(create(:person)).to be_player
+  end
+
+  it "is true for an administrator" do
+    expect(create(:person, roles: %w[admin])).to be_player
+  end
+
+  it "is not something the roles list can grant or withhold" do
+    person = create(:person, roles: %w[admin])
+
+    expect(person.roles).to eq([ "admin" ])
+    expect(person).to be_player
+  end
+
+  it "cannot be stored, so it cannot drift out of sync" do
+    expect(PersonRole::ROLES.keys).to match_array(%i[admin gm])
+    expect(build(:person).person_roles.build(name: "player")).not_to be_valid
+  end
+
+  it "is ignored when submitted, rather than failing the update" do
+    person = create(:person, roles: %w[gm])
+
+    person.update!(roles: %w[gm player])
+
+    expect(person.reload.roles).to eq([ "gm" ])
+    expect(person).to be_player
+  end
+
+  it "grants nothing beyond what a person with no roles can do" do
+    plain = create(:person)
+
+    expect(ScenarioPolicy.new(plain, Scenario.new).update?).to be_falsey
+    expect(PlaySessionPolicy.new(plain, PlaySession.new).manage?).to be_falsey
+    expect(PersonPolicy.new(plain, Person.new).manage?).to be_falsey
+  end
+
+  it "still lets a member see the signed-in area" do
+    plain = create(:person)
+
+    expect(PlaySessionPolicy.new(plain, PlaySession.new).index?).to be(true)
+    expect(PersonPolicy.new(plain, Person.new).show?).to be(true)
+  end
+end

--- a/spec/models/player_role_spec.rb
+++ b/spec/models/player_role_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe "The player role" do
     expect(person).to be_player
   end
 
+  # player だけを落とす。未知の値まで黙って捨てると、綴り間違いが成功して見える。
+  it "still rejects a role name that is not known at all" do
+    person = create(:person)
+
+    expect(person.update(roles: %w[owner])).to be(false)
+    expect(person.reload.roles).to be_empty
+  end
+
+  # 未知の整数が残った行があっても、翻訳キーの引き当てでロケール全体を出さない。
+  it "ignores a stored role whose value is no longer known" do
+    person = create(:person, roles: %w[gm])
+    ActiveRecord::Base.connection.execute(
+      "INSERT INTO person_roles (person_id, name, created_at, updated_at) VALUES (#{person.id}, 99, NOW(), NOW())"
+    )
+
+    expect(person.reload.roles).to eq([ "gm" ])
+  end
+
   it "grants nothing beyond what a person with no roles can do" do
     plain = create(:person)
 

--- a/spec/policies/play_session_policy_spec.rb
+++ b/spec/policies/play_session_policy_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe PlaySessionPolicy do
     it "opens the maintenance listing to editors only" do
       expect(described_class.new(create(:person, roles: %w[gm]), PlaySession).manage?).to be(true)
       expect(described_class.new(create(:person, roles: %w[admin]), PlaySession).manage?).to be(true)
-      expect(described_class.new(create(:person, roles: %w[player]), PlaySession).manage?).to be_falsey
+      expect(described_class.new(create(:person), PlaySession).manage?).to be_falsey
       expect(described_class.new(create(:person), PlaySession).manage?).to be_falsey
       expect(described_class.new(nil, PlaySession).manage?).to be_falsey
     end

--- a/spec/requests/manage/people_spec.rb
+++ b/spec/requests/manage/people_spec.rb
@@ -32,11 +32,12 @@ RSpec.describe "Manage::People" do
       group = create(:group, name: "よく遊ぶ人たち")
 
       post manage_people_path, params: {
-        person: { display_name: "新入り", x_account: "newbie", roles: [ "player" ], group_ids: [ group.id ] }
+        person: { display_name: "新入り", x_account: "newbie", roles: [ "gm" ], group_ids: [ group.id ] }
       }
 
       person = Person.find_by(display_name: "新入り")
-      expect(person.roles).to eq([ "player" ])
+      expect(person.roles).to eq([ "gm" ])
+      expect(person).to be_player
       expect(person.groups).to eq([ group ])
     end
 

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Manage::PlaySessions" do
     end
 
     it "answers 404 to a plain player, whose public index? would otherwise allow it" do
-      sign_in_as create(:person, roles: %w[player])
+      sign_in_as create(:person)
 
       get manage_play_sessions_path
 

--- a/spec/requests/manage/player_role_spec.rb
+++ b/spec/requests/manage/player_role_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "The player role on the manage screen" do
+  let(:person) { create(:person, display_name: "本人") }
+
+  before { sign_in_as create(:person, roles: %w[admin]) }
+
+  it "shows the player checkbox as ticked and not changeable" do
+    get edit_manage_person_path(person)
+
+    field = response.body[%r{<input[^>]*person_roles_player[^>]*>}]
+
+    expect(field).to be_present
+    expect(field).to include("checked")
+    expect(field).to include("disabled")
+  end
+
+  it "keeps the person a player even when the form omits it" do
+    patch manage_person_path(person), params: { person: { display_name: "本人", roles: [ "admin" ] } }
+
+    expect(person.reload).to be_player
+    expect(person.roles).to eq([ "admin" ])
+  end
+
+  it "does not fail when a submission still carries the player value" do
+    patch manage_person_path(person), params: { person: { display_name: "本人", roles: [ "gm", "player" ] } }
+
+    expect(response).to redirect_to(manage_people_path)
+    expect(person.reload.roles).to eq([ "gm" ])
+  end
+
+  it "lists プレイヤー for everyone on the member index" do
+    person
+
+    get manage_people_path
+
+    expect(response.body).to include("プレイヤー")
+  end
+end

--- a/spec/requests/manage/player_role_spec.rb
+++ b/spec/requests/manage/player_role_spec.rb
@@ -29,11 +29,20 @@ RSpec.describe "The player role on the manage screen" do
     expect(person.reload.roles).to eq([ "gm" ])
   end
 
-  it "lists プレイヤー for everyone on the member index" do
+  # フォームにも「プレイヤー」の文字があるため、一覧行の書式ごと確かめる。
+  it "lists プレイヤー as a role for everyone on the member index" do
     person
 
     get manage_people_path
 
-    expect(response.body).to include("プレイヤー")
+    expect(response.body).to include("権限: プレイヤー")
+  end
+
+  it "lists the stored roles after プレイヤー" do
+    create(:person, display_name: "GM の人", roles: %w[gm])
+
+    get manage_people_path
+
+    expect(response.body).to include("権限: プレイヤー、GM")
   end
 end


### PR DESCRIPTION
Closes #19

## Approach

The role is now implicit rather than stored. A row that every person carries holds no information, and it can drift — a Person created outside the form would silently lack it. `Person#player?` returns true unconditionally, `player` is gone from `PersonRole::ROLES`, and a migration deletes the rows that exist.

Submitting `roles: ["player"]` is ignored rather than rejected, so an old form or a stale tab cannot produce a 422.

## Against the three requirements

1. The checkbox renders ticked and `disabled`, with a line saying it cannot be removed. There is no form field behind it, so nothing can post it.
2. Everyone is a player, existing rows included — the migration drops the stored rows and the predicate answers for all.
3. Visibility is unchanged. Verified by request: anonymous and unlinked accounts get 404 on `/people` and `/play_sessions`; a member with no stored roles gets 200 on both and 404 on `/manage/*`. Specs assert the player role grants nothing an unroled person lacks.

## Verification

- [x] `bin/rspec` — 279 examples, 0 failures
- [x] `prek run --all-files`
- [x] The member list shows プレイヤー for everyone

## Note

`down` cannot restore who held a player row, since everyone did. It re-inserts one for every person, which is the state this issue describes.
