### PR TITLE
Configure database pool and queue worker concurrency independently

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
   host: <%= ENV.fetch("DATABASE_HOST", "localhost") %>
   port: <%= ENV.fetch("DATABASE_PORT", 5432) %>
   username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: <%= ENV.fetch("JOB_THREADS", 3) %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 1
 

--- a/spec/config/runtime_configuration_spec.rb
+++ b/spec/config/runtime_configuration_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "runtime configuration" do
+  around do |example|
+    original_values = ENV.values_at("DB_POOL", "JOB_THREADS")
+    ENV["DB_POOL"] = "7"
+    ENV["JOB_THREADS"] = "2"
+    example.run
+  ensure
+    ENV["DB_POOL"], ENV["JOB_THREADS"] = original_values
+  end
+
+  it "configures the database pool independently from Puma threads" do
+    configuration = ActiveRecord::DatabaseConfigurations.new(
+      YAML.safe_load(ERB.new(Rails.root.join("config/database.yml").read).result, aliases: true)
+    )
+
+    expect(configuration.configs_for(env_name: "production", name: "primary").max_connections).to eq(7)
+  end
+
+  it "configures Solid Queue worker threads independently from worker processes" do
+    configuration = YAML.safe_load(
+      ERB.new(Rails.root.join("config/queue.yml").read).result,
+      aliases: true
+    )
+
+    expect(configuration.dig("production", "workers", 0, "threads")).to eq(2)
+  end
+end


### PR DESCRIPTION
## What

- Add `DB_POOL` for per-process database pool sizing
- Add `JOB_THREADS` for Solid Queue worker thread sizing

## Why

Allow the web and dedicated Solid Queue deployments to use isolated concurrency and connection-pool settings.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

- karia/yuno04-k3s#54
