### PR TITLE
Restrict uploaded image formats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl file libjemalloc2 libvips postgresql-client && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,7 +13,9 @@ class Person < ApplicationRecord
   has_many :groups, through: :group_memberships
 
   validates :display_name, presence: true
-  validates :icon, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 5.megabytes }
+  validates :icon,
+    content_type: { in: [ :png, :jpeg, :webp ], spoofing_protection: true },
+    size: { less_than: 5.megabytes }
   validate :keeps_at_least_one_admin
   validate :roles_are_known
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -15,7 +15,8 @@ class Person < ApplicationRecord
   validates :display_name, presence: true
   validates :icon,
     content_type: { in: [ :png, :jpeg, :webp ], spoofing_protection: true },
-    size: { less_than: 5.megabytes }
+    size: { less_than: 5.megabytes },
+    if: -> { attachment_changes.key?("icon") }
   validate :keeps_at_least_one_admin
   validate :roles_are_known
 

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -61,7 +61,9 @@ class Scenario < ApplicationRecord
   def booth_purchase_url = purchase_links.find(&:booth?)&.url
 
   validates :title, presence: true
-  validates :jacket, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
+  validates :jacket,
+    content_type: { in: [ :png, :jpeg, :webp ], spoofing_protection: true },
+    size: { less_than: 10.megabytes }
   validates :booth_image, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
   # TODO: 並び順は position に移った（issue #41）。切り戻す必要がなくなったら列ごと落とす。
   validates :recommendation, inclusion: { in: 1..5 }, allow_nil: true

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -63,7 +63,8 @@ class Scenario < ApplicationRecord
   validates :title, presence: true
   validates :jacket,
     content_type: { in: [ :png, :jpeg, :webp ], spoofing_protection: true },
-    size: { less_than: 10.megabytes }
+    size: { less_than: 10.megabytes },
+    if: -> { attachment_changes.key?("jacket") }
   validates :booth_image, content_type: [ :png, :jpeg, :gif, :webp ], size: { less_than: 10.megabytes }
   # TODO: 並び順は position に移った（issue #41）。切り戻す必要がなくなったら列ごと落とす。
   validates :recommendation, inclusion: { in: 1..5 }, allow_nil: true

--- a/app/views/manage/people/_form.html.erb
+++ b/app/views/manage/people/_form.html.erb
@@ -16,7 +16,7 @@
 
   <div>
     <%= form.label :icon, "アイコン", class: "block text-xs text-muted" %>
-    <%= form.file_field :icon, accept: "image/*", class: "mt-1 text-sm" %>
+    <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
   </div>
 
   <div>

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -38,7 +38,7 @@
 
       <div>
         <%= form.label :jacket, "ジャケット画像", class: "block text-xs text-muted" %>
-        <%= form.file_field :jacket, accept: "image/*", class: "mt-1 text-sm" %>
+        <%= form.file_field :jacket, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="sm:col-span-2">
         <%= form.label :icon, "アイコン", class: "block text-xs text-muted" %>
-        <%= form.file_field :icon, accept: "image/*", class: "mt-1 text-sm" %>
+        <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
       </div>
     </div>
   </fieldset>

--- a/spec/models/attachment_validation_spec.rb
+++ b/spec/models/attachment_validation_spec.rb
@@ -4,7 +4,13 @@ require "rails_helper"
 # 一覧を開いた全員に 500 が出る。添付の時点で弾く。
 RSpec.describe "Attachment validation" do
   def upload(content, type, name)
-    Rack::Test::UploadedFile.new(StringIO.new(content), type, original_filename: name)
+    file = Tempfile.new
+    file.binmode
+    file.write(content)
+    file.close
+    Rack::Test::UploadedFile.new(file.path, type, original_filename: name)
+  ensure
+    file&.unlink
   end
 
   def png
@@ -27,6 +33,20 @@ RSpec.describe "Attachment validation" do
       expect(person.errors[:icon]).to be_present
     end
 
+    it "rejects a GIF icon" do
+      person = create(:person)
+      person.icon.attach(upload("GIF89a", "image/gif", "animated.gif"))
+
+      expect(person).not_to be_valid
+    end
+
+    it "rejects a malformed file declared as a PNG icon" do
+      person = create(:person)
+      person.icon.attach(upload("not an image", "image/png", "broken.png"))
+
+      expect(person).not_to be_valid
+    end
+
     it "rejects an image that is too large to be an icon" do
       person = create(:person)
       person.icon.attach(upload("x" * 6.megabytes, "image/png", "huge.png"))
