### PR TITLE
Rename the site to TRPGカタログ and trim the explanatory copy

### DIFF
--- a/app/controllers/play_sessions_controller.rb
+++ b/app/controllers/play_sessions_controller.rb
@@ -1,7 +1,7 @@
 class PlaySessionsController < ApplicationController
   def index
     authorize PlaySession
-    @play_sessions = visible_sessions.newest_first
+    @play_sessions = visible_sessions.newest_first.load
   end
 
   def show

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,5 +1,5 @@
 module MetaTagsHelper
-  SITE_NAME = "卓の記録".freeze
+  SITE_NAME = "TRPGカタログ".freeze
   SITE_DESCRIPTION = "遊んだ TRPG シナリオの一覧。システム、人数、目安時間から選べます。".freeze
 
   def default_meta_tags

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,9 +20,8 @@
     <header class="border-b border-rule bg-surface">
       <div class="mx-auto max-w-5xl px-5 py-5 flex items-baseline gap-4">
         <%= link_to root_path, class: "font-display text-xl tracking-wide no-underline text-ink" do %>
-          卓の記録
+          TRPGカタログ
         <% end %>
-        <p class="text-xs text-muted">シナリオとセッションのカタログ</p>
 
         <nav class="ml-auto flex items-center gap-4 text-xs">
           <% if signed_in? %>

--- a/app/views/manage/people/index.html.erb
+++ b/app/views/manage/people/index.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, "メンバーの管理" %>
 <h1 class="font-display text-2xl">メンバーの管理</h1>
-<p class="mt-2 text-sm text-muted">Person は管理者が作ります。Google アカウントとの紐づけは<%= link_to "アカウント一覧", manage_users_path, class: "text-seal" %>から。</p>
 
 <%= render "form", person: @person %>
 

--- a/app/views/manage/play_sessions/index.html.erb
+++ b/app/views/manage/play_sessions/index.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, "セッションの管理" %>
 <h1 class="font-display text-2xl">セッションの管理</h1>
-<p class="mt-2 text-sm text-muted">ここでは公開範囲に関わらず全ての回が並びます。</p>
 
 <%= render "form", play_session: @play_session || PlaySession.new %>
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, "メンバー" %>
 
 <h1 class="font-display text-3xl tracking-wide">メンバー</h1>
-<p class="mt-2 text-sm text-muted">ログインしている人だけが見られます。</p>
 
 <ul class="mt-8 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
   <% @people.each do |member| %>

--- a/app/views/play_sessions/index.html.erb
+++ b/app/views/play_sessions/index.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, "セッション一覧" %>
 
-<h1 class="font-display text-3xl tracking-wide">セッション一覧</h1>
-<p class="mt-2 text-sm text-muted">同じグループの人が参加した回だけが並びます。</p>
+<h1 class="font-display text-3xl tracking-wide">
+  セッション一覧<span class="ml-2 text-base text-muted">（全<%= @play_sessions.size %>件）</span>
+</h1>
 
 <ul class="mt-8 divide-y divide-rule border border-rule bg-surface">
   <% @play_sessions.each do |session| %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,10 +1,9 @@
 <% content_for :title, "シナリオ一覧" %>
 
 <div class="flex flex-wrap items-baseline justify-between gap-4">
-  <div>
-    <h1 class="font-display text-3xl tracking-wide">シナリオ一覧</h1>
-    <p class="mt-2 text-sm text-muted"><%= @scenarios.size %>本。人数と目安時間から選べます。</p>
-  </div>
+  <h1 class="font-display text-3xl tracking-wide">
+    シナリオ一覧<span class="ml-2 text-base text-muted">（全<%= @scenarios.size %>件）</span>
+  </h1>
 
   <nav class="flex items-center gap-3 text-xs" aria-label="表示の切り替え">
     <%= link_to "表形式", root_path(view: "table"), class: list_view_class("table", @view),

--- a/spec/requests/manage/people_spec.rb
+++ b/spec/requests/manage/people_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe "Manage::People" do
       expect(person.groups).to eq([ group ])
     end
 
+    it "carries no explanation under the title" do
+      get manage_people_path
+
+      expect(response.body).not_to include("Person は管理者が作ります")
+    end
+
     it "links a Google account to a person" do
       user = create(:user, person: nil, email: "someone@example.com")
       person = create(:person, display_name: "だれか")

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe "Manage::PlaySessions" do
       expect(response.body).to include(edit_manage_play_session_path(other))
     end
 
