### PR TITLE
Organize the repository conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@
 | テスト | `bin/rspec` |
 | 1 ファイルだけ | `bin/rspec spec/requests/scenarios_spec.rb:42` |
 | 静的解析をまとめて | `prek run --all-files` |
+| CI と同じ一式 | `bin/ci`（PR を出す前に通す） |
 | 開発サーバ | `bin/dev`（Puma と Tailwind の watch） |
 | シナリオの投入 | `bin/rails db:seed`（冪等） |
 
@@ -67,6 +68,7 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 ### 公開リポジトリとして
 
 - public repo である。クラスタ側の資格情報とリソース識別子を持ち込まない
+- インフラ側のリポジトリ名と、クラスタ内部のホスト名も書かない。「インフラ側のリポジトリ」と呼ぶ。公開サイトのホスト名は別で、README と `APP_HOST` の既定値に出ている
 - シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入先は `SCENARIOS_SEED_FILE` で差し替える
 
 ### 設定と実行
@@ -81,6 +83,7 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 - セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧、詳細、シナリオ詳細の履歴が同じものを通る
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない
+- 認可に触れる変更では、誰に何が見えるかを spec で固定する。役割ごとの可否は `spec/policies/authorization_matrix_spec.rb` の一覧に足し、画面から見えるかどうかは `spec/requests/` に足す
 
 ### ドメイン
 
@@ -90,4 +93,11 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 
 ### 進め方
 
