### PR TITLE
Offer an edit link where an editable record is shown

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
               <%= link_to "セッション", play_sessions_path, class: "text-seal underline" %>
               <%= link_to "メンバー", people_path, class: "text-seal underline" %>
             <% end %>
-            <% if current_person&.admin? || current_person&.gm? %>
+            <% if policy(Scenario).manage? %>
               <%= link_to "編集", manage_scenarios_path, class: "text-seal underline" %>
             <% end %>
             <% if current_person %>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -6,9 +6,14 @@
     <%= @play_session.scenario.title %>
   </nav>
 
-  <h1 class="mt-6 font-display text-3xl leading-tight tracking-wide">
-    <%= link_to @play_session.scenario.title, scenario_path(@play_session.scenario), class: "text-ink" %>
-  </h1>
+  <div class="mt-6 flex flex-wrap items-baseline justify-between gap-4">
+    <h1 class="font-display text-3xl leading-tight tracking-wide">
+      <%= link_to @play_session.scenario.title, scenario_path(@play_session.scenario), class: "text-ink" %>
+    </h1>
+    <% if policy(@play_session).update? %>
+      <%= link_to "編集", edit_manage_play_session_path(@play_session), class: "text-sm text-seal" %>
+    <% end %>
+  </div>
 
   <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
     <dt class="text-muted">日時</dt>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -24,7 +24,12 @@
         <%= @scenario.authors.map(&:name).join("、").presence || "作者未設定" %>
       </p>
 
-      <div class="mt-3"><%= render "scenarios/favorite_button", scenario: @scenario %></div>
+      <div class="mt-3 flex flex-wrap items-center gap-4">
+        <%= render "scenarios/favorite_button", scenario: @scenario %>
+        <% if policy(@scenario).update? %>
+          <%= link_to "編集", edit_manage_scenario_path(@scenario), class: "text-sm text-seal" %>
+        <% end %>
+      </div>
 
       <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
         <dt class="text-muted">システム</dt>

--- a/spec/requests/edit_links_spec.rb
+++ b/spec/requests/edit_links_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+# 編集リンクは編集画面と同じ判断で出す。出る相手と出ない相手を画面ごとに固定する。
+RSpec.describe "Edit links on detail screens" do
+  describe "GET /scenarios/:id" do
+    let(:scenario) { create(:scenario) }
+    let(:edit_path) { edit_manage_scenario_path(scenario) }
+
+    it "is absent for a visitor who has not signed in" do
+      get scenario_path(scenario)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(edit_path)
+    end
+
+    it "is absent for an account that is not linked to a person" do
+      sign_in_as create(:user, person: nil)
+
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include(edit_path)
+    end
+
+    it "is absent for a member who has no role" do
+      sign_in_as create(:person)
+
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include(edit_path)
+    end
+
+    it "is present for a GM" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include(edit_path)
+    end
+
+    it "is present for an admin" do
+      sign_in_as create(:person, roles: %w[admin])
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include(edit_path)
+    end
+  end
+
+  describe "GET /play_sessions/:id" do
+    let(:group) { create(:group) }
+    let(:play_session) { create(:play_session) }
+    let(:edit_path) { edit_manage_play_session_path(play_session) }
+
+    before do
+      play_session.participations.create!(person: create(:person, groups: [ group ]), role: :gm)
+    end
+
+    it "is absent for a member who may read the session but not edit it" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(play_session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(edit_path)
+    end
+
+    it "is present for a GM who may read the session" do
+      sign_in_as create(:person, roles: %w[gm], groups: [ group ])
+
+      get play_session_path(play_session)
+
+      expect(response.body).to include(edit_path)
+    end
+
+    it "is present for an admin, who may read every session" do
+      sign_in_as create(:person, roles: %w[admin])
+
+      get play_session_path(play_session)
+
+      expect(response.body).to include(edit_path)
+    end
+
+    # 編集する権限は可視性を広げない。リンクを出すために Scope を迂回しない。
+    it "leaves the session hidden from a GM who shares no group with a participant" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get play_session_path(play_session)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /people/:id" do
+    let(:person) { create(:person) }
+    let(:edit_path) { edit_person_path(person) }
+
+    it "is absent for another member" do
+      sign_in_as create(:person)
+
+      get person_path(person)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(edit_path)
+    end
+
+    # GM はシナリオとセッションを編集するが、他人のプロフィールには触れない。
+    it "is absent for a GM looking at someone else" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get person_path(person)
+
+      expect(response.body).not_to include(edit_path)
+    end
+
+    it "is present for the person themselves" do
+      sign_in_as person
+
+      get person_path(person)
+
+      expect(response.body).to include(edit_path)
+    end
+
+    it "is present for an admin" do
+      sign_in_as create(:person, roles: %w[admin])
+
+      get person_path(person)
+
+      expect(response.body).to include(edit_path)
+    end
+  end
+end

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -67,9 +67,23 @@ RSpec.describe "Manage navigation" do
       expect(response.body).to include(manage_scenarios_path)
     end
 
+    it "offers it to an administrator who does not also hold the GM role" do
+      sign_in_as create(:person, roles: %w[admin])
+
+      get root_path
+
+      expect(response.body).to include(manage_scenarios_path)
+    end
+
     it "does not offer it to a person with no role" do
       sign_in_as create(:person)
 
+      get root_path
+
+      expect(response.body).not_to include("/manage/")
+    end
+
+    it "does not offer it to a visitor who has not signed in" do
       get root_path
 
       expect(response.body).not_to include("/manage/")


### PR DESCRIPTION
## What

Adds an edit link to the scenario and session detail screens, shown only to viewers whose policy allows editing. Fixes the header link into the manage area to ask the policy instead of reading roles.

## Why

Closes #22. A detail screen of an editable record should offer the way to edit it, so an editor does not have to walk back into the manage index to find the row.

`spec/requests/edit_links_spec.rb` pins who is offered the link on each detail screen, including the profile screen that already had one. It also pins that a GM who shares no group with a participant still gets a 404 for the session: the right to edit does not widen visibility.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

<!-- Phase plan or ADR this PR belongs to -->