+    it "carries no explanation under the title" do
+      get manage_play_sessions_path
+
+      expect(response.body).not_to include("公開範囲に関わらず")
+    end
+
     it "shows the note, which the reader-facing scope would hide" do
       session = create(:play_session, scenario:, note: "覚え書きの見本")
 

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -168,5 +168,13 @@ RSpec.describe "People" do
 
       expect(response.body).to include("本人", "別の人")
     end
+
+    it "carries no explanation under the title" do
+      sign_in_as other
+
+      get people_path
+
+      expect(response.body).not_to include("ログインしている人だけが見られます")
+    end
   end
 end

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -41,6 +41,33 @@ RSpec.describe "PlaySessions" do
 
       expect(response.body).to include("見本シナリオ")
     end
+
+    # 件数は見える範囲の数。全体の数を出すと、見えない回があることを教えてしまう。
+    it "counts only the sessions the viewer may see" do
+      hidden = create(:play_session, scenario: create(:scenario, title: "見えない回"))
+      hidden.participations.create!(person: create(:person), role: :gm)
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_sessions_path
+
+      expect(response.body[%r{<h1.*?</h1>}m]).to include("（全1件）")
+    end
+
+    it "counts nothing for someone who shares no group" do
+      sign_in_as create(:person)
+
+      get play_sessions_path
+
+      expect(response.body[%r{<h1.*?</h1>}m]).to include("（全0件）")
+    end
+
+    it "carries no explanation under the title" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_sessions_path
+
+      expect(response.body).not_to include("同じグループの人が参加した回だけが並びます")
+    end
   end
 
   describe "GET /play_sessions/:id" do

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe "PlaySessions" do
 
       expect(response.body).not_to include("同じグループの人が参加した回だけが並びます")
     end
+
+    # Scope は EXISTS を 2 本抱えるため、件数のために引き直すと素の一覧が倍のコストになる。
+    it "evaluates the scope once, not again for the count" do
+      sign_in_as create(:person, groups: [ group ])
+
+      sqls = queries_against("play_sessions") { get play_sessions_path }
+
+      expect(sqls.size).to eq(1)
+    end
   end
 
   describe "GET /play_sessions/:id" do

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe "The scenario list" do
     end
   end
 
+  describe "the heading" do
+    it "counts the scenarios beside the title" do
+      create(:scenario, title: "もう1本")
+
+      get root_path
+
+      expect(response.body[%r{<h1.*?</h1>}m]).to include("（全2件）")
+    end
+
+    it "carries no explanation under the title" do
+      get root_path
+
+      expect(response.body).not_to include("人数と目安時間から選べます")
+    end
+  end
+
   describe "switching" do
     it "offers a link to the jacket view" do
       get root_path

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Scenarios" do
     it "puts the scenario name in the page title" do
       get scenario_path(scenario)
 
-      expect(response.body).to include("<title>ロールシャッハシンドローム | 卓の記録</title>")
+      expect(response.body).to include("<title>ロールシャッハシンドローム | TRPGカタログ</title>")
     end
 
     it "gives the JSON-LD block a nonce that matches the policy header" do

--- a/spec/requests/site_name_spec.rb
+++ b/spec/requests/site_name_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "The site name" do
+  it "names the site in the header" do
+    get root_path
+
+    header = response.body[%r{<header.*?</header>}m]
+
+    expect(header).to include("TRPGカタログ")
+    expect(header).not_to include("卓の記録")
+  end
+
+  it "names the site in the page title" do
+    get root_path
+
+    expect(response.body).to include("<title>シナリオ一覧 | TRPGカタログ</title>")
+  end
+
+  it "carries no subtitle beside the name" do
+    get root_path
+
+    expect(response.body).not_to include("シナリオとセッションのカタログ")
+  end
+end

--- a/spec/support/query_counting.rb
+++ b/spec/support/query_counting.rb
@@ -1,0 +1,14 @@
+module QueryCounting
+  def queries_against(table)
+    sqls = []
+    callback = ->(_name, _start, _finish, _id, payload) do
+      sqls << payload[:sql] if payload[:sql].include?(%(FROM "#{table}"))
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    sqls
+  end
+end
+
+RSpec.configure do |config|
+  config.include QueryCounting, type: :request
+end


### PR DESCRIPTION
## What

Rename the site to TRPGカタログ, drop the subtitle and the explanatory lines under each title, and put 「（全X件）」 beside the scenario and session list titles.

## Why

Closes #27.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

The session count comes from the policy scope, so it never reveals how many sessions the viewer cannot see. `spec/requests/play_sessions_spec.rb` pins that.

## Related

