### PR TITLE
Import BOOTH product images as jacket fallbacks

### DIFF
--- a/app/controllers/manage/scenarios_controller.rb
+++ b/app/controllers/manage/scenarios_controller.rb
@@ -1,6 +1,6 @@
 module Manage
   class ScenariosController < BaseController
-    before_action :set_scenario, only: %i[edit update destroy move]
+    before_action :set_scenario, only: %i[edit update destroy move refresh_booth_image]
 
     def index
       authorize Scenario, :manage?
@@ -17,6 +17,12 @@ module Manage
       authorize @scenario, :reorder?
       @scenario.move(params[:direction].to_s)
       redirect_to manage_scenarios_path
+    end
+
+    def refresh_booth_image
+      authorize @scenario, :update?
+      result = BoothImageImporter.new(@scenario).call(force: true)
+      redirect_to edit_manage_scenario_path(@scenario), (result.success? ? { notice: result.message } : { alert: result.message })
     end
 
     def new

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,12 +1,14 @@
 class ScenariosController < ApplicationController
   def index
     @listing = ScenarioListing.new(policy_scope(Scenario), params)
-    @scenarios = @listing.scenarios.includes(:game_systems, :authors, :purchase_links, jacket_attachment: :blob)
+    @scenarios = @listing.scenarios.includes(:game_systems, :authors, :purchase_links,
+      jacket_attachment: :blob, booth_image_attachment: :blob)
     authorize Scenario
   end
 
   def show
-    @scenario = policy_scope(Scenario).includes(:game_systems, :authors, :purchase_links, :stream_links).find(params[:id])
+    @scenario = policy_scope(Scenario).includes(:game_systems, :authors, :purchase_links, :stream_links,
+      jacket_attachment: :blob, booth_image_attachment: :blob).find(params[:id])
     authorize @scenario
   end
 end

--- a/app/jobs/refresh_booth_image_job.rb
+++ b/app/jobs/refresh_booth_image_job.rb
@@ -1,0 +1,7 @@
+class RefreshBoothImageJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(scenario_id)
+    BoothImageImporter.new(Scenario.find(scenario_id)).call(force: false)
+  end
+end

--- a/app/models/purchase_link.rb
+++ b/app/models/purchase_link.rb
@@ -1,6 +1,20 @@
 class PurchaseLink < ApplicationRecord
   belongs_to :scenario
 
+  after_commit :refresh_booth_image
+
   validates :label, presence: true
   validates :url, http_url: true
+
+  def booth?
+    host = URI.parse(url.to_s).host&.downcase
+    host == "booth.pm" || host&.end_with?(".booth.pm")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  private
+    def refresh_booth_image
+      RefreshBoothImageJob.perform_later(scenario_id)
+    end
 end

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -15,6 +15,11 @@ class Scenario < ApplicationRecord
     attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
   end
 
+  has_one_attached :booth_image do |attachable|
+    attachable.variant :thumb, resize_to_fill: [ 480, 640 ], format: :webp, saver: { quality: 80 }
+    attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
+  end
+
   has_many :scenario_game_systems, dependent: :destroy
   has_many :game_systems, through: :scenario_game_systems
   has_many :scenario_authors, dependent: :destroy
@@ -53,8 +58,11 @@ class Scenario < ApplicationRecord
     self.class.rearrange(ids)
   end
 
+  def booth_purchase_url = purchase_links.find(&:booth?)&.url
+
   validates :title, presence: true
   validates :jacket, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
+  validates :booth_image, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
   # TODO: 並び順は position に移った（issue #41）。切り戻す必要がなくなったら列ごと落とす。
   validates :recommendation, inclusion: { in: 1..5 }, allow_nil: true
   # 人数での絞り込みが下限を軸にするため、下限だけは必ず要る（issue #28）。

