### PR TITLE
Allow editors to delete scenario jackets

### DIFF
--- a/app/controllers/manage/scenarios_controller.rb
+++ b/app/controllers/manage/scenarios_controller.rb
@@ -1,6 +1,6 @@
 module Manage
   class ScenariosController < BaseController
-    before_action :set_scenario, only: %i[edit update destroy move refresh_booth_image]
+    before_action :set_scenario, only: %i[edit update destroy move refresh_booth_image destroy_jacket]
 
     def index
       authorize Scenario, :manage?
@@ -23,6 +23,12 @@ module Manage
       authorize @scenario, :update?
       result = BoothImageImporter.new(@scenario).call(force: true)
       redirect_to edit_manage_scenario_path(@scenario), (result.success? ? { notice: result.message } : { alert: result.message })
+    end
+
+    def destroy_jacket
+      authorize @scenario, :update?
+      @scenario.jacket.purge
+      redirect_to edit_manage_scenario_path(@scenario), notice: "ジャケット画像を削除しました"
     end
 
     def new

--- a/app/views/manage/scenarios/edit.html.erb
+++ b/app/views/manage/scenarios/edit.html.erb
@@ -7,4 +7,11 @@
     <span class="text-xs text-muted">取得済み</span>
   <% end %>
 </div>
+<% if @scenario.jacket.attached? %>
+  <div class="mt-4">
+    <%= button_to "ジャケット画像を削除", jacket_manage_scenario_path(@scenario), method: :delete,
+          form: { data: { turbo_confirm: "ジャケット画像を削除しますか" } },
+          class: "cursor-pointer border border-rule px-4 py-2 text-sm text-seal" %>
+  </div>
+<% end %>
 <%= render "form", scenario: @scenario %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       patch :reorder, on: :collection
       patch :move, on: :member
       post :refresh_booth_image, on: :member
+      delete :jacket, on: :member, action: :destroy_jacket
     end
     resources :game_systems, except: [ :show, :new ]
     resources :authors, except: [ :show, :new ]

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe "Manage::Scenarios" do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it "does not delete a jacket for anyone outside the editors" do
+      scenario = create(:scenario)
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "jacket.png", content_type: "image/png"
+      )
+
+      delete jacket_manage_scenario_path(scenario)
+
+      expect(response).to have_http_status(:not_found)
+      expect(scenario.reload.jacket).to be_attached
+    end
   end
 
   describe "as a GM" do
@@ -236,6 +248,40 @@ RSpec.describe "Manage::Scenarios" do
       get edit_manage_scenario_path(scenario)
 
       expect(response.body).to include("BOOTH画像を更新")
+    end
+
+    it "offers jacket deletion only when a jacket is attached" do
+      scenario = create(:scenario)
+
+      get edit_manage_scenario_path(scenario)
+      expect(response.body).not_to include("ジャケット画像を削除")
+
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "jacket.png", content_type: "image/png"
+      )
+
+      get edit_manage_scenario_path(scenario)
+      expect(Capybara.string(response.body))
+        .to have_css(%(form[action="#{jacket_manage_scenario_path(scenario)}"] button), text: "ジャケット画像を削除")
+    end
+
+    it "deletes an uploaded jacket and exposes the BOOTH image fallback" do
+      scenario = create(:scenario)
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "jacket.png", content_type: "image/png"
+      )
+      scenario.booth_image.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "booth-fallback.png", content_type: "image/png"
+      )
+
+      delete jacket_manage_scenario_path(scenario)
+
+      expect(response).to redirect_to(edit_manage_scenario_path(scenario))
+      expect(flash[:notice]).to eq("ジャケット画像を削除しました")
+      expect(scenario.reload.jacket).not_to be_attached
+
+      get scenario_path(scenario)
+      expect(response.body).to include("booth-fallback.png")
     end
 
     it "refreshes the BOOTH image and reports success" do


### PR DESCRIPTION
## What

Add a confirmed jacket deletion action to the scenario edit screen.

## Why

Editors cannot currently remove an uploaded jacket and return to the imported BOOTH image fallback.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Part of #39
