### PR TITLE
Show the GM recommendation note to signed-in members only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
 - セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧、詳細、シナリオ詳細の履歴が同じものを通る
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
+- GMからのオススメポイントは `ScenarioPolicy#show_recommendation_note?` が真のときだけレスポンスに載せる。未ログインには見出しごと出さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない
 - 誰に何が見えるかを固定する spec の置き場所は決まっている。役割ごとの可否は `spec/policies/authorization_matrix_spec.rb` の一覧に足し、画面から見えるかどうかは `spec/requests/` に足す
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ RAILS_ENV=test bin/rails runner 'puts Person.count'   # 0 でなければ残っ�
 - 権限は Person に付く。`User` は認証に要る情報だけを持つ。`pundit_user` は `current_person`
 - セッションの可視性は `PlaySessionPolicy::Scope` にだけ書く。一覧、詳細、シナリオ詳細の履歴が同じものを通る
 - 準備情報は `ScenarioPolicy#show_preparation_note?` が真のときだけ本文をレスポンスに載せる。CSS では隠さない
-- GMからのオススメポイントは `ScenarioPolicy#show_recommendation_note?` が真のときだけレスポンスに載せる。未ログインには見出しごと出さない
+- GMからのオススメポイントは `ScenarioPolicy#show_recommendation_note?` が真のときだけレスポンスに載せる。Person に紐づかない閲覧者には見出しごと出さない
 - プロフィールの編集は本人と管理者。グループ所属は管理画面（管理者のみ）でしか変えられない
 - 誰に何が見えるかを固定する spec の置き場所は決まっている。役割ごとの可否は `spec/policies/authorization_matrix_spec.rb` の一覧に足し、画面から見えるかどうかは `spec/requests/` に足す
 

--- a/app/policies/scenario_policy.rb
+++ b/app/policies/scenario_policy.rb
@@ -17,6 +17,9 @@ class ScenarioPolicy < ApplicationPolicy
   # 押した記録があるときだけ本文を返す。CSS では隠さない。
   def show_preparation_note? = person.present? && person.revealed?(record)
 
+  # GM の私見であり、公開エリアの一部ではあっても外部の閲覧者には見せない。
+  def show_recommendation_note? = person.present?
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.all

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -108,7 +108,8 @@
       </div>
 
       <div>
-        <%= form.label :recommendation_note, "おすすめポイント", class: "block text-xs text-muted" %>
+        <%= form.label :recommendation_note, "GMからのオススメポイント", class: "block text-xs text-muted" %>
+        <p class="text-xs text-muted">ログインした人にだけ見せる。</p>
         <%= form.text_area :recommendation_note, rows: 4, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
       </div>
 

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -109,7 +109,7 @@
 
       <div>
         <%= form.label :recommendation_note, "GMからのオススメポイント", class: "block text-xs text-muted" %>
-        <p class="text-xs text-muted">ログインした人にだけ見せる。</p>
+        <p class="text-xs text-muted">メンバーにだけ見せる。未登録のログインユーザーと未ログインには出さない。</p>
         <%= form.text_area :recommendation_note, rows: 4, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
       </div>
 

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -53,9 +53,9 @@
     </section>
   <% end %>
 
-  <% if @scenario.recommendation_note.present? %>
+  <% if @scenario.recommendation_note.present? && policy(@scenario).show_recommendation_note? %>
     <section class="mt-10">
-      <h2 class="font-display text-xl">おすすめポイント</h2>
+      <h2 class="font-display text-xl">GMからのオススメポイント</h2>
       <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @scenario.recommendation_note %></p>
     </section>
   <% end %>

--- a/db/seeds/scenarios.example.yml
+++ b/db/seeds/scenarios.example.yml
@@ -16,7 +16,7 @@
   gm_experienced: true
   character_restriction: HOあり
   character_sheet_deadline: two_days_before
-  recommendation_note: GMからのオススメポイントをここに書く。ログインした人にだけ出る。
+  recommendation_note: GMからのオススメポイントをここに書く。メンバーにだけ出る。
   purchase_links:
     - label: BOOTH
       url: https://example.com/items/1

--- a/db/seeds/scenarios.example.yml
+++ b/db/seeds/scenarios.example.yml
@@ -16,7 +16,7 @@
   gm_experienced: true
   character_restriction: HOあり
   character_sheet_deadline: two_days_before
-  recommendation_note: おすすめポイントをここに書く。公開ページに出る。
+  recommendation_note: GMからのオススメポイントをここに書く。ログインした人にだけ出る。
   purchase_links:
     - label: BOOTH
       url: https://example.com/items/1

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe "Authorization matrix" do
         expect(allows?(person, described_class, Scenario.new, :show_preparation_note?)).to be(false)
       end
     end
+
+    it "shows the recommendation note to members only" do
+      expect(allows?(anonymous, described_class, Scenario.new, :show_recommendation_note?)).to be_falsey
+      expect(allows?(unlinked, described_class, Scenario.new, :show_recommendation_note?)).to be_falsey
+      expect(allows?(no_role, described_class, Scenario.new, :show_recommendation_note?)).to be(true)
+      expect(allows?(gm, described_class, Scenario.new, :show_recommendation_note?)).to be(true)
+      expect(allows?(admin, described_class, Scenario.new, :show_recommendation_note?)).to be(true)
+    end
   end
 
   describe PersonPolicy do

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Scenarios" do
         title: "ロールシャッハシンドローム",
         synopsis: "あらすじ本文",
         preparation_note: "ネタバレを含む準備情報",
+        recommendation_note: "GM が推す一点",
         game_systems: [ create(:game_system, name: "エモクロアTRPG") ],
         authors: [ create(:author, name: "ディズム") ]
       )
@@ -44,6 +45,30 @@ RSpec.describe "Scenarios" do
       get scenario_path(scenario)
 
       expect(response.body).not_to include("ネタバレを含む準備情報")
+    end
+
+    it "keeps the recommendation note out of the response for a visitor" do
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("GM が推す一点")
+      expect(response.body).not_to include("GMからのオススメポイント")
+    end
+
+    it "keeps the recommendation note out of the response for a user with no person" do
+      sign_in_as(create(:user))
+
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("GM が推す一点")
+      expect(response.body).not_to include("GMからのオススメポイント")
+    end
+
+    it "shows the recommendation note to a signed-in member" do
+      sign_in_as(create(:person))
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include("GMからのオススメポイント", "GM が推す一点")
     end
 
     it "puts the scenario name in the page title" do


### PR DESCRIPTION
## What

Rename 「おすすめポイント」 to 「GMからのオススメポイント」 and gate it behind `ScenarioPolicy#show_recommendation_note?`, so only a signed-in user linked to a `Person` gets it. Visitors get neither the heading nor the body.

## Why

The note is the GM's own take, not catalogue data, so it should not reach search engines or anonymous visitors.

`person.present?` follows `show_preparation_note?` and `favourite?`: a `User` with no `Person` stays in the public area.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #34
