### PR TITLE
Make player preparation information collapsible

### DIFF
--- a/app/controllers/spoiler_reveals_controller.rb
+++ b/app/controllers/spoiler_reveals_controller.rb
@@ -1,13 +1,30 @@
 class SpoilerRevealsController < ApplicationController
+  before_action :set_scenario
+
   # 押した記録は Person に紐づける。端末を変えても開いたままになる。
   def create
-    @scenario = Scenario.find(params[:scenario_id])
     authorize @scenario, :reveal_preparation_note?
     current_person.spoiler_reveals.find_or_create_by!(scenario: @scenario)
 
-    respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.replace("preparation_note_#{@scenario.id}", partial: "scenarios/preparation_note", locals: { scenario: @scenario }) }
-      format.html { redirect_to scenario_path(@scenario) }
-    end
+    render_preparation_note
   end
+
+  def destroy
+    authorize @scenario, :reveal_preparation_note?
+    current_person.spoiler_reveals.where(scenario: @scenario).destroy_all
+
+    render_preparation_note
+  end
+
+  private
+    def set_scenario
+      @scenario = Scenario.find(params[:scenario_id])
+    end
+
+    def render_preparation_note
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("preparation_note_#{@scenario.id}", partial: "scenarios/preparation_note", locals: { scenario: @scenario }) }
+        format.html { redirect_to scenario_path(@scenario) }
+      end
+    end
 end

--- a/app/views/scenarios/_preparation_note.html.erb
+++ b/app/views/scenarios/_preparation_note.html.erb
@@ -1,16 +1,19 @@
-<%# Phase 1 が空で置いた場所。show.html.erb には触らない。 %>
 <% if scenario.preparation_note.present? %>
   <section class="mt-10" id="preparation_note_<%= scenario.id %>">
-    <h2 class="font-display text-xl">シナリオ準備情報</h2>
+    <h2 class="font-display text-xl">プレーヤー向け事前情報</h2>
 
     <% if policy(scenario).show_preparation_note? %>
       <p class="mt-3 whitespace-pre-line leading-relaxed"><%= scenario.preparation_note %></p>
+      <%= button_to "プレーヤー向け事前情報を閉じる", scenario_spoiler_reveal_path(scenario), method: :delete,
+            class: "mt-3 cursor-pointer border border-rule px-4 py-3 text-sm text-muted" %>
     <% elsif policy(scenario).reveal_preparation_note? %>
-      <p class="mt-3 text-sm text-muted">ネタバレを含みます。読む準備ができたら開いてください。</p>
-      <%= button_to "ネタバレを開く", scenario_spoiler_reveal_path(scenario),
+      <p class="mt-3 text-sm text-muted">
+        本編のネタバレはありませんが、購入しないとわからない情報等を含みます。GMから許可があった場合のみ開いてください。
+      </p>
+      <%= button_to "プレーヤー向け事前情報を見る", scenario_spoiler_reveal_path(scenario),
             class: "mt-3 cursor-pointer redacted px-4 py-3 text-sm" %>
     <% else %>
-      <p class="mt-3 redacted px-4 py-3 text-sm">ネタバレを含みます。ログインすると開けるようになります。</p>
+      <p class="mt-3 redacted px-4 py-3 text-sm">GMが許可したログイン済メンバーのみ表示可能です。</p>
     <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   resources :scenarios, only: [ :index, :show ] do
     resource :favorite, only: [ :create, :destroy ]
-    resource :spoiler_reveal, only: [ :create ]
+    resource :spoiler_reveal, only: [ :create, :destroy ]
   end
   resources :play_sessions, only: [ :index, :show ]
   resources :people, only: [ :index, :show, :edit, :update ]

--- a/spec/requests/spoiler_reveals_spec.rb
+++ b/spec/requests/spoiler_reveals_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "SpoilerReveals" do
   it "keeps the note out of the response for a visitor who has not signed in" do
     get scenario_path(scenario)
 
+    expect(response.body).to include("プレーヤー向け事前情報")
+    expect(response.body).to include("GMが許可したログイン済メンバーのみ表示可能です。")
     expect(response.body).not_to include("ネタバレを含む準備情報")
   end
 
@@ -14,7 +16,10 @@ RSpec.describe "SpoilerReveals" do
 
     get scenario_path(scenario)
 
-    expect(response.body).to include("シナリオ準備情報")
+    expect(response.body).to include("プレーヤー向け事前情報")
+    expect(response.body).to include("本編のネタバレはありませんが、購入しないとわからない情報等を含みます。GMから許可があった場合のみ開いてください。")
+    expect(response.body).to include("プレーヤー向け事前情報を見る")
+    expect(response.body).not_to include("ネタバレを開く")
     expect(response.body).not_to include("ネタバレを含む準備情報")
   end
 
@@ -34,7 +39,20 @@ RSpec.describe "SpoilerReveals" do
     post scenario_spoiler_reveal_path(scenario)
     get scenario_path(scenario)
 
-    expect(response.body).to include("ネタバレを含む準備情報")
+    expect(response.body).to include("ネタバレを含む準備情報", "プレーヤー向け事前情報を閉じる")
+  end
+
+  it "hides the note again once the member closes it" do
+    person = create(:person)
+    sign_in_as person
+    post scenario_spoiler_reveal_path(scenario)
+
+    delete scenario_spoiler_reveal_path(scenario)
+    get scenario_path(scenario)
+
+    expect(response.body).to include("プレーヤー向け事前情報を見る")
+    expect(response.body).not_to include("ネタバレを含む準備情報")
+    expect(person.spoiler_reveals.where(scenario: scenario)).not_to exist
   end
 
   it "remembers the press across sessions, so another device sees it open" do
@@ -68,5 +86,16 @@ RSpec.describe "SpoilerReveals" do
     post scenario_spoiler_reveal_path(scenario), headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+  end
+
+  it "replaces only the note area when closing" do
+    person = create(:person)
+    sign_in_as person
+    post scenario_spoiler_reveal_path(scenario)
+
+    delete scenario_spoiler_reveal_path(scenario), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    expect(response.body).to include("プレーヤー向け事前情報を見る")
   end
 end

--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe "A member's own pages" do
     visit scenario_path(scenario)
     expect(page).to have_no_content("ネタバレを含む準備情報")
 
-    click_button "ネタバレを開く"
+    click_button "プレーヤー向け事前情報を見る"
     expect(page).to have_content("ネタバレを含む準備情報")
+
+    click_button "プレーヤー向け事前情報を閉じる"
+    expect(page).to have_no_content("ネタバレを含む準備情報")
 
     visit scenario_path(scenario)
     click_button "お気に入りに入れる"


### PR DESCRIPTION
## What

- Rename the preparation section and update its guidance
- Let linked members close previously revealed information
- Update the visitor-only message

## Why

Make the player preparation information clearer and reversible as requested in issue #55.

## Verification

- [x] bin/rspec
- [x] prek run --all-files
- [x] bin/ci

## Related

Closes #55