### PR TITLE
Say to look for a library before hand-writing a widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,5 @@ TDD、commit の分け方、pre-commit の扱いは [README の「変更を出�
 ### コードを書くとき
 
 - ソースに複数行コメントを書かない。書くのは、コードから読み取れない背景や理由に限る
+- 画面の部品を自前で書く前に、既存のライブラリを探す（ADR-0001 の「自前実装は避ける」）。importmap でも `./bin/importmap pin <名前> --download` で npm のパッケージが入る。CSP が `script_src :self` のため CDN からは読めず、`vendor/javascript/` へ落とす形になる
+- 部分更新は Turbo Frame と Turbo Stream で書く。素の `fetch` を足す前に、`favorites_controller.rb` の `turbo_stream.replace` を見る

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,5 +109,5 @@ TDD、commit の分け方、pre-commit の扱いは [README の「変更を出�
 ### コードを書くとき
 
 - ソースに複数行コメントを書かない。書くのは、コードから読み取れない背景や理由に限る
-- 画面の部品を自前で書く前に、既存のライブラリを探す（ADR-0001 の「自前実装は避ける」）。importmap でも `./bin/importmap pin <名前> --download` で npm のパッケージが入る。CSP が `script_src :self` のため CDN からは読めず、`vendor/javascript/` へ落とす形になる
+- 画面の部品を自前で書く前に、既存のライブラリを探す（ADR-0001 の「自前実装は避ける」）。importmap でも `bin/importmap pin <名前>` で npm のパッケージが入る。CSP が外部ホストのスクリプトを許していないため CDN からは読めないが、pin したものは `vendor/javascript/` に落ちるので自ホストから配れる
 - 部分更新は Turbo Frame と Turbo Stream で書く。素の `fetch` を足す前に、`favorites_controller.rb` の `turbo_stream.replace` を見る


### PR DESCRIPTION
## What

Two lines under 「コードを書くとき」: look for a library before hand-writing a UI widget, and reach for Turbo before a bare `fetch`.

## Why

#51 hand-rolled the HTML5 drag-and-drop API when SortableJS would have done, and it does not work on touch devices as a result (#57). ADR-0001 already says 自前実装は避ける, but nothing pointed at it from the place where a Stimulus controller gets written. The Turbo line is the same gap seen from the other side (#58).

## Verification

- [ ] `bin/rspec`
- [x] `prek run --all-files`

Documentation only; no code paths change. `bin/rspec` was left to CI rather than run here — the test database is shared with the worktree for #51, and re-preparing it from this branch's schema would knock that one over.

## Related

- #51, #57, #58
- ADR-0001「自前実装は避け、著名ライブラリに寄せる」
