### PR TITLE
Preserve jacket image aspect ratios

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -11,12 +11,12 @@ class Scenario < ApplicationRecord
   }, validate: { allow_nil: true }
 
   has_one_attached :jacket do |attachable|
-    attachable.variant :thumb, resize_to_fill: [ 480, 640 ], format: :webp, saver: { quality: 80 }
+    attachable.variant :thumb, resize_to_limit: [ 480, 640 ], format: :webp, saver: { quality: 80 }
     attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
   end
 
   has_one_attached :booth_image do |attachable|
-    attachable.variant :thumb, resize_to_fill: [ 480, 640 ], format: :webp, saver: { quality: 80 }
+    attachable.variant :thumb, resize_to_limit: [ 480, 640 ], format: :webp, saver: { quality: 80 }
     attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
   end
 

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -5,10 +5,10 @@
         <div class="aspect-3/4 overflow-hidden bg-paper">
           <% if scenario.jacket.attached? %>
             <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",
-                  class: "h-full w-full object-cover" %>
+                  class: "h-full w-full object-contain" %>
           <% elsif scenario.booth_image.attached? %>
             <%= image_tag scenario.booth_image.variant(:thumb), alt: "", loading: "lazy",
-                  class: "h-full w-full object-cover" %>
+                  class: "h-full w-full object-contain" %>
           <% else %>
             <span class="flex h-full items-center justify-center font-display text-sm text-muted">
               画像なし

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -12,10 +12,10 @@
     <div class="aspect-3/4 overflow-hidden border border-rule bg-surface">
       <% if @scenario.jacket.attached? %>
         <%= image_tag @scenario.jacket.variant(:cover), alt: "#{@scenario.title} のジャケット画像",
-              class: "h-full w-full object-cover" %>
+              class: "h-full w-full object-contain" %>
       <% elsif @scenario.booth_image.attached? %>
         <%= image_tag @scenario.booth_image.variant(:cover), alt: "#{@scenario.title} のBOOTH商品画像",
-              class: "h-full w-full object-cover" %>
+              class: "h-full w-full object-contain" %>
       <% else %>
         <span class="flex h-full items-center justify-center font-display text-sm text-muted">画像なし</span>
       <% end %>

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Scenario do
+  describe "jacket image variants" do
+    it "fits uploaded and imported images inside their bounds without cropping" do
+      %i[jacket booth_image].each do |attachment|
+        variants = described_class.reflect_on_attachment(attachment).named_variants
+
+        expect(variants[:thumb].transformations).to include(resize_to_limit: [ 480, 640 ])
+        expect(variants[:cover].transformations).to include(resize_to_limit: [ 800, 1200 ])
+      end
+    end
+  end
+
   describe "BOOTH image source" do
     it "uses the first BOOTH purchase URL" do
       scenario = create(:scenario)

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -70,10 +70,16 @@ RSpec.describe "The scenario list" do
     end
 
     it "shows the jackets when asked" do
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "jacket.png", content_type: "image/png"
+      )
+
       get root_path(view: "gallery")
 
       expect(response.body).not_to include("<table")
       expect(response.body).to include("aspect-3/4")
+      expect(Capybara.string(response.body)).to have_css("img.object-contain")
+      expect(Capybara.string(response.body)).not_to have_css("img.object-cover")
     end
 
     it "uses the imported BOOTH image when no jacket is attached" do

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe "Scenarios" do
       expect(response.body).to include("booth-detail.png")
     end
 
+    it "fits the whole jacket inside its frame" do
+      scenario.jacket.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "jacket.png", content_type: "image/png"
+      )
+
+      get scenario_path(scenario)
+
+      expect(Capybara.string(response.body)).to have_css("img.object-contain")
+      expect(Capybara.string(response.body)).not_to have_css("img.object-cover")
+    end
+
     it "keeps the GM supplementary information out of the response for a visitor" do
       get scenario_path(scenario)
 


### PR DESCRIPTION
## What

Fit uploaded jackets and imported BOOTH images inside their fixed display frames without cropping.

## Why

Wide and unusually tall images currently lose content in the gallery and scenario detail views.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Part of #39
