### PR TITLE
Protect GM supplementary scenario information

### DIFF
--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -25,7 +25,6 @@ module ScenariosHelper
   def duration_label(scenario) = duration_value(scenario) || UNSET
 
   def character_sheet_deadline_label(scenario)
-    return scenario.character_sheet_deadline_note if scenario.character_sheet_deadline_note.present?
     return UNSET if scenario.character_sheet_deadline.blank?
 
     t("scenarios.character_sheet_deadlines.#{scenario.character_sheet_deadline}")

--- a/app/policies/scenario_policy.rb
+++ b/app/policies/scenario_policy.rb
@@ -22,6 +22,7 @@ class ScenarioPolicy < ApplicationPolicy
 
   # GM の私見であり、公開エリアの一部ではあっても外部の閲覧者には見せない。
   def show_recommendation_note? = person.present?
+  def show_gm_supplementary_info? = person.present?
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/views/scenarios/_gm_supplementary_info.html.erb
+++ b/app/views/scenarios/_gm_supplementary_info.html.erb
@@ -1,0 +1,13 @@
+<% if policy(scenario).show_gm_supplementary_info? %>
+  <section class="mt-10">
+    <h2 class="font-display text-xl">GMからの補足情報</h2>
+    <dl class="mt-3 grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+      <dt class="text-muted">参加可能キャラの制限</dt>
+      <dd><%= scenario.character_restriction.presence || "制限なし" %></dd>
+      <dt class="text-muted">キャラシ提出期限</dt>
+      <dd><%= character_sheet_deadline_label(scenario) %></dd>
+      <dt class="text-muted">キャラシ提出期限の補足</dt>
+      <dd><%= scenario.character_sheet_deadline_note.presence || "補足なし" %></dd>
+    </dl>
+  </section>
+<% end %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -34,17 +34,16 @@
       <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
         <dt class="text-muted">システム</dt>
         <dd class="font-sans"><%= @scenario.game_systems.map(&:name).join("／").presence || "未設定" %></dd>
+        <dt class="text-muted">GM経験</dt>
+        <dd class="font-sans"><%= @scenario.gm_experienced? ? "☑GM経験あり" : "GM経験なし" %></dd>
         <dt class="text-muted">人数</dt>
         <dd><%= player_count_label(@scenario) %></dd>
         <dt class="text-muted">目安時間</dt>
         <dd><%= duration_label(@scenario) %></dd>
-        <dt class="text-muted">GM経験</dt>
-        <dd class="font-sans"><%= @scenario.gm_experienced? ? "☑GM経験あり" : "GM経験なし" %></dd>
-        <dt class="text-muted">参加制限</dt>
-        <dd class="font-sans"><%= @scenario.character_restriction.presence || "制限なし" %></dd>
-        <dt class="text-muted">キャラシ</dt>
-        <dd class="font-sans"><%= character_sheet_deadline_label(@scenario) %></dd>
       </dl>
+      <p class="mt-3 text-xs text-muted">
+        この情報はGMが独自判断で記載しており、シナリオ公式の案内と異なる場合があります
+      </p>
     </div>
   </div>
 
@@ -61,6 +60,8 @@
       <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @scenario.recommendation_note %></p>
     </section>
   <% end %>
+
+  <%= render "scenarios/gm_supplementary_info", scenario: @scenario %>
 
   <% if @scenario.purchase_links.any? %>
     <section class="mt-10">

--- a/spec/helpers/scenarios_helper_spec.rb
+++ b/spec/helpers/scenarios_helper_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe ScenariosHelper do
         .to eq("セッション前々日")
     end
 
-    it "prefers the free-text note when the deadline does not fit the enum" do
+    it "keeps the selected option separate from its note" do
       scenario = build(:scenario, character_sheet_deadline: :see_note, character_sheet_deadline_note: "継続の場合提出不要")
 
-      expect(helper.character_sheet_deadline_label(scenario)).to eq("継続の場合提出不要")
+      expect(helper.character_sheet_deadline_label(scenario)).to eq("備考参照")
     end
 
     it "says unset for 「-」 and a blank cell" do

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe "Authorization matrix" do
       expect(allows?(gm, described_class, Scenario.new, :show_recommendation_note?)).to be(true)
       expect(allows?(admin, described_class, Scenario.new, :show_recommendation_note?)).to be(true)
     end
+
+    it "shows the GM supplementary information to members only" do
+      expect(allows?(anonymous, described_class, Scenario.new, :show_gm_supplementary_info?)).to be_falsey
+      expect(allows?(unlinked, described_class, Scenario.new, :show_gm_supplementary_info?)).to be_falsey
+      expect(allows?(no_role, described_class, Scenario.new, :show_gm_supplementary_info?)).to be(true)
+      expect(allows?(gm, described_class, Scenario.new, :show_gm_supplementary_info?)).to be(true)
+      expect(allows?(admin, described_class, Scenario.new, :show_gm_supplementary_info?)).to be(true)
+    end
   end
 
   describe PersonPolicy do

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe "Scenarios" do
         synopsis: "あらすじ本文",
         preparation_note: "ネタバレを含む準備情報",
         recommendation_note: "GM が推す一点",
+        player_count_min: 2,
+        player_count_max: 4,
+        duration_min_hours: 3,
+        duration_max_hours: 5,
+        character_restriction: "継続キャラクター限定",
+        character_sheet_deadline: :two_days_before,
+        character_sheet_deadline_note: "正午までに提出",
         game_systems: [ create(:game_system, name: "エモクロアTRPG") ],
         authors: [ create(:author, name: "ディズム") ]
       )
@@ -39,6 +46,36 @@ RSpec.describe "Scenarios" do
 
       expect(response.body).to include("ロールシャッハシンドローム", "あらすじ本文", "エモクロアTRPG", "ディズム")
       expect(response.body).to include("https://booth.pm/ja/items/1", "https://youtu.be/abc")
+      expect(response.body).to include("2人〜4人", "3時間〜5時間")
+      expect(response.body).to include("この情報はGMが独自判断で記載しており、シナリオ公式の案内と異なる場合があります")
+    end
+
+    it "keeps the GM supplementary information out of the response for a visitor" do
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("GMからの補足情報", "継続キャラクター限定", "正午までに提出")
+      expect(response.body).not_to include("セッション前々日")
+    end
+
+    it "keeps the GM supplementary information out of the response for a user with no person" do
+      sign_in_as(create(:user))
+
+      get scenario_path(scenario)
+
+      expect(response.body).not_to include("GMからの補足情報", "継続キャラクター限定", "正午までに提出")
+      expect(response.body).not_to include("セッション前々日")
+    end
+
+    it "shows the GM supplementary information below the recommendation to a signed-in member" do
+      sign_in_as(create(:person))
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include(
+        "GMからの補足情報", "参加可能キャラの制限", "継続キャラクター限定",
+        "キャラシ提出期限", "セッション前々日", "キャラシ提出期限の補足", "正午までに提出"
+      )
+      expect(response.body.index("GMからのオススメポイント")).to be < response.body.index("GMからの補足情報")
     end
 
     it "keeps the preparation note out of the response entirely" do


### PR DESCRIPTION
## What

- Restrict character limitations and character-sheet deadlines to linked members
- Move those fields into a GM supplementary information section
- Add a disclaimer below the public player-count and duration details

## Why

Keep GM-authored supplementary information out of public responses while retaining the public scheduling guidance requested in issue #53.

## Verification

- [x] bin/rspec
- [x] prek run --all-files
- [x] bin/ci

## Related

Closes #53