@@ -39,6 +59,20 @@ RSpec.describe "Attachment validation" do
     it "rejects a jacket that is not an image" do
       scenario = create(:scenario)
       scenario.jacket.attach(upload("not an image", "text/plain", "evil.txt"))
+
+      expect(scenario).not_to be_valid
+    end
+
+    it "rejects a GIF jacket" do
+      scenario = create(:scenario)
+      scenario.jacket.attach(upload("GIF89a", "image/gif", "animated.gif"))
+
+      expect(scenario).not_to be_valid
+    end
+
+    it "rejects a malformed file declared as a PNG jacket" do
+      scenario = create(:scenario)
+      scenario.jacket.attach(upload("not an image", "image/png", "broken.png"))
 
       expect(scenario).not_to be_valid
     end

--- a/spec/models/attachment_validation_spec.rb
+++ b/spec/models/attachment_validation_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe "Attachment validation" do
     Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/dot.png"), "image/png")
   end
 
+  def attach_legacy_gif(record, name)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("GIF89a"), filename: "legacy.gif", content_type: "image/gif"
+    )
+    ActiveStorage::Attachment.create!(record:, name:, blob:)
+  end
+
   describe Person do
     it "accepts a PNG icon" do
       person = create(:person)
@@ -38,6 +45,13 @@ RSpec.describe "Attachment validation" do
       person.icon.attach(upload("GIF89a", "image/gif", "animated.gif"))
 
       expect(person).not_to be_valid
+    end
+
+    it "allows unrelated updates while a legacy GIF icon remains attached" do
+      person = create(:person)
+      attach_legacy_gif(person, "icon")
+
+      expect(person.update(display_name: "更新後")).to be(true)
     end
 
     it "rejects a malformed file declared as a PNG icon" do
@@ -68,6 +82,13 @@ RSpec.describe "Attachment validation" do
       scenario.jacket.attach(upload("GIF89a", "image/gif", "animated.gif"))
 
       expect(scenario).not_to be_valid
+    end
+
+    it "allows unrelated updates while a legacy GIF jacket remains attached" do
+      scenario = create(:scenario)
+      attach_legacy_gif(scenario, "jacket")
+
+      expect(scenario.update(title: "更新後")).to be(true)
     end
 
     it "rejects a malformed file declared as a PNG jacket" do

--- a/spec/requests/manage/people_spec.rb
+++ b/spec/requests/manage/people_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe "Manage::People" do
   describe "as an admin" do
     before { sign_in_as create(:person, roles: %w[admin], display_name: "カーリア") }
 
+    it "limits the icon picker to supported image formats" do
+      person = create(:person)
+
+      get edit_manage_person_path(person)
+
+      expect(Capybara.string(response.body))
+        .to have_css('input[name="person[icon]"][accept="image/png,image/jpeg,image/webp"]')
+    end
+
     it "creates a person with roles and groups" do
       group = create(:group, name: "よく遊ぶ人たち")
 

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -284,6 +284,15 @@ RSpec.describe "Manage::Scenarios" do
       expect(response.body).to include("booth-fallback.png")
     end
 
+    it "limits the jacket picker to supported image formats" do
+      scenario = create(:scenario)
+
+      get edit_manage_scenario_path(scenario)
+
+      expect(Capybara.string(response.body))
+        .to have_css('input[name="scenario[jacket]"][accept="image/png,image/jpeg,image/webp"]')
+    end
+
     it "refreshes the BOOTH image and reports success" do
       scenario = create(:scenario)
       result = BoothImageImporter::Result.new(success: true, message: "BOOTH画像を更新しました")

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe "People" do
       Rack::Test::UploadedFile.new(StringIO.new(content), type, original_filename: name)
     end
 
+    it "limits the icon picker to supported image formats" do
+      sign_in_as person
+
+      get edit_person_path(person)
+
+      expect(Capybara.string(response.body))
+        .to have_css('input[name="person[icon]"][accept="image/png,image/jpeg,image/webp"]')
+    end
+
     # 1 人の不正なアップロードで、一覧を開いた全員が 500 になるのを防ぐ。
     it "refuses a file that is not an image, and leaves the member list working" do
       sign_in_as person


### PR DESCRIPTION
## What

Limit scenario jacket and person icon uploads to PNG, JPEG, and WebP, and verify their declared MIME type against their contents.

## Why

User-uploaded images need an explicit format allowlist and protection against files whose declared type does not match their contents.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #39
