### PR TITLE
Show GM experience on public scenario pages

### DIFF
--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -91,7 +91,7 @@
     <div class="space-y-4">
       <div>
         <label class="inline-flex items-center gap-2 text-sm">
-          <%= form.check_box :gm_experienced %> 回したことがある
+          <%= form.check_box :gm_experienced %> GM経験あり
         </label>
       </div>
 

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -7,6 +7,7 @@
         <th scope="col" class="p-3">システム</th>
         <th scope="col" class="p-3">人数</th>
         <th scope="col" class="p-3">目安時間</th>
+        <th scope="col" class="p-3">GM経験</th>
         <th scope="col" class="p-3">入手先</th>
       </tr>
     </thead>
@@ -20,6 +21,7 @@
           <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
           <td class="p-3 font-mono text-xs"><%= player_count_value(scenario) %></td>
           <td class="p-3 font-mono text-xs"><%= duration_value(scenario) %></td>
+          <td class="p-3 text-center"><%= "☑" if scenario.gm_experienced? %></td>
           <td class="p-3 text-xs">
             <% scenario.purchase_links.each do |link| %>
               <% if link.url.present? %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -38,6 +38,8 @@
         <dd><%= player_count_label(@scenario) %></dd>
         <dt class="text-muted">目安時間</dt>
         <dd><%= duration_label(@scenario) %></dd>
+        <dt class="text-muted">GM経験</dt>
+        <dd class="font-sans"><%= @scenario.gm_experienced? ? "☑GM経験あり" : "GM経験なし" %></dd>
         <dt class="text-muted">参加制限</dt>
         <dd class="font-sans"><%= @scenario.character_restriction.presence || "制限なし" %></dd>
         <dt class="text-muted">キャラシ</dt>

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -132,6 +132,43 @@ RSpec.describe "The scenario list" do
     end
   end
 
+  describe "GM experience" do
+    it "marks only experienced scenarios in the table" do
+      inexperienced = create(:scenario, title: "未経験シナリオ", gm_experienced: false)
+
+      get root_path
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("th", text: "GM経験")
+      expect(page.find("tr", text: scenario.title)).to have_text("☑")
+      expect(page.find("tr", text: inexperienced.title)).to have_no_text("☑")
+    end
+
+    it "says the GM has experience on an experienced scenario page" do
+      get scenario_path(scenario)
+
+      expect(response.body).to include("☑GM経験あり")
+    end
+
+    it "says the GM has no experience on an inexperienced scenario page" do
+      scenario.update!(gm_experienced: false)
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include("GM経験なし")
+      expect(response.body).not_to include("☑GM経験あり")
+    end
+
+    it "uses the new label on the edit screen" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get edit_manage_scenario_path(scenario)
+
+      expect(response.body).to include("GM経験あり")
+      expect(response.body).not_to include("回したことがある")
+    end
+  end
+
   describe "the order the GM arranged" do
     # 作成順と期待順をずらす。並べ替えを外すと落ちるようにする。
     it "is what the list opens with" do


### PR DESCRIPTION
## What

- Add a GM experience column to the scenario table
- Show whether the GM has experience on scenario detail pages
- Rename the management form label to GM経験あり

## Why

Make the existing GM experience flag visible with the terminology requested in issue #52.

## Verification

- [x] bin/rspec
- [x] prek run --all-files
- [x] bin/ci

## Related

Closes #52