### PR TITLE
Embed YouTube streams and recordings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     uri = URI.parse(url)
     video_id = youtube_video_id(uri)
 
-    "https://www.youtube-nocookie.com/embed/#{video_id}" if video_id&.match?(YOUTUBE_VIDEO_ID)
+    "https://www.youtube.com/embed/#{video_id}" if video_id&.match?(YOUTUBE_VIDEO_ID)
   rescue URI::InvalidURIError, Rack::QueryParser::InvalidParameterError
     nil
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,24 @@
 module ApplicationHelper
+  YOUTUBE_VIDEO_ID = /\A[\w-]{11}\z/
+
+  def youtube_embed_url(url)
+    uri = URI.parse(url)
+    video_id = youtube_video_id(uri)
+
+    "https://www.youtube-nocookie.com/embed/#{video_id}" if video_id&.match?(YOUTUBE_VIDEO_ID)
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  private
+    def youtube_video_id(uri)
+      host = uri.host&.downcase
+
+      return uri.path.delete_prefix("/").split("/").first if host == "youtu.be"
+      return unless %w[youtube.com www.youtube.com m.youtube.com].include?(host)
+
+      segments = uri.path.split("/").reject(&:blank?)
+      return Rack::Utils.parse_query(uri.query)["v"] if segments.first == "watch"
+      segments.second if %w[embed shorts live].include?(segments.first)
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
     video_id = youtube_video_id(uri)
 
     "https://www.youtube-nocookie.com/embed/#{video_id}" if video_id&.match?(YOUTUBE_VIDEO_ID)
-  rescue URI::InvalidURIError
+  rescue URI::InvalidURIError, Rack::QueryParser::InvalidParameterError
     nil
   end
 

--- a/app/javascript/controllers/video_disclosure_controller.js
+++ b/app/javascript/controllers/video_disclosure_controller.js
@@ -1,18 +1,23 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["content", "openButton"]
+  static targets = ["content", "openButton", "closeButton"]
 
   open() {
     this.contentTarget.hidden = false
     this.openButtonTarget.hidden = true
     this.openButtonTarget.setAttribute("aria-expanded", "true")
+    this.closeButtonTarget.focus()
   }
 
   close() {
+    this.reset()
+    this.openButtonTarget.focus()
+  }
+
+  reset() {
     this.contentTarget.hidden = true
     this.openButtonTarget.hidden = false
     this.openButtonTarget.setAttribute("aria-expanded", "false")
-    this.openButtonTarget.focus()
   }
 }

--- a/app/javascript/controllers/video_disclosure_controller.js
+++ b/app/javascript/controllers/video_disclosure_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "openButton"]
+
+  open() {
+    this.contentTarget.hidden = false
+    this.openButtonTarget.hidden = true
+    this.openButtonTarget.setAttribute("aria-expanded", "true")
+  }
+
+  close() {
+    this.contentTarget.hidden = true
+    this.openButtonTarget.hidden = false
+    this.openButtonTarget.setAttribute("aria-expanded", "false")
+    this.openButtonTarget.focus()
+  }
+}

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -23,7 +23,8 @@
     <% if @play_session.recording_url.present? %>
       <dt class="text-muted">録画</dt>
       <dd class="space-y-2 font-sans">
-        <%= render "shared/video_link", title: "録画", url: @play_session.recording_url, rel: "noopener" %>
+        <%= render "shared/video_link", title: "録画", url: @play_session.recording_url,
+              link_text: @play_session.recording_url, rel: "noopener", show_url: false %>
       </dd>
     <% end %>
   </dl>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -22,8 +22,8 @@
     <dd class="font-sans"><%= play_session_status_label(@play_session) %></dd>
     <% if @play_session.recording_url.present? %>
       <dt class="text-muted">録画</dt>
-      <dd class="font-sans">
-        <%= link_to @play_session.recording_url, @play_session.recording_url, rel: "noopener", class: "text-seal" %>
+      <dd class="space-y-2 font-sans">
+        <%= render "shared/video_link", title: "録画", url: @play_session.recording_url, rel: "noopener" %>
       </dd>
     <% end %>
   </dl>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -83,19 +83,30 @@
   <% if @scenario.stream_links.any? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">おすすめの配信</h2>
-      <details class="mt-3">
-        <summary class="inline-block cursor-pointer border border-rule bg-surface px-4 py-2 text-sm text-seal">
+      <div class="mt-3" data-controller="video-disclosure">
+        <button type="button" aria-controls="scenario_<%= @scenario.id %>_streams" aria-expanded="false"
+                data-video-disclosure-target="openButton" data-action="video-disclosure#open"
+                class="border border-rule bg-surface px-4 py-2 text-sm text-seal">
           おすすめ配信を開く
-        </summary>
-        <ul class="mt-3 space-y-1 text-sm">
-          <% @scenario.stream_links.each do |link| %>
-            <li class="space-y-2">
-              <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
-                    link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
-            </li>
-          <% end %>
-        </ul>
-      </details>
+        </button>
+        <div id="scenario_<%= @scenario.id %>_streams" hidden data-video-disclosure-target="content"
+             class="border border-rule bg-surface p-4">
+          <ul class="space-y-1 text-sm">
+            <% @scenario.stream_links.each do |link| %>
+              <li class="space-y-2">
+                <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
+                      link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
+              </li>
+            <% end %>
+          </ul>
+          <div class="mt-4 border-t border-rule pt-3 text-right">
+            <button type="button" data-action="video-disclosure#close"
+                    class="border border-rule bg-paper px-4 py-2 text-sm text-seal">
+              おすすめ配信を閉じる
+            </button>
+          </div>
+        </div>
+      </div>
     </section>
   <% end %>
 

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -83,7 +83,8 @@
   <% if @scenario.stream_links.any? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">おすすめの配信</h2>
-      <div class="mt-3" data-controller="video-disclosure">
+      <div class="mt-3" data-controller="video-disclosure"
+           data-action="turbo:before-cache@document->video-disclosure#reset">
         <button type="button" aria-controls="scenario_<%= @scenario.id %>_streams" aria-expanded="false"
                 data-video-disclosure-target="openButton" data-action="video-disclosure#open"
                 class="border border-rule bg-surface px-4 py-2 text-sm text-seal">
@@ -100,7 +101,7 @@
             <% end %>
           </ul>
           <div class="mt-4 border-t border-rule pt-3 text-right">
-            <button type="button" data-action="video-disclosure#close"
+            <button type="button" data-video-disclosure-target="closeButton" data-action="video-disclosure#close"
                     class="border border-rule bg-paper px-4 py-2 text-sm text-seal">
               おすすめ配信を閉じる
             </button>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -83,14 +83,19 @@
   <% if @scenario.stream_links.any? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">おすすめの配信</h2>
-      <ul class="mt-3 space-y-1 text-sm">
-        <% @scenario.stream_links.each do |link| %>
-          <li class="space-y-2">
-            <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
-                  link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
-          </li>
-        <% end %>
-      </ul>
+      <details class="mt-3">
+        <summary class="inline-block cursor-pointer border border-rule bg-surface px-4 py-2 text-sm text-seal">
+          おすすめ配信を開く
+        </summary>
+        <ul class="mt-3 space-y-1 text-sm">
+          <% @scenario.stream_links.each do |link| %>
+            <li class="space-y-2">
+              <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
+                    link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
+            </li>
+          <% end %>
+        </ul>
+      </details>
     </section>
   <% end %>
 

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -85,8 +85,9 @@
       <h2 class="font-display text-xl">おすすめの配信</h2>
       <ul class="mt-3 space-y-1 text-sm">
         <% @scenario.stream_links.each do |link| %>
-          <li>
-            <%= link_to link.label.presence || link.url, link.url, rel: "noopener nofollow", class: "text-seal" %>
+          <li class="space-y-2">
+            <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
+                  rel: "noopener nofollow" %>
             <span class="font-mono text-xs text-muted"><%= link.url %></span>
           </li>
         <% end %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -87,8 +87,7 @@
         <% @scenario.stream_links.each do |link| %>
           <li class="space-y-2">
             <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
-                  rel: "noopener nofollow" %>
-            <span class="font-mono text-xs text-muted"><%= link.url %></span>
+                  link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/_video_link.html.erb
+++ b/app/views/shared/_video_link.html.erb
@@ -4,5 +4,9 @@
           allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
           allowfullscreen: true %>
   </div>
+<% else %>
+  <%= link_to link_text, url, rel:, class: "text-seal" %>
+  <% if show_url %>
+    <span class="font-mono text-xs text-muted"><%= url %></span>
+  <% end %>
 <% end %>
-<%= link_to title, url, rel:, class: "text-seal" %>

--- a/app/views/shared/_video_link.html.erb
+++ b/app/views/shared/_video_link.html.erb
@@ -1,0 +1,8 @@
+<% if (embed_url = youtube_embed_url(url)) %>
+  <div class="aspect-video overflow-hidden bg-black">
+    <%= tag.iframe title:, src: embed_url, class: "h-full w-full", loading: "lazy",
+          allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+          allowfullscreen: true %>
+  </div>
+<% end %>
+<%= link_to title, url, rel:, class: "text-seal" %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     policy.script_src  :self, *GOOGLE_TAG_ORIGINS
     policy.style_src   :self
     policy.connect_src :self, *GOOGLE_MEASUREMENT_ORIGINS, *GOOGLE_TAG_ORIGINS
-    policy.frame_src   :self, *GOOGLE_TAG_ORIGINS
+    policy.frame_src   :self, *GOOGLE_TAG_ORIGINS, "https://www.youtube-nocookie.com"
     policy.frame_ancestors :none
     policy.base_uri    :self
     # Chrome は form-action をリダイレクト先にも適用する。ログインの POST は Google へ 302 する。

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     policy.script_src  :self, *GOOGLE_TAG_ORIGINS
     policy.style_src   :self
     policy.connect_src :self, *GOOGLE_MEASUREMENT_ORIGINS, *GOOGLE_TAG_ORIGINS
-    policy.frame_src   :self, *GOOGLE_TAG_ORIGINS, "https://www.youtube-nocookie.com"
+    policy.frame_src   :self, *GOOGLE_TAG_ORIGINS, "https://www.youtube.com"
     policy.frame_ancestors :none
     policy.base_uri    :self
     # Chrome は form-action をリダイレクト先にも適用する。ログインの POST は Google へ 302 する。

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#youtube_embed_url" do
+    it "converts supported YouTube URLs to privacy-enhanced embed URLs" do
+      expect(helper.youtube_embed_url("https://youtu.be/dQw4w9WgXcQ?t=43"))
+        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+      expect(helper.youtube_embed_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=example"))
+        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+      expect(helper.youtube_embed_url("https://youtube.com/shorts/dQw4w9WgXcQ"))
+        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+      expect(helper.youtube_embed_url("https://youtube.com/live/dQw4w9WgXcQ"))
+        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+    end
+
+    it "returns nil for other hosts and malformed video IDs" do
+      expect(helper.youtube_embed_url("https://example.com/watch?v=dQw4w9WgXcQ")).to be_nil
+      expect(helper.youtube_embed_url("https://youtube.com/watch?v=not/valid")).to be_nil
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe ApplicationHelper do
   describe "#youtube_embed_url" do
-    it "converts supported YouTube URLs to privacy-enhanced embed URLs" do
+    it "converts supported YouTube URLs to embed URLs" do
       expect(helper.youtube_embed_url("https://youtu.be/dQw4w9WgXcQ?t=43"))
-        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        .to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
       expect(helper.youtube_embed_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=example"))
-        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        .to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
       expect(helper.youtube_embed_url("https://youtube.com/shorts/dQw4w9WgXcQ"))
-        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        .to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
       expect(helper.youtube_embed_url("https://youtube.com/live/dQw4w9WgXcQ"))
-        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        .to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
     end
 
     it "returns nil for other hosts and malformed video IDs" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,5 +17,9 @@ RSpec.describe ApplicationHelper do
       expect(helper.youtube_embed_url("https://example.com/watch?v=dQw4w9WgXcQ")).to be_nil
       expect(helper.youtube_embed_url("https://youtube.com/watch?v=not/valid")).to be_nil
     end
+
+    it "returns nil when the query string is malformed" do
+      expect(helper.youtube_embed_url("https://youtube.com/watch?v=dQw4w9WgXcQ&x=%")).to be_nil
+    end
   end
 end

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe "PlaySessions" do
       expect(page).to have_css(
         'iframe[title="録画"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
+      expect(page).to have_no_css("details iframe")
       expect(page).to have_no_link(href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
       expect(page).to have_no_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
     end

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "PlaySessions" do
       expect(page).to have_css(
         'iframe[title="録画"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
-      expect(page).to have_no_css("details iframe")
+      expect(page).to have_no_css('[data-controller="video-disclosure"] iframe')
       expect(page).to have_no_link(href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
       expect(page).to have_no_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
     end

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe "PlaySessions" do
       expect(response.body).to include("https://charasheet.example/1234", "https://youtu.be/abc")
     end
 
+    it "embeds a YouTube recording" do
+      session.update!(recording_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css(
+        'iframe[title="録画"][src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"]'
+      )
+    end
+
     it "shows the start time without the placeholder date a time column carries" do
       session.update!(started_at: "20:00")
       sign_in_as create(:person, groups: [ group ])

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe "PlaySessions" do
       expect(page).to have_css(
         'iframe[title="録画"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
+      expect(page).to have_no_link(href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      expect(page).to have_no_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
     end
 
     it "shows the start time without the placeholder date a time column carries" do

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "PlaySessions" do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(
-        'iframe[title="録画"][src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"]'
+        'iframe[title="録画"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
     end
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -49,12 +49,14 @@ RSpec.describe "Scenarios" do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(
-        'iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
+        'details:not([open]) > ul iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]',
+        visible: :all
       )
-      expect(page).to have_no_link("YouTube配信", href: "https://youtu.be/dQw4w9WgXcQ")
-      expect(page).to have_no_text("https://youtu.be/dQw4w9WgXcQ")
-      expect(page).to have_link("別サイトの配信", href: "https://example.com/stream")
-      expect(page).to have_text("https://example.com/stream")
+      expect(page).to have_css("details > summary", text: "おすすめ配信を開く")
+      expect(page).to have_no_link("YouTube配信", href: "https://youtu.be/dQw4w9WgXcQ", visible: :all)
+      expect(response.body).not_to include("https://youtu.be/dQw4w9WgXcQ")
+      expect(page).to have_link("別サイトの配信", href: "https://example.com/stream", visible: :all)
+      expect(response.body).to include("https://example.com/stream")
     end
 
     it "leaves a YouTube URL with a malformed query string clickable" do
@@ -65,7 +67,7 @@ RSpec.describe "Scenarios" do
 
       page = Capybara.string(response.body)
       expect(response).to have_http_status(:ok)
-      expect(page).to have_link("配信", href: url)
+      expect(page).to have_link("配信", href: url, visible: :all)
       expect(page).to have_no_css("iframe")
     end
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe "Scenarios" do
       expect(page).to have_css(
         'iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
+      expect(page).to have_no_link("YouTube配信", href: "https://youtu.be/dQw4w9WgXcQ")
+      expect(page).to have_no_text("https://youtu.be/dQw4w9WgXcQ")
       expect(page).to have_link("別サイトの配信", href: "https://example.com/stream")
+      expect(page).to have_text("https://example.com/stream")
     end
 
     it "leaves a YouTube URL with a malformed query string clickable" do

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Scenarios" do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(
-        'iframe[title="YouTube配信"][src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"]'
+        'iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
       )
       expect(page).to have_link("別サイトの配信", href: "https://example.com/stream")
     end

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe "Scenarios" do
       expect(page).to have_link("別サイトの配信", href: "https://example.com/stream")
     end
 
+    it "leaves a YouTube URL with a malformed query string clickable" do
+      url = "https://youtube.com/watch?v=dQw4w9WgXcQ&x=%"
+      scenario.stream_links.create!(label: "配信", url:)
+
+      get scenario_path(scenario)
+
+      page = Capybara.string(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_link("配信", href: url)
+      expect(page).to have_no_css("iframe")
+    end
+
     it "keeps the preparation note out of the response entirely" do
       get scenario_path(scenario)
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe "Scenarios" do
       expect(page).to have_button("おすすめ配信を開く")
       expect(page).to have_button("おすすめ配信を閉じる", visible: :all)
       expect(page).to have_css('[data-video-disclosure-target="content"].bg-surface', visible: :all)
+      expect(page).to have_css('[data-controller="video-disclosure"]' \
+        '[data-action*="turbo:before-cache@document->video-disclosure#reset"]')
+      expect(page).to have_css('[data-video-disclosure-target="closeButton"]', visible: :all)
       expect(page).to have_no_link("YouTube配信", href: "https://youtu.be/dQw4w9WgXcQ", visible: :all)
       expect(response.body).not_to include("https://youtu.be/dQw4w9WgXcQ")
       expect(page).to have_link("別サイトの配信", href: "https://example.com/stream", visible: :all)

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe "Scenarios" do
       expect(response.body).to include("https://booth.pm/ja/items/1", "https://youtu.be/abc")
     end
 
+    it "embeds YouTube stream links and leaves other stream links clickable" do
+      scenario.stream_links.create!(label: "YouTube配信", url: "https://youtu.be/dQw4w9WgXcQ")
+      scenario.stream_links.create!(label: "別サイトの配信", url: "https://example.com/stream")
+
+      get scenario_path(scenario)
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css(
+        'iframe[title="YouTube配信"][src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"]'
+      )
+      expect(page).to have_link("別サイトの配信", href: "https://example.com/stream")
+    end
+
     it "keeps the preparation note out of the response entirely" do
       get scenario_path(scenario)
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -48,11 +48,12 @@ RSpec.describe "Scenarios" do
       get scenario_path(scenario)
 
       page = Capybara.string(response.body)
-      expect(page).to have_css(
-        'details:not([open]) > ul iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]',
-        visible: :all
-      )
-      expect(page).to have_css("details > summary", text: "おすすめ配信を開く")
+      hidden_embed = '[data-controller="video-disclosure"] [data-video-disclosure-target="content"][hidden] ' \
+        'iframe[title="YouTube配信"][src="https://www.youtube.com/embed/dQw4w9WgXcQ"]'
+      expect(page).to have_css(hidden_embed, visible: :all)
+      expect(page).to have_button("おすすめ配信を開く")
+      expect(page).to have_button("おすすめ配信を閉じる", visible: :all)
+      expect(page).to have_css('[data-video-disclosure-target="content"].bg-surface', visible: :all)
       expect(page).to have_no_link("YouTube配信", href: "https://youtu.be/dQw4w9WgXcQ", visible: :all)
       expect(response.body).not_to include("https://youtu.be/dQw4w9WgXcQ")
       expect(page).to have_link("別サイトの配信", href: "https://example.com/stream", visible: :all)


### PR DESCRIPTION
## What

- Embed supported YouTube stream and recording URLs on scenario and play session pages
- Keep the original link available and leave non-YouTube URLs unchanged
- Allow standard YouTube embeds in the content security policy

## Why

Make linked YouTube streams and recordings playable without leaving the catalog.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #32