### PR TITLE
Add participant-only Cocofolia links

### DIFF
--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -52,7 +52,7 @@ module Manage
       def play_session_params
         params.expect(
           play_session: [
-            :scenario_id, :played_on, :started_at, :status, :recording_url, :note,
+            :scenario_id, :played_on, :started_at, :status, :recording_url, :cocofolia_url, :note,
             { participations_attributes: [ [ :id, :person_id, :role, :character_name, :character_sheet_url, :position, :_destroy ] ] }
           ]
         )

--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -50,12 +50,14 @@ module Manage
       end
 
       def play_session_params
-        params.expect(
+        permitted = params.expect(
           play_session: [
             :scenario_id, :played_on, :started_at, :status, :recording_url, :cocofolia_url, :note,
             { participations_attributes: [ [ :id, :person_id, :role, :character_name, :character_sheet_url, :position, :_destroy ] ] }
           ]
         )
+        permitted.delete(:cocofolia_url) unless policy(PlaySession).update_cocofolia_url?
+        permitted
       end
   end
 end

--- a/app/models/play_session.rb
+++ b/app/models/play_session.rb
@@ -10,6 +10,7 @@ class PlaySession < ApplicationRecord
     reject_if: ->(attrs) { attrs["person_id"].blank? }
 
   validates :recording_url, http_url: true
+  validates :cocofolia_url, http_url: true
   validate :participants_are_distinct
 
   # 日付が無い回を末尾に固定する。データベース既定の NULL の並びに任せない。

--- a/app/policies/play_session_policy.rb
+++ b/app/policies/play_session_policy.rb
@@ -10,6 +10,10 @@ class PlaySessionPolicy < ApplicationPolicy
   def update? = editor?
   def destroy? = editor?
 
+  def show_cocofolia_url?
+    person.present? && record.participations.any? { |participation| participation.person_id == person.id }
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none if person.blank?

--- a/app/policies/play_session_policy.rb
+++ b/app/policies/play_session_policy.rb
@@ -14,6 +14,8 @@ class PlaySessionPolicy < ApplicationPolicy
     person.present? && record.participations.any? { |participation| participation.person_id == person.id }
   end
 
+  def update_cocofolia_url? = !!gm?
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none if person.blank?

--- a/app/views/manage/play_sessions/_form.html.erb
+++ b/app/views/manage/play_sessions/_form.html.erb
@@ -31,11 +31,13 @@
         <%= form.label :recording_url, "録画リンク", class: "block text-xs text-muted" %>
         <%= form.url_field :recording_url, placeholder: "https://", class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
       </div>
-      <div>
-        <%= form.label :cocofolia_url, "ココフォリアリンク", class: "block text-xs text-muted" %>
-        <%= form.url_field :cocofolia_url, placeholder: "https://ccfolia.com/rooms/",
-              class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-      </div>
+      <% if policy(play_session).update_cocofolia_url? %>
+        <div>
+          <%= form.label :cocofolia_url, "ココフォリアリンク", class: "block text-xs text-muted" %>
+          <%= form.url_field :cocofolia_url, placeholder: "https://ccfolia.com/rooms/",
+                class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+        </div>
+      <% end %>
       <div class="sm:col-span-2">
         <%= form.label :note, "メモ", class: "block text-xs text-muted" %>
         <%= form.text_area :note, rows: 3, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>

--- a/app/views/manage/play_sessions/_form.html.erb
+++ b/app/views/manage/play_sessions/_form.html.erb
@@ -31,6 +31,11 @@
         <%= form.label :recording_url, "録画リンク", class: "block text-xs text-muted" %>
         <%= form.url_field :recording_url, placeholder: "https://", class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
       </div>
+      <div>
+        <%= form.label :cocofolia_url, "ココフォリアリンク", class: "block text-xs text-muted" %>
+        <%= form.url_field :cocofolia_url, placeholder: "https://ccfolia.com/rooms/",
+              class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      </div>
       <div class="sm:col-span-2">
         <%= form.label :note, "メモ", class: "block text-xs text-muted" %>
         <%= form.text_area :note, rows: 3, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -27,6 +27,13 @@
               link_text: @play_session.recording_url, rel: "noopener", show_url: false %>
       </dd>
     <% end %>
+    <% if @play_session.cocofolia_url.present? && policy(@play_session).show_cocofolia_url? %>
+      <dt class="text-muted">ココフォリア</dt>
+      <dd class="font-sans">
+        <%= link_to @play_session.cocofolia_url, @play_session.cocofolia_url,
+              rel: "noopener", class: "text-seal" %>
+      </dd>
+    <% end %>
   </dl>
 
   <section class="mt-10">

--- a/db/migrate/20260811130723_add_cocofolia_url_to_play_sessions.rb
+++ b/db/migrate/20260811130723_add_cocofolia_url_to_play_sessions.rb
@@ -1,0 +1,5 @@
+class AddCocofoliaUrlToPlaySessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :play_sessions, :cocofolia_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_130723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -124,6 +124,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_020000) do
   end
 
   create_table "play_sessions", force: :cascade do |t|
+    t.string "cocofolia_url"
     t.datetime "created_at", null: false
     t.text "note"
     t.date "played_on"

--- a/spec/models/play_session_spec.rb
+++ b/spec/models/play_session_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe PlaySession do
     expect(build(:play_session, recording_url: "javascript:alert(1)")).not_to be_valid
   end
 
+  it "rejects a Cocofolia URL that is not an http URL" do
+    expect(build(:play_session, cocofolia_url: "javascript:alert(1)")).not_to be_valid
+  end
+
   describe "ordering" do
     it "puts a session with no start time after one with a time on the same day" do
       timed = create(:play_session, played_on: Date.new(2026, 5, 1), started_at: "20:00")

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe "Authorization matrix" do
     end
   end
 
+  describe PlaySessionPolicy do
+    it "shows the Cocofolia URL to participants, regardless of editor roles" do
+      session = create(:play_session)
+      session.participations.create!(person: no_role, role: :player)
+
+      expect(allows?(anonymous, described_class, session, :show_cocofolia_url?)).to be_falsey
+      expect(allows?(unlinked, described_class, session, :show_cocofolia_url?)).to be_falsey
+      expect(allows?(no_role, described_class, session, :show_cocofolia_url?)).to be(true)
+      expect(allows?(gm, described_class, session, :show_cocofolia_url?)).to be(false)
+      expect(allows?(admin, described_class, session, :show_cocofolia_url?)).to be(false)
+    end
+  end
+
   describe UserPolicy do
     it "is admin only, so a GM cannot rebind accounts to people and grant themselves roles" do
       expect(allows?(anonymous, described_class, User.new, :index?)).to be_falsey

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe "Authorization matrix" do
       expect(allows?(no_role, described_class, session, :show_cocofolia_url?)).to be(true)
       expect(allows?(gm, described_class, session, :show_cocofolia_url?)).to be(false)
       expect(allows?(admin, described_class, session, :show_cocofolia_url?)).to be(false)
+
+      expect(allows?(gm, described_class, session, :update_cocofolia_url?)).to be(true)
+      expect(allows?(admin, described_class, session, :update_cocofolia_url?)).to be(false)
+      expect(allows?(no_role, described_class, session, :update_cocofolia_url?)).to be(false)
     end
   end
 

--- a/spec/policies/play_session_policy_spec.rb
+++ b/spec/policies/play_session_policy_spec.rb
@@ -92,5 +92,17 @@ RSpec.describe PlaySessionPolicy do
       expect(described_class.new(create(:person), session).update?).to be_falsey
       expect(described_class.new(nil, session).update?).to be_falsey
     end
+
+    it "shows the Cocofolia URL only to participants" do
+      peer = create(:person, groups: [ group ])
+      admin = create(:person, roles: %w[admin])
+      gm = create(:person, roles: %w[gm])
+
+      expect(described_class.new(participant, session).show_cocofolia_url?).to be(true)
+      expect(described_class.new(peer, session).show_cocofolia_url?).to be(false)
+      expect(described_class.new(admin, session).show_cocofolia_url?).to be(false)
+      expect(described_class.new(gm, session).show_cocofolia_url?).to be(false)
+      expect(described_class.new(nil, session).show_cocofolia_url?).to be(false)
+    end
   end
 end

--- a/spec/policies/play_session_policy_spec.rb
+++ b/spec/policies/play_session_policy_spec.rb
@@ -104,5 +104,12 @@ RSpec.describe PlaySessionPolicy do
       expect(described_class.new(gm, session).show_cocofolia_url?).to be(false)
       expect(described_class.new(nil, session).show_cocofolia_url?).to be(false)
     end
+
+    it "lets only GMs edit the Cocofolia URL" do
+      expect(described_class.new(create(:person, roles: %w[gm]), session).update_cocofolia_url?).to be(true)
+      expect(described_class.new(create(:person, roles: %w[admin]), session).update_cocofolia_url?).to be(false)
+      expect(described_class.new(create(:person), session).update_cocofolia_url?).to be(false)
+      expect(described_class.new(nil, session).update_cocofolia_url?).to be(false)
+    end
   end
 end

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -170,4 +170,28 @@ RSpec.describe "Manage::PlaySessions" do
       expect(session.reload).to be_played
     end
   end
+
+  describe "as an admin who is not a GM" do
+    let(:session) do
+      create(:play_session, scenario:, cocofolia_url: "https://ccfolia.com/rooms/participant-only")
+    end
+
+    before { sign_in_as create(:person, roles: %w[admin]) }
+
+    it "keeps the Cocofolia URL out of the edit form" do
+      get edit_manage_play_session_path(session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("ココフォリアリンク", "play_session[cocofolia_url]",
+        "https://ccfolia.com/rooms/participant-only")
+    end
+
+    it "does not update the Cocofolia URL from a crafted request" do
+      patch manage_play_session_path(session), params: {
+        play_session: { cocofolia_url: "https://ccfolia.com/rooms/changed-by-admin" }
+      }
+
+      expect(session.reload.cocofolia_url).to eq("https://ccfolia.com/rooms/participant-only")
+    end
+  end
 end

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Manage::PlaySessions" do
           started_at: "20:00",
           status: "played",
           recording_url: "https://youtu.be/abc",
+          cocofolia_url: "https://ccfolia.com/rooms/example",
           participations_attributes: [
             { person_id: gm.id, role: "gm" },
             { person_id: player.id, role: "player", character_name: "探索者A",
@@ -60,6 +61,7 @@ RSpec.describe "Manage::PlaySessions" do
       session = PlaySession.sole
       expect(session.scenario).to eq(scenario)
       expect(session.participations.map(&:role)).to contain_exactly("gm", "player")
+      expect(session.cocofolia_url).to eq("https://ccfolia.com/rooms/example")
       expect(session.participations.find(&:player?).character_sheet_url).to eq("https://charasheet.example/1")
     end
 
@@ -100,6 +102,7 @@ RSpec.describe "Manage::PlaySessions" do
       get edit_manage_play_session_path(session)
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("ココフォリアリンク", "play_session[cocofolia_url]")
     end
 
     it "re-renders instead of raising when the scenario is cleared on update" do

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -139,6 +139,35 @@ RSpec.describe "PlaySessions" do
       expect(response.body).to include("覚え書きの見本")
     end
 
+    it "shows the Cocofolia URL to a participant" do
+      session.update!(cocofolia_url: "https://ccfolia.com/rooms/participant-only")
+      sign_in_as participant
+
+      get play_session_path(session)
+
+      expect(response.body).to include("ココフォリア", "https://ccfolia.com/rooms/participant-only")
+    end
+
+    it "keeps the Cocofolia URL out of the response for a group peer who is not a participant" do
+      session.update!(cocofolia_url: "https://ccfolia.com/rooms/participant-only")
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("ココフォリア", "https://ccfolia.com/rooms/participant-only")
+    end
+
+    it "keeps the Cocofolia URL out of the response for an admin who is not a participant" do
+      session.update!(cocofolia_url: "https://ccfolia.com/rooms/participant-only")
+      sign_in_as create(:person, roles: %w[admin])
+
+      get play_session_path(session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("ココフォリア", "https://ccfolia.com/rooms/participant-only")
+    end
+
     it "links back to the scenario" do
       sign_in_as create(:person, groups: [ group ])
 


### PR DESCRIPTION
## What

- Add a Cocofolia URL field to play sessions
- Let session editors maintain the URL
- Render the URL only for people participating in that session

## Why

Keep session room links available to participants without exposing them to other viewers.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #49