### PR TITLE
Add admin-managed GA4 tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,4 @@ GOOGLE_CLIENT_SECRET=
 # APP_HOST=trpg-catalog.side2.net
 
 # 非ログインユーザーにだけ描画する。未設定ならタグ自体を出さない。
-# GA_MEASUREMENT_ID=
 # ADSENSE_CLIENT_ID=

--- a/app/controllers/manage/site_settings_controller.rb
+++ b/app/controllers/manage/site_settings_controller.rb
@@ -1,0 +1,27 @@
+module Manage
+  class SiteSettingsController < BaseController
+    def show
+      @site_setting = authorize SiteSetting.current
+    end
+
+    def edit
+      @site_setting = authorize SiteSetting.current
+    end
+
+    def update
+      @site_setting = authorize SiteSetting.current, :update?
+      @site_setting.google_analytics_measurement_id = site_setting_params[:google_analytics_measurement_id].strip
+
+      if @site_setting.save
+        redirect_to manage_site_setting_path, notice: "サイト全体設定を更新しました"
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    private
+      def site_setting_params
+        params.expect(site_setting: [ :google_analytics_measurement_id ])
+      end
+  end
+end

--- a/app/helpers/third_party_tags_helper.rb
+++ b/app/helpers/third_party_tags_helper.rb
@@ -1,7 +1,13 @@
 module ThirdPartyTagsHelper
   # ログイン中に解析タグと広告タグを出すと、閲覧者と非公開の情報が外部へ渡る。
   def show_analytics?
-    !signed_in? && ENV["GA_MEASUREMENT_ID"].present?
+    !signed_in? && analytics_measurement_id.present?
+  end
+
+  def analytics_measurement_id
+    return @analytics_measurement_id if defined?(@analytics_measurement_id)
+
+    @analytics_measurement_id = SiteSetting.current.google_analytics_measurement_id
   end
 
   def show_ads?

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,0 +1,12 @@
+class SiteSetting < ApplicationRecord
+  validates :google_analytics_measurement_id,
+    allow_blank: true,
+    format: {
+      with: /\AG-[A-Z0-9]+\z/,
+      message: "は G- から始まる測定 ID を入力してください"
+    }
+
+  def self.current
+    find_or_initialize_by(id: 1)
+  end
+end

--- a/app/policies/site_setting_policy.rb
+++ b/app/policies/site_setting_policy.rb
@@ -1,0 +1,4 @@
+class SiteSettingPolicy < ApplicationPolicy
+  def show? = admin?
+  def update? = admin?
+end

--- a/app/views/manage/_nav.html.erb
+++ b/app/views/manage/_nav.html.erb
@@ -11,6 +11,7 @@
       <%= link_to "メンバー", manage_people_path, class: manage_nav_class(manage_people_path) %>
       <%= link_to "グループ", manage_groups_path, class: manage_nav_class(manage_groups_path) %>
       <%= link_to "アカウント", manage_users_path, class: manage_nav_class(manage_users_path) %>
+      <%= link_to "サイト全体設定", manage_site_setting_path, class: manage_nav_class(manage_site_setting_path) %>
     <% end %>
   </div>
 </nav>

--- a/app/views/manage/site_settings/edit.html.erb
+++ b/app/views/manage/site_settings/edit.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, "サイト全体設定" %>
+
+<h1 class="font-display text-2xl">サイト全体設定</h1>
+
+<%= form_with model: @site_setting, url: manage_site_setting_path, method: :patch, class: "mt-6 space-y-6" do |form| %>
+  <% if @site_setting.errors.any? %>
+    <div class="border border-seal bg-surface px-4 py-3 text-sm text-seal" role="alert">
+      <ul class="list-disc pl-5">
+        <% @site_setting.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :google_analytics_measurement_id, "Google Analytics 測定 ID", class: "block text-sm font-bold" %>
+    <%= form.text_field :google_analytics_measurement_id,
+          placeholder: "G-XXXXXXXXXX",
+          autocomplete: "off",
+          class: "mt-2 w-full max-w-md border border-rule bg-paper px-3 py-2" %>
+    <p class="mt-2 text-sm text-muted">未入力にすると Google Analytics を無効にします。</p>
+  </div>
+
+  <div class="flex gap-4">
+    <%= form.submit "更新", class: "cursor-pointer border border-ink bg-ink px-4 py-2 text-paper" %>
+    <%= link_to "詳細に戻る", manage_site_setting_path, class: "self-center text-sm text-muted" %>
+  </div>
+<% end %>

--- a/app/views/manage/site_settings/show.html.erb
+++ b/app/views/manage/site_settings/show.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "サイト全体設定" %>
+
+<article>
+  <div class="flex flex-wrap items-baseline justify-between gap-4">
+    <h1 class="font-display text-2xl">サイト全体設定</h1>
+    <%= link_to "編集", edit_manage_site_setting_path, class: "text-sm text-seal" %>
+  </div>
+
+  <dl class="mt-6 grid grid-cols-[12rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 text-sm">
+    <dt class="text-muted">Google Analytics 測定 ID</dt>
+    <dd><%= @site_setting.google_analytics_measurement_id.presence || "無効" %></dd>
+  </dl>
+</article>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,9 +1,9 @@
 <% if show_analytics? %>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_MEASUREMENT_ID"] %>"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_measurement_id %>"></script>
   <script nonce="<%= content_security_policy_nonce %>">
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', <%= ENV["GA_MEASUREMENT_ID"].to_json %>);
+    gtag('config', <%= analytics_measurement_id.to_json %>);
   </script>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     resources :groups, except: [ :new ]
     resources :users, only: [ :index, :show, :edit, :update ]
     resources :play_sessions, except: [ :show, :new ]
+    resource :site_setting, only: [ :show, :edit, :update ]
   end
 
   # sitemap_generator の出力を tmp から配信する。

--- a/db/migrate/20260811153058_create_site_settings.rb
+++ b/db/migrate/20260811153058_create_site_settings.rb
@@ -1,0 +1,9 @@
+class CreateSiteSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :site_settings do |t|
+      t.string :google_analytics_measurement_id, null: false, default: ""
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_130723) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_153058) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -186,6 +186,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_130723) do
     t.datetime "updated_at", null: false
     t.index ["position"], name: "index_scenarios_on_position"
     t.index ["title"], name: "index_scenarios_on_title"
+  end
+
+  create_table "site_settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "google_analytics_measurement_id", default: "", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "spoiler_reveals", force: :cascade do |t|

--- a/spec/policies/authorization_matrix_spec.rb
+++ b/spec/policies/authorization_matrix_spec.rb
@@ -123,6 +123,15 @@ RSpec.describe "Authorization matrix" do
     end
   end
 
+  describe SiteSettingPolicy do
+    it "is admin only" do
+      expect(allows?(gm, described_class, SiteSetting.new, :show?)).to be_falsey
+      expect(allows?(admin, described_class, SiteSetting.new, :show?)).to be(true)
+      expect(allows?(gm, described_class, SiteSetting.new, :update?)).to be_falsey
+      expect(allows?(admin, described_class, SiteSetting.new, :update?)).to be(true)
+    end
+  end
+
   describe "scopes" do
     it "returns nothing about groups or accounts to a GM" do
       create(:group)

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Manage navigation" do
       "作者" => "/manage/authors",
       "メンバー" => "/manage/people",
       "グループ" => "/manage/groups",
-      "アカウント" => "/manage/users"
+      "アカウント" => "/manage/users",
+      "サイト全体設定" => "/manage/site_setting"
     }
   end
 
@@ -55,6 +56,7 @@ RSpec.describe "Manage navigation" do
       expect(response.body).not_to include("/manage/people")
       expect(response.body).not_to include("/manage/groups")
       expect(response.body).not_to include("/manage/users")
+      expect(response.body).not_to include("/manage/site_setting")
     end
   end
 

--- a/spec/requests/manage/site_settings_spec.rb
+++ b/spec/requests/manage/site_settings_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Manage site settings" do
+  describe "authorization" do
+    it "lets an administrator view and edit the settings" do
+      sign_in_as create(:person, roles: %w[admin])
+
+      get manage_site_setting_path
+      expect(response).to have_http_status(:ok)
+
+      get edit_manage_site_setting_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "hides the settings from a GM" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      get edit_manage_site_setting_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "updating" do
+    before { sign_in_as create(:person, roles: %w[admin]) }
+
+    it "stores a GA4 measurement ID" do
+      patch manage_site_setting_path, params: {
+        site_setting: { google_analytics_measurement_id: "G-ABC123DEF4" }
+      }
+
+      expect(response).to redirect_to(manage_site_setting_path)
+      expect(SiteSetting.current.google_analytics_measurement_id).to eq("G-ABC123DEF4")
+    end
+
+    it "accepts an empty value to disable analytics" do
+      SiteSetting.current.update!(google_analytics_measurement_id: "G-ABC123DEF4")
+
+      patch manage_site_setting_path, params: {
+        site_setting: { google_analytics_measurement_id: "" }
+      }
+
+      expect(SiteSetting.current.google_analytics_measurement_id).to eq("")
+    end
+
+    it "rejects a value that is not a GA4 measurement ID" do
+      patch manage_site_setting_path, params: {
+        site_setting: { google_analytics_measurement_id: "UA-1234-1" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("G- から始まる測定 ID を入力してください")
+      expect(response.body).to include("詳細に戻る")
+      expect(SiteSetting.current.google_analytics_measurement_id).to eq("")
+    end
+  end
+end

--- a/spec/requests/third_party_tags_spec.rb
+++ b/spec/requests/third_party_tags_spec.rb
@@ -2,17 +2,26 @@ require "rails_helper"
 
 RSpec.describe "Third party tags" do
   around do |example|
-    ClimateControl.modify(GA_MEASUREMENT_ID: "G-TEST", ADSENSE_CLIENT_ID: "ca-pub-test") { example.run }
+    ClimateControl.modify(ADSENSE_CLIENT_ID: "ca-pub-test") { example.run }
   end
 
   it "renders the analytics and ad tags for an anonymous visitor" do
+    SiteSetting.current.update!(google_analytics_measurement_id: "G-TEST123")
+
     get root_path
 
-    expect(response.body).to include("googletagmanager.com/gtag/js?id=G-TEST")
+    expect(response.body).to include("googletagmanager.com/gtag/js?id=G-TEST123")
     expect(response.body).to include("adsbygoogle.js?client=ca-pub-test")
   end
 
+  it "does not render analytics when the measurement ID is empty" do
+    get root_path
+
+    expect(response.body).not_to include("googletagmanager.com")
+  end
+
   it "renders neither once a visitor signs in, even before they are linked" do
+    SiteSetting.current.update!(google_analytics_measurement_id: "G-TEST123")
     sign_in_as create(:user, person: nil)
 
     get root_path


### PR DESCRIPTION
## What

Add an administrator-managed GA4 measurement ID and render the gtag.js snippet for anonymous visitors.

## Why

Allow analytics to be enabled without deployment-time environment configuration.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #35