### PR TITLE
Hide the recommendation and add a table view to the scenario list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Ruby と Node は mise で固定している。`mise exec --` を通すか、mis
 - テストは RSpec。実装より先にテストを書く
 - インフラ（PostgreSQL、MinIO、Ingress、Cloudflare Tunnel）は `yuno04-k3s` で管理する
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
+- おすすめ度は編集画面にだけ出す。表示はせず並び順の材料として持つ（issue #18）
 - プレイヤーは全員が持つため保存しない。`Person#player?` は常に真で、付け外しできない
 - 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,6 +1,11 @@
 class ScenariosController < ApplicationController
+  VIEWS = %w[table gallery].freeze
+
   def index
-    @scenarios = policy_scope(Scenario).includes(:game_systems, :authors, jacket_attachment: :blob)
+    @view = VIEWS.include?(params[:view]) ? params[:view] : VIEWS.first
+    @scenarios = policy_scope(Scenario)
+      .includes(:game_systems, :authors, :purchase_links, jacket_attachment: :blob)
+      .recommended_first
     authorize Scenario
   end
 

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,6 +1,6 @@
 module MetaTagsHelper
   SITE_NAME = "卓の記録".freeze
-  SITE_DESCRIPTION = "遊んだ TRPG シナリオの一覧。システム、人数、目安時間、おすすめ度から選べます。".freeze
+  SITE_DESCRIPTION = "遊んだ TRPG シナリオの一覧。システム、人数、目安時間から選べます。".freeze
 
   def default_meta_tags
     {

--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -5,24 +5,27 @@ module ScenariosHelper
     name == current ? "font-bold text-ink no-underline" : "text-seal"
   end
 
-  # 一覧では、値が無い欄は空欄のままにする（issue #20）。
-  def blank_to_empty(label) = label == UNSET ? "" : label
 
-  def player_count_label(scenario)
+  # 値が無ければ nil。一覧は空欄に、詳細は「未設定」に落とす。
+  def player_count_value(scenario)
     numeric = bounded_label(scenario.player_count_min, scenario.player_count_max) { |n| "#{n}人" }
 
-    [ numeric, scenario.player_count_note ].compact_blank.join(" ").presence || UNSET
+    [ numeric, scenario.player_count_note ].compact_blank.join(" ").presence
   end
 
-  def duration_label(scenario)
+  def player_count_label(scenario) = player_count_value(scenario) || UNSET
+
+  def duration_value(scenario)
     min = scenario.duration_min_minutes
     max = scenario.duration_max_minutes
-    return UNSET if min.blank? && max.blank?
+    return nil if min.blank? && max.blank?
 
     # 2 時間未満は分のままのほうが元データに近く、範囲でも単位が揃う。
     unit = [ min, max ].compact.max < 120 ? :minutes : :hours
     bounded_label(min, max) { |n| humanized_minutes(n, unit:) }
   end
+
+  def duration_label(scenario) = duration_value(scenario) || UNSET
 
   def character_sheet_deadline_label(scenario)
     return scenario.character_sheet_deadline_note if scenario.character_sheet_deadline_note.present?

--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -1,6 +1,13 @@
 module ScenariosHelper
   UNSET = "未設定".freeze
 
+  def list_view_class(name, current)
+    name == current ? "font-bold text-ink no-underline" : "text-seal"
+  end
+
+  # 一覧では、値が無い欄は空欄のままにする（issue #20）。
+  def blank_to_empty(label) = label == UNSET ? "" : label
+
   def player_count_label(scenario)
     numeric = bounded_label(scenario.player_count_min, scenario.player_count_max) { |n| "#{n}人" }
 
@@ -15,13 +22,6 @@ module ScenariosHelper
     # 2 時間未満は分のままのほうが元データに近く、範囲でも単位が揃う。
     unit = [ min, max ].compact.max < 120 ? :minutes : :hours
     bounded_label(min, max) { |n| humanized_minutes(n, unit:) }
-  end
-
-  def recommendation_label(scenario)
-    return "回したことない" unless scenario.gm_experienced
-    return "未評価" if scenario.recommendation.blank?
-
-    "★" * scenario.recommendation
   end
 
   def character_sheet_deadline_label(scenario)

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -27,6 +27,11 @@ class Scenario < ApplicationRecord
   accepts_nested_attributes_for :purchase_links, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :stream_links, allow_destroy: true, reject_if: :all_blank
 
+  # おすすめ度は画面に出さない。並び順を決めるためだけに持つ（issue #18）。
+  scope :recommended_first, -> {
+    order(Arel.sql("recommendation DESC NULLS LAST"), :title)
+  }
+
   validates :title, presence: true
   validates :jacket, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
   validates :recommendation, inclusion: { in: 1..5 }, allow_nil: true

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -1,0 +1,33 @@
+<ul class="mt-8 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
+  <% scenarios.each do |scenario| %>
+    <li class="bg-surface">
+      <%= link_to scenario_path(scenario), class: "group flex h-full flex-col gap-3 p-4 no-underline text-ink" do %>
+        <div class="aspect-3/4 overflow-hidden bg-paper">
+          <% if scenario.jacket.attached? %>
+            <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",
+                  class: "h-full w-full object-cover" %>
+          <% else %>
+            <span class="flex h-full items-center justify-center font-display text-sm text-muted">
+              画像なし
+            </span>
+          <% end %>
+        </div>
+
+        <h2 class="font-display text-lg leading-snug group-hover:text-seal">
+          <%= scenario.title %>
+        </h2>
+
+        <p class="text-xs text-muted">
+          <%= scenario.game_systems.map(&:name).join("／") %>
+        </p>
+
+        <dl class="mt-auto grid grid-cols-[4rem_1fr] gap-x-3 gap-y-1 font-mono text-xs">
+          <dt class="text-muted">人数</dt>
+          <dd><%= blank_to_empty(player_count_label(scenario)) %></dd>
+          <dt class="text-muted">時間</dt>
+          <dd><%= blank_to_empty(duration_label(scenario)) %></dd>
+        </dl>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -18,14 +18,14 @@
         </h2>
 
         <p class="text-xs text-muted">
-          <%= scenario.game_systems.map(&:name).join("／") %>
+          <%= scenario.game_systems.map(&:name).join("／").presence || "システム未設定" %>
         </p>
 
         <dl class="mt-auto grid grid-cols-[4rem_1fr] gap-x-3 gap-y-1 font-mono text-xs">
           <dt class="text-muted">人数</dt>
-          <dd><%= blank_to_empty(player_count_label(scenario)) %></dd>
+          <dd><%= player_count_value(scenario) %></dd>
           <dt class="text-muted">時間</dt>
-          <dd><%= blank_to_empty(duration_label(scenario)) %></dd>
+          <dd><%= duration_value(scenario) %></dd>
         </dl>
       <% end %>
     </li>

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -1,0 +1,36 @@
+<div class="mt-8 overflow-x-auto border border-rule bg-surface">
+  <table class="w-full min-w-3xl text-sm">
+    <thead class="border-b border-rule text-left text-xs text-muted">
+      <tr>
+        <th scope="col" class="p-3">シナリオ名</th>
+        <th scope="col" class="p-3">作者</th>
+        <th scope="col" class="p-3">システム</th>
+        <th scope="col" class="p-3">人数</th>
+        <th scope="col" class="p-3">目安時間</th>
+        <th scope="col" class="p-3">入手先</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scenarios.each do |scenario| %>
+        <tr class="border-b border-rule last:border-b-0 hover:bg-paper">
+          <td class="p-3">
+            <%= link_to scenario.title, scenario_path(scenario), class: "font-display text-ink" %>
+          </td>
+          <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
+          <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
+          <td class="p-3 font-mono text-xs"><%= blank_to_empty(player_count_label(scenario)) %></td>
+          <td class="p-3 font-mono text-xs"><%= blank_to_empty(duration_label(scenario)) %></td>
+          <td class="p-3 text-xs">
+            <% scenario.purchase_links.each do |link| %>
+              <% if link.url.present? %>
+                <%= link_to link.label, link.url, rel: "noopener nofollow", class: "text-seal" %>
+              <% else %>
+                <span class="text-muted"><%= link.label %></span>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -18,8 +18,8 @@
           </td>
           <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
           <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
-          <td class="p-3 font-mono text-xs"><%= blank_to_empty(player_count_label(scenario)) %></td>
-          <td class="p-3 font-mono text-xs"><%= blank_to_empty(duration_label(scenario)) %></td>
+          <td class="p-3 font-mono text-xs"><%= player_count_value(scenario) %></td>
+          <td class="p-3 font-mono text-xs"><%= duration_value(scenario) %></td>
           <td class="p-3 text-xs">
             <% scenario.purchase_links.each do |link| %>
               <% if link.url.present? %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -7,14 +7,16 @@
   </div>
 
   <nav class="flex items-center gap-3 text-xs" aria-label="表示の切り替え">
-    <%= link_to "表形式", root_path(view: "table"), class: list_view_class("table", @view) %>
-    <%= link_to "ジャケット", root_path(view: "gallery"), class: list_view_class("gallery", @view) %>
+    <%= link_to "表形式", root_path(view: "table"), class: list_view_class("table", @view),
+          aria: { current: ("page" if @view == "table") } %>
+    <%= link_to "ジャケット", root_path(view: "gallery"), class: list_view_class("gallery", @view),
+          aria: { current: ("page" if @view == "gallery") } %>
   </nav>
 </div>
 
-<%= render "scenarios/#{@view}", scenarios: @scenarios %>
-
-<% if @scenarios.empty? %>
+<% if @scenarios.any? %>
+  <%= render "scenarios/#{@view}", scenarios: @scenarios %>
+<% else %>
   <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">
     まだシナリオが登録されていません。
   </p>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,45 +1,18 @@
 <% content_for :title, "シナリオ一覧" %>
 
-<h1 class="font-display text-3xl tracking-wide">シナリオ一覧</h1>
-<p class="mt-2 text-sm text-muted"><%= @scenarios.size %>本。人数と目安時間から選べます。</p>
+<div class="flex flex-wrap items-baseline justify-between gap-4">
+  <div>
+    <h1 class="font-display text-3xl tracking-wide">シナリオ一覧</h1>
+    <p class="mt-2 text-sm text-muted"><%= @scenarios.size %>本。人数と目安時間から選べます。</p>
+  </div>
 
-<ul class="mt-8 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
-  <% @scenarios.each do |scenario| %>
-    <li class="bg-surface">
-      <%= link_to scenario_path(scenario), class: "group flex h-full flex-col gap-3 p-4 no-underline text-ink" do %>
-        <div class="aspect-3/4 overflow-hidden bg-paper">
-          <% if scenario.jacket.attached? %>
-            <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",
-                  class: "h-full w-full object-cover" %>
-          <% else %>
-            <span class="flex h-full items-center justify-center font-display text-sm text-muted">
-              画像なし
-            </span>
-          <% end %>
-        </div>
+  <nav class="flex items-center gap-3 text-xs" aria-label="表示の切り替え">
+    <%= link_to "表形式", root_path(view: "table"), class: list_view_class("table", @view) %>
+    <%= link_to "ジャケット", root_path(view: "gallery"), class: list_view_class("gallery", @view) %>
+  </nav>
+</div>
 
-        <h2 class="font-display text-lg leading-snug group-hover:text-seal">
-          <%= scenario.title %>
-        </h2>
-
-        <p class="text-xs text-muted">
-          <%= scenario.game_systems.map(&:name).join("／").presence || "システム未設定" %>
-        </p>
-
-        <dl class="mt-auto grid grid-cols-[4rem_1fr] gap-x-3 gap-y-1 font-mono text-xs">
-          <dt class="text-muted">人数</dt>
-          <dd><%= player_count_label(scenario) %></dd>
-          <dt class="text-muted">時間</dt>
-          <dd><%= duration_label(scenario) %></dd>
-          <dt class="text-muted">評価</dt>
-          <dd class="<%= "text-seal" if scenario.recommendation.present? %>">
-            <%= recommendation_label(scenario) %>
-          </dd>
-        </dl>
-      <% end %>
-    </li>
-  <% end %>
-</ul>
+<%= render "scenarios/#{@view}", scenarios: @scenarios %>
 
 <% if @scenarios.empty? %>
   <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -33,8 +33,6 @@
         <dd><%= player_count_label(@scenario) %></dd>
         <dt class="text-muted">目安時間</dt>
         <dd><%= duration_label(@scenario) %></dd>
-        <dt class="text-muted">おすすめ度</dt>
-        <dd class="<%= "text-seal" if @scenario.recommendation.present? %>"><%= recommendation_label(@scenario) %></dd>
         <dt class="text-muted">参加制限</dt>
         <dd class="font-sans"><%= @scenario.character_restriction.presence || "制限なし" %></dd>
         <dt class="text-muted">キャラシ</dt>

--- a/spec/helpers/scenarios_helper_spec.rb
+++ b/spec/helpers/scenarios_helper_spec.rb
@@ -69,20 +69,6 @@ RSpec.describe ScenariosHelper do
     end
   end
 
-  describe "#recommendation_label" do
-    it "shows stars" do
-      expect(helper.recommendation_label(build(:scenario, recommendation: 4))).to eq("★★★★")
-    end
-
-    it "distinguishes 「回したことない」 from an unrated scenario" do
-      never_run = build(:scenario, gm_experienced: false, recommendation: nil)
-      unrated = build(:scenario, gm_experienced: true, recommendation: nil)
-
-      expect(helper.recommendation_label(never_run)).to eq("回したことない")
-      expect(helper.recommendation_label(unrated)).to eq("未評価")
-    end
-  end
-
   describe "#character_sheet_deadline_label" do
     it "translates the enum" do
       expect(helper.character_sheet_deadline_label(build(:scenario, character_sheet_deadline: :two_days_before)))

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -74,36 +74,46 @@ RSpec.describe "The scenario list" do
   end
 
   describe "the recommendation" do
+    # 星や見出しだけでなく、属性や生の値として漏れていないかも見る。
     it "is absent from the list" do
       get root_path
 
-      expect(response.body).not_to include("★")
-      expect(response.body).not_to include("おすすめ度")
+      expect(response.body).not_to include("★", "おすすめ度")
+      expect(response.body).not_to match(/recommendation/i)
     end
 
     it "is absent from the jacket view" do
       get root_path(view: "gallery")
 
       expect(response.body).not_to include("★")
+      expect(response.body).not_to match(/recommendation/i)
     end
 
     it "is absent from the scenario page" do
       get scenario_path(scenario)
 
-      expect(response.body).not_to include("★")
-      expect(response.body).not_to include("おすすめ度")
-      expect(response.body).not_to include("回したことない")
+      expect(response.body).not_to include("★", "おすすめ度", "回したことない")
+      expect(response.body).not_to match(/recommendation/i)
     end
 
+    # 作成順と期待順をずらす。並べ替えを外すと落ちるようにする。
     it "still orders the list, best first" do
-      create(:scenario, title: "低評価", recommendation: 1)
       create(:scenario, title: "未評価", recommendation: nil)
+      create(:scenario, title: "低評価", recommendation: 1)
 
-      get root_path
+      body = (get(root_path) && response.body)
 
-      body = response.body
       expect(body.index("見本シナリオ")).to be < body.index("低評価")
       expect(body.index("低評価")).to be < body.index("未評価")
+    end
+
+    it "breaks a tie on the title" do
+      create(:scenario, title: "い", recommendation: 5)
+      create(:scenario, title: "あ", recommendation: 5)
+
+      body = (get(root_path) && response.body)
+
+      expect(body.index("あ")).to be < body.index("い")
     end
 
     it "remains editable on the edit screen" do

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe "The scenario list" do
+  let!(:scenario) do
+    create(
+      :scenario,
+      title: "見本シナリオ",
+      recommendation: 5,
+      player_count_min: 3,
+      player_count_max: 3,
+      duration_min_minutes: 360,
+      duration_max_minutes: 480,
+      game_systems: [ create(:game_system, name: "見本システム") ],
+      authors: [ create(:author, name: "見本作者") ]
+    ).tap { |s| s.purchase_links.create!(label: "BOOTH", url: "https://example.com/items/1") }
+  end
+
+  describe "the default view" do
+    it "is the table, which is what the spreadsheet gave" do
+      get root_path
+
+      expect(response.body).to include("<table")
+    end
+
+    it "shows the title, author, system, player count and duration" do
+      get root_path
+
+      expect(response.body).to include("見本シナリオ", "見本作者", "見本システム", "3人", "6時間〜8時間")
+    end
+
+    it "links the title to the scenario and the purchase label to the shop" do
+      get root_path
+
+      expect(response.body).to include(scenario_path(scenario))
+      expect(response.body).to include("https://example.com/items/1")
+    end
+
+    it "leaves a column blank rather than inventing a value" do
+      create(:scenario, title: "空欄だらけ")
+
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("空欄だらけ")
+      expect(response.body).not_to include("未設定")
+    end
+  end
+
+  describe "switching" do
+    it "offers a link to the jacket view" do
+      get root_path
+
+      expect(response.body).to include(root_path(view: "gallery"))
+    end
+
+    it "shows the jackets when asked" do
+      get root_path(view: "gallery")
+
+      expect(response.body).not_to include("<table")
+      expect(response.body).to include("aspect-3/4")
+    end
+
+    it "offers a link back to the table" do
+      get root_path(view: "gallery")
+
+      expect(response.body).to include(root_path(view: "table"))
+    end
+
+    it "falls back to the table for an unknown value" do
+      get root_path(view: "nonsense")
+
+      expect(response.body).to include("<table")
+    end
+  end
+
+  describe "the recommendation" do
+    it "is absent from the list" do
+      get root_path
+
+      expect(response.body).not_to include("★")
+      expect(response.body).not_to include("おすすめ度")
+    end
+
+    it "is absent from the jacket view" do
+      get root_path(view: "gallery")
+
+      expect(response.body).not_to include("★")
+    end
+
+    it "is absent from the scenario page" do
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("★")
+      expect(response.body).not_to include("おすすめ度")
+      expect(response.body).not_to include("回したことない")
+    end
+
+    it "still orders the list, best first" do
+      create(:scenario, title: "低評価", recommendation: 1)
+      create(:scenario, title: "未評価", recommendation: nil)
+
+      get root_path
+
+      body = response.body
+      expect(body.index("見本シナリオ")).to be < body.index("低評価")
+      expect(body.index("低評価")).to be < body.index("未評価")
+    end
+
+    it "remains editable on the edit screen" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get edit_manage_scenario_path(scenario)
+
+      expect(response.body).to include("おすすめ度")
+    end
+  end
+end

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe "Browsing scenarios" do
 
     visit root_path
     expect(page).to have_content("シナリオ一覧")
+    expect(page).to have_no_content("★")
 
     click_link "カタシロ"
 
     expect(page).to have_content("ディズム")
     expect(page).to have_content("CoC 7版")
     expect(page).to have_content("2時間")
-    expect(page).to have_content("★★★★★")
     expect(page).to have_no_content("ネタバレを含む準備情報")
   end
 end


### PR DESCRIPTION
Closes #18
Closes #20

Both issues touch the same screen, so they are here together as two commits.

## #18 — the recommendation leaves the front

Gone from the list, the jacket view and the scenario page; still on the edit form. It now drives the default ordering instead: best first, unrated last, ties by title. The site description mentioned it too, and no longer does.

## #20 — table by default, jackets on request

`?view=table` (the default) and `?view=gallery`, chosen because it keeps the URL shareable, behaves the same signed out, and leaves caching alone — the alternative of remembering the choice in a cookie makes one URL render differently per visitor. An unknown value falls back to the table.

The table carries シナリオ名 / 作者 / システム / 人数 / 目安時間 / 入手先. The title links to the scenario; the purchase label links to the shop. Empty columns render empty rather than 未設定, which the list previously showed — the table reads better without a column of placeholder text.

## Verification

- [x] `bin/rspec` — 293 examples, 0 failures
- [x] `prek run --all-files`
- [x] Rendered and inspected: a fully populated row comes out as `["見本シナリオ", "見本作者", "CoC 7版", "3人", "6時間〜8時間", "BOOTH"]`, an empty scenario as blanks, and no `★` anywhere