+TDD、commit の分け方、pre-commit の扱いは [README の「変更を出す」](README.md#変更を出す) にある。加えて次を守る。
+
+- 作業は `main` から切った worktree で行う。元のディレクトリは `main` のまま残す
+- PR を作ったら必ずサブエージェントで第三者レビューを実行し、GitHub の行コメントとして投稿する。規模を問わず必須で、実施の可否は尋ねない
+- レビューが返ったら内容を精査し、対応・非対応を PR 上で1件ずつ返信する
+- マージは依頼者が行う。こちらでは merge しない
+- 会話は日本語。commit と PR の title/description は英語
 - ソースに複数行コメントを書かない。書くのは、コードから読み取れない背景や理由に限る

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,16 +64,30 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 
 ## この repo の約束
 
+### 公開リポジトリとして
+
 - public repo である。クラスタ側の資格情報とリソース識別子を持ち込まない
+- シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入先は `SCENARIOS_SEED_FILE` で差し替える
+
+### 設定と実行
+
 - 設定はすべて環境変数から読む。Rails credentials は使わない（`config/master.key` は存在しない）
+
+### 認可
+
 - 認可は Pundit に寄せる。`ApplicationPolicy` は既定で拒否し、`Scope` は空集合を返す
 - 権限が無い相手には 403 ではなく 404 を返す。隠している画面の存在を教えない
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
-- プレイヤーは全員が持つため保存しない。`Person#player?` は常に真で、付け外しできない
-- 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
 - セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧、詳細、シナリオ詳細の履歴が同じものを通る
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない
+
+### ドメイン
+
+- プレイヤーは全員が持つため保存しない。`Person#player?` は常に真で、付け外しできない
+- 最初の管理者は `bin/rails admin:grant EMAIL=... NAME=...` で作る。管理画面からは作れない
 - おすすめ度は編集画面にだけ出す。表示はせず並び順の材料として持つ
-- シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入先は `SCENARIOS_SEED_FILE` で差し替える
+
+### 進め方
+
 - ソースに複数行コメントを書かない。書くのは、コードから読み取れない背景や理由に限る

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,17 +68,16 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 ### 公開リポジトリとして
 
 - public repo である。クラスタ側の資格情報とリソース識別子を持ち込まない
-- インフラ側のリポジトリ名と、クラスタ内部のホスト名も書かない。「インフラ側のリポジトリ」と呼ぶ。公開サイトのホスト名は別で、README と `APP_HOST` の既定値に出ている
 - シナリオの実データは git に置かない。書式は `db/seeds/scenarios.example.yml`、投入先は `SCENARIOS_SEED_FILE` で差し替える
 
 ### 設定と実行
 
-[The Twelve-Factor App](https://12factor.net/) に従う。この 4 つは崩さない。
+[The Twelve-Factor App](https://12factor.net/) に従う。とくに次の 4 つを崩さない。
 
 - 設定はすべて環境変数から読む。Rails credentials は使わない（`config/master.key` は存在しない）。本番で欠けては困る変数は `config/initializers/required_env.rb` に足し、起動時に落とす
 - ログは標準出力にだけ出す（`config/environments/production.rb`）。ファイルへの書き出しや収集サービスへの直接送信を足さない。収集はクラスタ側に任せる
 - マイグレーションはリリース時の Job が実行する。`bin/docker-entrypoint` にも起動時フックにも入れない。手順は「データベースを変える」にある
-- 状態はプロセスの外に置く。アップロードは Active Storage 経由で MinIO、キャッシュとキューは Solid Cache / Solid Queue の DB に入れる。ローカルディスクとプロセス内メモリに残すと、Pod の入れ替えで消える
+- 本番では状態をプロセスの外に置く。アップロードは Active Storage 経由で MinIO、キャッシュとキューは Solid Cache / Solid Queue の DB に入れる（`config/environments/production.rb`）。ローカルディスクとプロセス内メモリに残すと、Pod の入れ替えで消える
 
 ### 認可
 
@@ -88,7 +87,7 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 - セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧、詳細、シナリオ詳細の履歴が同じものを通る
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない
-- 認可に触れる変更では、誰に何が見えるかを spec で固定する。役割ごとの可否は `spec/policies/authorization_matrix_spec.rb` の一覧に足し、画面から見えるかどうかは `spec/requests/` に足す
+- 誰に何が見えるかを固定する spec の置き場所は決まっている。役割ごとの可否は `spec/policies/authorization_matrix_spec.rb` の一覧に足し、画面から見えるかどうかは `spec/requests/` に足す
 
 ### ドメイン
 
@@ -105,4 +104,7 @@ TDD、commit の分け方、pre-commit の扱いは [README の「変更を出�
 - レビューが返ったら内容を精査し、対応・非対応を PR 上で1件ずつ返信する
 - マージは依頼者が行う。こちらでは merge しない
 - 会話は日本語。commit と PR の title/description は英語
+
+### コードを書くとき
+
 - ソースに複数行コメントを書かない。書くのは、コードから読み取れない背景や理由に限る

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,12 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 
 ### 設定と実行
 
-- 設定はすべて環境変数から読む。Rails credentials は使わない（`config/master.key` は存在しない）
+[The Twelve-Factor App](https://12factor.net/) に従う。この 4 つは崩さない。
+
+- 設定はすべて環境変数から読む。Rails credentials は使わない（`config/master.key` は存在しない）。本番で欠けては困る変数は `config/initializers/required_env.rb` に足し、起動時に落とす
+- ログは標準出力にだけ出す（`config/environments/production.rb`）。ファイルへの書き出しや収集サービスへの直接送信を足さない。収集はクラスタ側に任せる
+- マイグレーションはリリース時の Job が実行する。`bin/docker-entrypoint` にも起動時フックにも入れない。手順は「データベースを変える」にある
+- 状態はプロセスの外に置く。アップロードは Active Storage 経由で MinIO、キャッシュとキューは Solid Cache / Solid Queue の DB に入れる。ローカルディスクとプロセス内メモリに残すと、Pod の入れ替えで消える
 
 ### 認可
 


### PR DESCRIPTION
## What

Split "この repo の約束" into subsections, add the working agreements that were only passed to sessions verbally, and state the twelve-factor rules the app already follows.

## Why

The conventions were one flat list, so nothing was findable. The twelve-factor policy lived only in ADR-0001 and was easy to break.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

ADR-0001 "設定と実行"

Depends on #45. The rule about not naming the infrastructure repository is left out here because ADR-0001 still allows it; it goes in once #45 is merged.