--- a/app/services/booth_http_client.rb
+++ b/app/services/booth_http_client.rb
@@ -1,0 +1,62 @@
+require "net/http"
+
+class BoothHttpClient
+  Error = Class.new(StandardError)
+  Response = Data.define(:body, :content_type)
+
+  LIMITS = { page: 1.megabyte, image: 10.megabytes }.freeze
+  REDIRECT_LIMIT = 3
+
+  def get(url, kind:)
+    fetch(URI.parse(url), kind:, redirects_left: REDIRECT_LIMIT)
+  rescue URI::InvalidURIError => error
+    raise Error, error.message
+  end
+
+  private
+    def fetch(uri, kind:, redirects_left:)
+      validate_uri!(uri, kind:)
+      response = request(uri)
+
+      if response.is_a?(Net::HTTPRedirection)
+        raise Error, "too many redirects" if redirects_left.zero?
+
+        return fetch(URI.join(uri, response.fetch("location")), kind:, redirects_left: redirects_left - 1)
+      end
+
+      raise Error, "HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      body = response.body.to_s
+      content_type = response["content-type"].to_s.split(";", 2).first
+      validate_response!(body, content_type, kind:)
+      Response.new(body:, content_type:)
+    end
+
+    def request(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 5
+      http.read_timeout = 10
+      request = Net::HTTP::Get.new(uri, "User-Agent" => "trpg-scenario-session-catalog")
+      http.request(request)
+    rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError => error
+      raise Error, error.message
+    end
+
+    def validate_uri!(uri, kind:)
+      host = uri.host&.downcase
+      allowed = if kind == :page
+        host == "booth.pm" || host&.end_with?(".booth.pm")
+      else
+        host == "booth.pximg.net"
+      end
+      raise Error, "unsupported URL" unless uri.is_a?(URI::HTTPS) && uri.port == 443 && uri.userinfo.nil? && allowed
+    end
+
+    def validate_response!(body, content_type, kind:)
+      expected = kind == :page ? "text/html" : %r{\Aimage/}
+      valid_type = expected.is_a?(Regexp) ? content_type.match?(expected) : content_type == expected
+      raise Error, "unexpected content type" unless valid_type
+      raise Error, "response is too large" if body.bytesize > LIMITS.fetch(kind)
+    end
+end

--- a/app/services/booth_http_client.rb
+++ b/app/services/booth_http_client.rb
@@ -16,7 +16,7 @@ class BoothHttpClient
   private
     def fetch(uri, kind:, redirects_left:)
       validate_uri!(uri, kind:)
-      response = request(uri)
+      response = request(uri, limit: LIMITS.fetch(kind))
 
       if response.is_a?(Net::HTTPRedirection)
         raise Error, "too many redirects" if redirects_left.zero?
@@ -32,13 +32,24 @@ class BoothHttpClient
       Response.new(body:, content_type:)
     end
 
-    def request(uri)
+    def request(uri, limit:)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.open_timeout = 5
       http.read_timeout = 10
       request = Net::HTTP::Get.new(uri, "User-Agent" => "trpg-scenario-session-catalog")
-      http.request(request)
+      http.request(request) do |response|
+        content_length = response["content-length"]&.to_i
+        raise Error, "response is too large" if content_length&.>(limit)
+
+        body = +"".b
+        response.read_body do |chunk|
+          raise Error, "response is too large" if body.bytesize + chunk.bytesize > limit
+
+          body << chunk
+        end
+        response.body = body
+      end
     rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError => error
       raise Error, error.message
     end
@@ -57,6 +68,5 @@ class BoothHttpClient
       expected = kind == :page ? "text/html" : %r{\Aimage/}
       valid_type = expected.is_a?(Regexp) ? content_type.match?(expected) : content_type == expected
       raise Error, "unexpected content type" unless valid_type
-      raise Error, "response is too large" if body.bytesize > LIMITS.fetch(kind)
     end
 end

--- a/app/services/booth_image_importer.rb
+++ b/app/services/booth_image_importer.rb
@@ -1,0 +1,63 @@
+class BoothImageImporter
+  Result = Data.define(:success, :message) do
+    def success? = success
+  end
+
+  def initialize(scenario, client: BoothHttpClient.new)
+    @scenario = scenario
+    @client = client
+  end
+
+  def call(force:)
+    source_url = scenario.booth_purchase_url
+    return without_source(force:) if source_url.blank?
+    return Result.new(success: true, message: "BOOTH画像は最新です") if current_source?(source_url) && !force
+
+    page = client.get(source_url, kind: :page)
+    image_url = extract_image_url(page.body, source_url)
+    image = client.get(image_url, kind: :image)
+    validate_image!(image, image_url)
+    attach(image, image_url, source_url)
+
+    Result.new(success: true, message: "BOOTH画像を更新しました")
+  rescue BoothHttpClient::Error, Nokogiri::XML::SyntaxError => error
+    Rails.logger.warn("BOOTH image import failed for scenario #{scenario.id}: #{error.message}")
+    Result.new(success: false, message: "BOOTH画像を取得できませんでした")
+  end
+
+  private
+    attr_reader :scenario, :client
+
+    def without_source(force:)
+      if force
+        Result.new(success: false, message: "BOOTHの入手先URLがありません")
+      else
+        scenario.booth_image.purge if scenario.booth_image.attached?
+        Result.new(success: true, message: "BOOTH画像を削除しました")
+      end
+    end
+
+    def current_source?(source_url)
+      scenario.booth_image.attached? && scenario.booth_image.blob.metadata["source_url"] == source_url
+    end
+
+    def extract_image_url(html, source_url)
+      content = Nokogiri::HTML.parse(html).at_css('meta[property="og:image"]')&.[]("content")
+      raise BoothHttpClient::Error, "og:image is missing" if content.blank?
+
+      URI.join(source_url, content).to_s
+    end
+
+    def attach(image, image_url, source_url)
+      filename = File.basename(URI.parse(image_url).path).presence || "booth-image"
+      scenario.booth_image.attach(
+        io: StringIO.new(image.body), filename:, content_type: image.content_type,
+        metadata: { source_url: }
+      )
+    end
+
+    def validate_image!(image, image_url)
+      detected = Marcel::MimeType.for(StringIO.new(image.body))
+      raise BoothHttpClient::Error, "invalid image" unless detected.in?(%w[image/png image/jpeg image/gif image/webp])
+    end
+end

--- a/app/services/booth_image_importer.rb
+++ b/app/services/booth_image_importer.rb
@@ -20,7 +20,7 @@ class BoothImageImporter
     attach(image, image_url, source_url)
 
     Result.new(success: true, message: "BOOTH画像を更新しました")
-  rescue BoothHttpClient::Error, Nokogiri::XML::SyntaxError => error
+  rescue BoothHttpClient::Error, Nokogiri::XML::SyntaxError, StandardError => error
     Rails.logger.warn("BOOTH image import failed for scenario #{scenario.id}: #{error.message}")
     Result.new(success: false, message: "BOOTH画像を取得できませんでした")
   end
@@ -50,10 +50,14 @@ class BoothImageImporter
 
     def attach(image, image_url, source_url)
       filename = File.basename(URI.parse(image_url).path).presence || "booth-image"
-      scenario.booth_image.attach(
+      blob = ActiveStorage::Blob.create_and_upload!(
         io: StringIO.new(image.body), filename:, content_type: image.content_type,
         metadata: { source_url: }
       )
+      scenario.booth_image.attach(blob)
+    rescue StandardError
+      blob&.purge
+      raise
     end
 
     def validate_image!(image, image_url)

--- a/app/views/manage/scenarios/edit.html.erb
+++ b/app/views/manage/scenarios/edit.html.erb
@@ -1,3 +1,10 @@
 <% content_for :title, "#{@scenario.title} の編集" %>
 <h1 class="font-display text-2xl"><%= @scenario.title %> の編集</h1>
+<div class="mt-4 flex items-center gap-4">
+  <%= button_to "BOOTH画像を更新", refresh_booth_image_manage_scenario_path(@scenario),
+        class: "cursor-pointer border border-rule px-4 py-2 text-sm text-seal" %>
+  <% if @scenario.booth_image.attached? %>
+    <span class="text-xs text-muted">取得済み</span>
+  <% end %>
+</div>
 <%= render "form", scenario: @scenario %>

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -6,6 +6,9 @@
           <% if scenario.jacket.attached? %>
             <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",
                   class: "h-full w-full object-cover" %>
+          <% elsif scenario.booth_image.attached? %>
+            <%= image_tag scenario.booth_image.variant(:thumb), alt: "", loading: "lazy",
+                  class: "h-full w-full object-cover" %>
           <% else %>
             <span class="flex h-full items-center justify-center font-display text-sm text-muted">
               画像なし

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -13,6 +13,9 @@
       <% if @scenario.jacket.attached? %>
         <%= image_tag @scenario.jacket.variant(:cover), alt: "#{@scenario.title} のジャケット画像",
               class: "h-full w-full object-cover" %>
+      <% elsif @scenario.booth_image.attached? %>
+        <%= image_tag @scenario.booth_image.variant(:cover), alt: "#{@scenario.title} のBOOTH商品画像",
+              class: "h-full w-full object-cover" %>
       <% else %>
         <span class="flex h-full items-center justify-center font-display text-sm text-muted">画像なし</span>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :scenarios do
       patch :reorder, on: :collection
       patch :move, on: :member
+      post :refresh_booth_image, on: :member
     end
     resources :game_systems, except: [ :show, :new ]
     resources :authors, except: [ :show, :new ]

--- a/spec/jobs/refresh_booth_image_job_spec.rb
+++ b/spec/jobs/refresh_booth_image_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe RefreshBoothImageJob do
+  it "runs an automatic refresh for the scenario" do
+    scenario = create(:scenario)
+    importer = instance_double(BoothImageImporter)
+    allow(BoothImageImporter).to receive(:new).with(scenario).and_return(importer)
+    allow(importer).to receive(:call)
+
+    described_class.perform_now(scenario.id)
+
+    expect(importer).to have_received(:call).with(force: false)
+  end
+end

--- a/spec/models/attachment_validation_spec.rb
+++ b/spec/models/attachment_validation_spec.rb
@@ -42,5 +42,12 @@ RSpec.describe "Attachment validation" do
 
       expect(scenario).not_to be_valid
     end
+
+    it "rejects an imported BOOTH file that is not an image" do
+      scenario = create(:scenario)
+      scenario.booth_image.attach(upload("not an image", "text/plain", "evil.txt"))
+
+      expect(scenario).not_to be_valid
+    end
   end
 end

--- a/spec/models/purchase_link_spec.rb
+++ b/spec/models/purchase_link_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe PurchaseLink do
   it "rejects something that is not an http URL" do
     expect(build(:purchase_link, url: "javascript:alert(1)")).not_to be_valid
   end
+
+  it "recognizes BOOTH and its shop subdomains without accepting lookalikes" do
+    expect(build(:purchase_link, url: "https://booth.pm/ja/items/1")).to be_booth
+    expect(build(:purchase_link, url: "https://example.booth.pm/items/1")).to be_booth
+    expect(build(:purchase_link, url: "https://evilbooth.pm/items/1")).not_to be_booth
+  end
+
+  it "queues a BOOTH image refresh after the link is saved" do
+    scenario = create(:scenario)
+
+    expect { create(:purchase_link, scenario:) }
+      .to have_enqueued_job(RefreshBoothImageJob).with(scenario.id)
+  end
 end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Scenario do
+  describe "BOOTH image source" do
+    it "uses the first BOOTH purchase URL" do
+      scenario = create(:scenario)
+      scenario.purchase_links.create!(label: "別サイト", url: "https://example.com/item", position: 1)
+      scenario.purchase_links.create!(label: "後のBOOTH", url: "https://booth.pm/ja/items/2", position: 3)
+      scenario.purchase_links.create!(label: "先のBOOTH", url: "https://shop.booth.pm/items/1", position: 2)
+
+      expect(scenario.booth_purchase_url).to eq("https://shop.booth.pm/items/1")
+    end
+  end
+
   it "requires a title" do
     expect(described_class.new(title: "")).not_to be_valid
   end

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe "Manage::Scenarios" do
       expect(response).to have_http_status(:not_found)
       expect(first.reload.position).to be < second.reload.position
     end
+
+    it "does not refresh a BOOTH image for anyone outside the editors" do
+      scenario = create(:scenario)
+
+      post refresh_booth_image_manage_scenario_path(scenario)
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "as a GM" do
@@ -220,6 +228,37 @@ RSpec.describe "Manage::Scenarios" do
       patch manage_scenario_path(scenario), params: { scenario: { title: "新題" } }
 
       expect(scenario.reload.title).to eq("新題")
+    end
+
+    it "offers a manual BOOTH image refresh on the edit screen" do
+      scenario = create(:scenario)
+
+      get edit_manage_scenario_path(scenario)
+
+      expect(response.body).to include("BOOTH画像を更新")
+    end
+
+    it "refreshes the BOOTH image and reports success" do
+      scenario = create(:scenario)
+      result = BoothImageImporter::Result.new(success: true, message: "BOOTH画像を更新しました")
+      importer = instance_double(BoothImageImporter, call: result)
+      allow(BoothImageImporter).to receive(:new).with(scenario).and_return(importer)
+
+      post refresh_booth_image_manage_scenario_path(scenario)
+
+      expect(importer).to have_received(:call).with(force: true)
+      expect(response).to redirect_to(edit_manage_scenario_path(scenario))
+      expect(flash[:notice]).to eq("BOOTH画像を更新しました")
+    end
+
+    it "reports a manual refresh failure without treating it as success" do
+      scenario = create(:scenario)
+      result = BoothImageImporter::Result.new(success: false, message: "BOOTH画像を取得できませんでした")
+      allow(BoothImageImporter).to receive(:new).and_return(instance_double(BoothImageImporter, call: result))
+
+      post refresh_booth_image_manage_scenario_path(scenario)
+
+      expect(flash[:alert]).to eq("BOOTH画像を取得できませんでした")
     end
   end
 end

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -76,6 +76,30 @@ RSpec.describe "The scenario list" do
       expect(response.body).to include("aspect-3/4")
     end
 
+    it "uses the imported BOOTH image when no jacket is attached" do
+      scenario.booth_image.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "booth-fallback.png", content_type: "image/png"
+      )
+
+      get root_path(view: "gallery")
+
+      expect(response.body).to include("booth-fallback.png")
+    end
+
+    it "prefers the uploaded jacket to the imported BOOTH image" do
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "uploaded-jacket.png", content_type: "image/png"
+      )
+      scenario.booth_image.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "booth-fallback.png", content_type: "image/png"
+      )
+
+      get root_path(view: "gallery")
+
+      expect(response.body).to include("uploaded-jacket.png")
+      expect(response.body).not_to include("booth-fallback.png")
+    end
+
     it "offers a link back to the table" do
       get root_path(view: "gallery")
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe "Scenarios" do
       expect(response.body).to include("この情報はGMが独自判断で記載しており、シナリオ公式の案内と異なる場合があります")
     end
 
+    it "uses the imported BOOTH image when no jacket is attached" do
+      scenario.booth_image.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "booth-detail.png", content_type: "image/png"
+      )
+
+      get scenario_path(scenario)
+
+      expect(response.body).to include("booth-detail.png")
+    end
+
     it "keeps the GM supplementary information out of the response for a visitor" do
       get scenario_path(scenario)
 

--- a/spec/services/booth_http_client_spec.rb
+++ b/spec/services/booth_http_client_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe BoothHttpClient do
+  subject(:client) { described_class.new }
+
+  def response(type, body:, content_type:, location: nil)
+    code, message = type == Net::HTTPFound ? [ "302", "Found" ] : [ "200", "OK" ]
+    result = type.new("1.1", code, message)
+    result.body = body
+    result.instance_variable_set(:@read, true)
+    result["content-type"] = content_type
+    result["location"] = location if location
+    result
+  end
+
+  it "refuses a page outside BOOTH before making a request" do
+    allow(client).to receive(:request)
+
+    expect { client.get("https://example.com/items/1", kind: :page) }
+      .to raise_error(described_class::Error, "unsupported URL")
+    expect(client).not_to have_received(:request)
+  end
+
+  it "refuses an og:image outside BOOTH's image host" do
+    allow(client).to receive(:request)
+
+    expect { client.get("https://example.com/image.png", kind: :image) }
+      .to raise_error(described_class::Error, "unsupported URL")
+  end
+
+  it "follows redirects only through allowed BOOTH URLs" do
+    redirect = response(Net::HTTPFound, body: "", content_type: "text/html", location: "https://shop.booth.pm/items/1")
+    success = response(Net::HTTPOK, body: "<html></html>", content_type: "text/html")
+    allow(client).to receive(:request).and_return(redirect, success)
+
+    result = client.get("https://booth.pm/items/1", kind: :page)
+
+    expect(result.body).to eq("<html></html>")
+  end
+
+  it "rejects a non-image response from the image host" do
+    allow(client).to receive(:request).and_return(
+      response(Net::HTTPOK, body: "not an image", content_type: "text/html")
+    )
+
+    expect { client.get("https://booth.pximg.net/image.png", kind: :image) }
+      .to raise_error(described_class::Error, "unexpected content type")
+  end
+end

--- a/spec/services/booth_http_client_spec.rb
+++ b/spec/services/booth_http_client_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe BoothHttpClient do
     expect { client.get("https://booth.pximg.net/image.png", kind: :image) }
       .to raise_error(described_class::Error, "unexpected content type")
   end
+
+  it "stops reading a response as soon as it exceeds the size limit" do
+    oversized = instance_double(Net::HTTPOK, :[] => nil)
+    allow(oversized).to receive(:read_body).and_yield("a" * 1.megabyte).and_yield("b")
+    http = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:request).and_yield(oversized)
+
+    expect { client.get("https://booth.pm/items/1", kind: :page) }
+      .to raise_error(described_class::Error, "response is too large")
+  end
 end

--- a/spec/services/booth_image_importer_spec.rb
+++ b/spec/services/booth_image_importer_spec.rb
@@ -67,6 +67,25 @@ RSpec.describe BoothImageImporter do
     expect(scenario.reload.booth_image.blob).to eq(old_blob)
   end
 
+  it "keeps the existing image when uploading the replacement fails" do
+    scenario.booth_image.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png"
+    )
+    old_blob = scenario.booth_image.blob
+    allow(client).to receive(:get).with(page_url, kind: :page).and_return(
+      BoothHttpClient::Response.new(body: %(<meta property="og:image" content="#{image_url}">), content_type: "text/html")
+    )
+    allow(client).to receive(:get).with(image_url, kind: :image).and_return(
+      BoothHttpClient::Response.new(body: File.binread(Rails.root.join("spec/fixtures/files/dot.png")), content_type: "image/png")
+    )
+    allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_raise(IOError, "storage unavailable")
+
+    result = described_class.new(scenario, client:).call(force: true)
+
+    expect(result).not_to be_success
+    expect(scenario.reload.booth_image.blob).to eq(old_blob)
+  end
+
   it "removes a stale imported image automatically when no BOOTH URL remains" do
     scenario.booth_image.attach(
       io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png"

--- a/spec/services/booth_image_importer_spec.rb
+++ b/spec/services/booth_image_importer_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe BoothImageImporter do
+  let(:scenario) { create(:scenario) }
+  let(:client) { instance_double(BoothHttpClient) }
+  let(:page_url) { "https://booth.pm/ja/items/1" }
+  let(:image_url) { "https://booth.pximg.net/item.jpg" }
+
+  before { scenario.purchase_links.create!(label: "BOOTH", url: page_url) }
+
+  it "imports the og:image and records its source page" do
+    allow(client).to receive(:get).with(page_url, kind: :page).and_return(
+      BoothHttpClient::Response.new(body: %(<meta property="og:image" content="#{image_url}">), content_type: "text/html")
+    )
+    allow(client).to receive(:get).with(image_url, kind: :image).and_return(
+      BoothHttpClient::Response.new(body: File.binread(Rails.root.join("spec/fixtures/files/dot.png")), content_type: "image/png")
+    )
+
+    result = described_class.new(scenario, client:).call(force: false)
+
+    expect(result).to be_success
+    expect(scenario.booth_image).to be_attached
+    expect(scenario.booth_image.blob.metadata["source_url"]).to eq(page_url)
+  end
+
+  it "does not fetch the same source again automatically" do
+    allow(client).to receive(:get)
+    scenario.booth_image.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png",
+      metadata: { source_url: page_url }
+    )
+
+    result = described_class.new(scenario, client:).call(force: false)
+
+    expect(result).to be_success
+    expect(client).not_to have_received(:get)
+  end
+
+  it "keeps the existing image when a forced refresh fails" do
+    scenario.booth_image.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png"
+    )
+    old_blob = scenario.booth_image.blob
+    allow(client).to receive(:get).and_raise(BoothHttpClient::Error, "timeout")
+
+    result = described_class.new(scenario, client:).call(force: true)
+
+    expect(result).not_to be_success
+    expect(scenario.reload.booth_image.blob).to eq(old_blob)
+  end
+
+  it "keeps the existing image when the downloaded body is not really an image" do
+    scenario.booth_image.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png"
+    )
+    old_blob = scenario.booth_image.blob
+    allow(client).to receive(:get).with(page_url, kind: :page).and_return(
+      BoothHttpClient::Response.new(body: %(<meta property="og:image" content="#{image_url}">), content_type: "text/html")
+    )
+    allow(client).to receive(:get).with(image_url, kind: :image).and_return(
+      BoothHttpClient::Response.new(body: "not really a JPEG", content_type: "image/jpeg")
+    )
+
+    result = described_class.new(scenario, client:).call(force: true)
+
+    expect(result).not_to be_success
+    expect(scenario.reload.booth_image.blob).to eq(old_blob)
+  end
+
+  it "removes a stale imported image automatically when no BOOTH URL remains" do
+    scenario.booth_image.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "old.png", content_type: "image/png"
+    )
+    scenario.purchase_links.destroy_all
+
+    result = described_class.new(scenario, client:).call(force: false)
+
+    expect(result).to be_success
+    expect(scenario.booth_image).not_to be_attached
+  end
+end


### PR DESCRIPTION
## What

- Import the first BOOTH purchase link's `og:image` after link changes
- Use the imported image as a fallback on scenario details and the gallery
- Add a manual refresh action that preserves the current image on failure

## Why

Show BOOTH product artwork when no jacket has been uploaded, as requested in issue #42.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`
- [x] Verified the importer against a live BOOTH product page

## Related

Closes #42