### PR TITLE
Support multi-day play sessions

### DIFF
--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -42,7 +42,7 @@ module Manage
     private
       # 保守用なので公開側の Scope は通さない。入口は require_editor と manage? で守る。
       def maintained_sessions
-        PlaySession.includes(:scenario, participations: :person).newest_first
+        PlaySession.includes(:scenario, :session_schedules, participations: :person).newest_first
       end
 
       def set_play_session
@@ -52,7 +52,11 @@ module Manage
       def play_session_params
         permitted = params.expect(
           play_session: [
-            :scenario_id, :played_on, :started_at, :status, :recording_url, :cocofolia_url, :note,
+            :scenario_id, :cocofolia_url, :note,
+            { session_schedules_attributes: [
+              [ :id, :started_at, :position, :_destroy,
+                { recording_links_attributes: [ [ :id, :url, :position, :_destroy ] ] } ]
+            ] },
             { participations_attributes: [ [ :id, :person_id, :role, :character_name, :character_sheet_url, :position, :_destroy ] ] }
           ]
         )

--- a/app/controllers/manage/play_sessions_controller.rb
+++ b/app/controllers/manage/play_sessions_controller.rb
@@ -54,7 +54,7 @@ module Manage
           play_session: [
             :scenario_id, :cocofolia_url, :note,
             { session_schedules_attributes: [
-              [ :id, :started_at, :position, :_destroy,
+              [ :id, :scheduled_on, :started_at, :position, :_destroy,
                 { recording_links_attributes: [ [ :id, :url, :position, :_destroy ] ] } ]
             ] },
             { participations_attributes: [ [ :id, :person_id, :role, :character_name, :character_sheet_url, :position, :_destroy ] ] }

--- a/app/controllers/play_sessions_controller.rb
+++ b/app/controllers/play_sessions_controller.rb
@@ -11,12 +11,14 @@ class PlaySessionsController < ApplicationController
 
   private
     def visible_sessions
-      policy_scope(PlaySession).includes(:scenario, participations: :person)
+      policy_scope(PlaySession).includes(:scenario, session_schedules: :recording_links, participations: :person)
     end
 
     # 編集者は管理一覧と編集画面ですべての回を扱えるため、詳細も同じ範囲を許可する。
     # 公開一覧は引き続き visible_sessions を使い、表示範囲を広げない。
     def sessions_for_detail
-      policy(PlaySession).manage? ? PlaySession.all.includes(:scenario, participations: :person) : visible_sessions
+      policy(PlaySession).manage? ?
+        PlaySession.all.includes(:scenario, session_schedules: :recording_links, participations: :person) :
+        visible_sessions
     end
 end

--- a/app/helpers/play_sessions_helper.rb
+++ b/app/helpers/play_sessions_helper.rb
@@ -5,10 +5,17 @@ module PlaySessionsHelper
   end
 
   def play_session_schedule(session)
-    schedules = session.session_schedules.filter_map(&:started_at)
+    schedules = session.session_schedules.select(&:scheduled_on?)
     return "日程未定" if schedules.empty?
 
-    schedules.map { |started_at| l(started_at, format: :session_schedule) }.join("、")
+    schedules.map { |schedule| play_session_schedule_time(schedule) }.join("、")
+  end
+
+  def play_session_schedule_time(schedule)
+    return "日程未定" if schedule.scheduled_on.blank?
+
+    date = l(schedule.scheduled_on, format: :with_weekday)
+    schedule.started_at.present? ? "#{date} #{schedule.started_at.strftime("%H:%M")}" : date
   end
 
   def play_session_status_label(session)

--- a/app/helpers/play_sessions_helper.rb
+++ b/app/helpers/play_sessions_helper.rb
@@ -5,14 +5,14 @@ module PlaySessionsHelper
   end
 
   def play_session_schedule(session)
-    return "日程未定" if session.played_on.blank?
+    schedules = session.session_schedules.filter_map(&:started_at)
+    return "日程未定" if schedules.empty?
 
-    date = l(session.played_on, format: :long)
-    session.started_at.present? ? "#{date} #{session.started_at.strftime("%H:%M")}" : date
+    schedules.map { |started_at| l(started_at, format: :session_schedule) }.join("、")
   end
 
   def play_session_status_label(session)
-    t("play_sessions.statuses.#{session.status}")
+    t("play_sessions.statuses.#{session.derived_status}")
   end
 
   def participation_role_label(participation)

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -3,9 +3,10 @@ import { Controller } from "@hotwired/stimulus"
 // 入手先と配信リンクの行を増やす。増やした行は保存時にまとめて送られる。
 export default class extends Controller {
   static targets = ["template", "anchor"]
+  static values = { token: { type: String, default: "NEW_RECORD" } }
 
   add() {
-    const html = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime())
+    const html = this.templateTarget.innerHTML.replaceAll(this.tokenValue, new Date().getTime())
     this.anchorTarget.insertAdjacentHTML("beforebegin", html)
   }
 }

--- a/app/models/play_session.rb
+++ b/app/models/play_session.rb
@@ -1,6 +1,7 @@
 class PlaySession < ApplicationRecord
   belongs_to :scenario
-  has_many :session_schedules, -> { order(Arel.sql("started_at ASC NULLS LAST"), :position, :id) },
+  has_many :session_schedules, -> { order(Arel.sql("scheduled_on ASC NULLS LAST"),
+    Arel.sql("started_at ASC NULLS LAST"), :position, :id) },
     dependent: :destroy, inverse_of: :play_session
   has_many :participations, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :play_session
   has_many :people, through: :participations
@@ -10,7 +11,7 @@ class PlaySession < ApplicationRecord
     reject_if: lambda { |attrs|
       recordings = attrs["recording_links_attributes"]
       recordings = recordings.values if recordings.respond_to?(:values)
-      attrs["started_at"].blank? && Array(recordings).all? { |recording| recording["url"].blank? }
+      attrs["scheduled_on"].blank? && Array(recordings).all? { |recording| recording["url"].blank? }
     }
   accepts_nested_attributes_for :participations, allow_destroy: true,
     reject_if: ->(attrs) { attrs["person_id"].blank? }
@@ -21,18 +22,35 @@ class PlaySession < ApplicationRecord
   # 日付が無い回を末尾に固定する。データベース既定の NULL の並びに任せない。
   scope :newest_first, -> {
     left_joins(:session_schedules).group(:id)
-      .order(Arel.sql("MIN(session_schedules.started_at) DESC NULLS LAST"), id: :desc)
+      .order(Arel.sql("MIN(session_schedules.scheduled_on) DESC NULLS LAST"), id: :desc)
   }
 
   def derived_status(now = Time.current)
-    starts = session_schedules.filter_map(&:started_at)
-    return :scheduled if starts.empty? || now < starts.first
-    return :in_progress if now < starts.last
+    starts = session_schedules.filter_map(&:effective_start)
+    return :scheduled if starts.empty?
+
+    boundaries = starts.minmax
+    return :scheduled if now < boundaries.first
+    return :in_progress if now < boundaries.last
 
     :completed
   end
 
+  after_commit :sync_legacy_schedule_columns, on: %i[create update]
+
   private
+    def sync_legacy_schedule_columns
+      schedule = session_schedules.reload.first
+      status_value = derived_status == :completed ? 1 : 0
+      update_columns(
+        played_on: schedule&.scheduled_on,
+        started_at: schedule&.started_at,
+        recording_url: schedule&.recording_links&.first&.url,
+        status: status_value
+      )
+      session_schedules.reset
+    end
+
     # 一意制約は DB にもあるが、同じ送信内に重複があると例外になる前に弾く必要がある。
     def participants_are_distinct
       ids = participations.reject(&:marked_for_destruction?).filter_map(&:person_id)

--- a/app/models/play_session.rb
+++ b/app/models/play_session.rb
@@ -1,22 +1,36 @@
 class PlaySession < ApplicationRecord
-  enum :status, { scheduled: 0, played: 1, cancelled: 2 }, validate: true
-
   belongs_to :scenario
+  has_many :session_schedules, -> { order(Arel.sql("started_at ASC NULLS LAST"), :position, :id) },
+    dependent: :destroy, inverse_of: :play_session
   has_many :participations, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :play_session
   has_many :people, through: :participations
 
   # person_id が空の行は増やしただけの行なので捨てる。role には既定値があり all_blank では消えない。
+  accepts_nested_attributes_for :session_schedules, allow_destroy: true,
+    reject_if: lambda { |attrs|
+      recordings = attrs["recording_links_attributes"]
+      recordings = recordings.values if recordings.respond_to?(:values)
+      attrs["started_at"].blank? && Array(recordings).all? { |recording| recording["url"].blank? }
+    }
   accepts_nested_attributes_for :participations, allow_destroy: true,
     reject_if: ->(attrs) { attrs["person_id"].blank? }
 
-  validates :recording_url, http_url: true
   validates :cocofolia_url, http_url: true
   validate :participants_are_distinct
 
   # 日付が無い回を末尾に固定する。データベース既定の NULL の並びに任せない。
   scope :newest_first, -> {
-    order(Arel.sql("played_on DESC NULLS LAST"), Arel.sql("started_at DESC NULLS LAST"), id: :desc)
+    left_joins(:session_schedules).group(:id)
+      .order(Arel.sql("MIN(session_schedules.started_at) DESC NULLS LAST"), id: :desc)
   }
+
+  def derived_status(now = Time.current)
+    starts = session_schedules.filter_map(&:started_at)
+    return :scheduled if starts.empty? || now < starts.first
+    return :in_progress if now < starts.last
+
+    :completed
+  end
 
   private
     # 一意制約は DB にもあるが、同じ送信内に重複があると例外になる前に弾く必要がある。

--- a/app/models/recording_link.rb
+++ b/app/models/recording_link.rb
@@ -1,0 +1,5 @@
+class RecordingLink < ApplicationRecord
+  belongs_to :session_schedule
+
+  validates :url, presence: true, http_url: true
+end

--- a/app/models/session_schedule.rb
+++ b/app/models/session_schedule.rb
@@ -4,4 +4,12 @@ class SessionSchedule < ApplicationRecord
 
   accepts_nested_attributes_for :recording_links, allow_destroy: true,
     reject_if: ->(attrs) { attrs["url"].blank? }
+
+  def effective_start
+    return if scheduled_on.blank?
+    return scheduled_on.in_time_zone if started_at.blank?
+
+    Time.zone.local(scheduled_on.year, scheduled_on.month, scheduled_on.day,
+      started_at.hour, started_at.min, started_at.sec)
+  end
 end

--- a/app/models/session_schedule.rb
+++ b/app/models/session_schedule.rb
@@ -1,0 +1,7 @@
+class SessionSchedule < ApplicationRecord
+  belongs_to :play_session
+  has_many :recording_links, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :session_schedule
+
+  accepts_nested_attributes_for :recording_links, allow_destroy: true,
+    reject_if: ->(attrs) { attrs["url"].blank? }
+end

--- a/app/views/manage/play_sessions/_form.html.erb
+++ b/app/views/manage/play_sessions/_form.html.erb
@@ -14,22 +14,20 @@
         <%= form.collection_select :scenario_id, Scenario.order(:title), :id, :title,
               { include_blank: "選択してください" }, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
       </div>
-      <div>
-        <%= form.label :played_on, "日付（未定なら空欄）", class: "block text-xs text-muted" %>
-        <%= form.date_field :played_on, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-      </div>
-      <div>
-        <%= form.label :started_at, "開始時刻（未定なら空欄）", class: "block text-xs text-muted" %>
-        <%= form.time_field :started_at, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-      </div>
-      <div>
-        <%= form.label :status, "状態", class: "block text-xs text-muted" %>
-        <%= form.select :status, PlaySession.statuses.keys.map { |k| [ t("play_sessions.statuses.#{k}"), k ] },
-              {}, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-      </div>
-      <div>
-        <%= form.label :recording_url, "録画リンク", class: "block text-xs text-muted" %>
-        <%= form.url_field :recording_url, placeholder: "https://", class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+      <div class="sm:col-span-2">
+        <p class="text-xs text-muted">日程と録画リンク</p>
+        <div class="mt-1 space-y-3" data-controller="nested-form" data-nested-form-token-value="NEW_SCHEDULE">
+          <template data-nested-form-target="template">
+            <%= form.fields_for :session_schedules, SessionSchedule.new, child_index: "NEW_SCHEDULE" do |schedule_form| %>
+              <%= render "session_schedule_row", schedule_form: schedule_form %>
+            <% end %>
+          </template>
+          <%= form.fields_for :session_schedules do |schedule_form| %>
+            <%= render "session_schedule_row", schedule_form: schedule_form %>
+          <% end %>
+          <div data-nested-form-target="anchor"></div>
+          <button type="button" data-action="nested-form#add" class="cursor-pointer text-sm text-seal">日程を足す</button>
+        </div>
       </div>
       <% if policy(play_session).update_cocofolia_url? %>
         <div>

--- a/app/views/manage/play_sessions/_recording_link_row.html.erb
+++ b/app/views/manage/play_sessions/_recording_link_row.html.erb
@@ -1,0 +1,7 @@
+<div class="flex flex-wrap items-center gap-3">
+  <%= recording_form.url_field :url, placeholder: "https://",
+        class: "min-w-64 grow border border-rule bg-surface px-3 py-2 text-sm" %>
+  <% if recording_form.object.persisted? %>
+    <label class="text-xs text-muted"><%= recording_form.check_box :_destroy %> 削除</label>
+  <% end %>
+</div>

--- a/app/views/manage/play_sessions/_session_schedule_row.html.erb
+++ b/app/views/manage/play_sessions/_session_schedule_row.html.erb
@@ -1,0 +1,24 @@
+<div class="border border-rule bg-paper p-3">
+  <div class="flex flex-wrap items-end gap-3">
+    <div class="grow">
+      <%= schedule_form.label :started_at, "開始日時", class: "block text-xs text-muted" %>
+      <%= schedule_form.datetime_local_field :started_at,
+            class: "mt-1 w-full border border-rule bg-surface px-3 py-2 text-sm" %>
+    </div>
+    <% if schedule_form.object.persisted? %>
+      <label class="pb-2 text-xs text-muted"><%= schedule_form.check_box :_destroy %> この日程を削除</label>
+    <% end %>
+  </div>
+  <div class="mt-3 space-y-2" data-controller="nested-form" data-nested-form-token-value="NEW_RECORDING">
+    <template data-nested-form-target="template">
+      <%= schedule_form.fields_for :recording_links, RecordingLink.new, child_index: "NEW_RECORDING" do |recording_form| %>
+        <%= render "recording_link_row", recording_form: recording_form %>
+      <% end %>
+    </template>
+    <%= schedule_form.fields_for :recording_links do |recording_form| %>
+      <%= render "recording_link_row", recording_form: recording_form %>
+    <% end %>
+    <div data-nested-form-target="anchor"></div>
+    <button type="button" data-action="nested-form#add" class="cursor-pointer text-xs text-seal">録画リンクを足す</button>
+  </div>
+</div>

--- a/app/views/manage/play_sessions/_session_schedule_row.html.erb
+++ b/app/views/manage/play_sessions/_session_schedule_row.html.erb
@@ -1,8 +1,13 @@
 <div class="border border-rule bg-paper p-3">
   <div class="flex flex-wrap items-end gap-3">
     <div class="grow">
-      <%= schedule_form.label :started_at, "開始日時", class: "block text-xs text-muted" %>
-      <%= schedule_form.datetime_local_field :started_at,
+      <%= schedule_form.label :scheduled_on, "開催日", class: "block text-xs text-muted" %>
+      <%= schedule_form.date_field :scheduled_on,
+            class: "mt-1 w-full border border-rule bg-surface px-3 py-2 text-sm" %>
+    </div>
+    <div class="grow">
+      <%= schedule_form.label :started_at, "開始時刻（未定なら空欄）", class: "block text-xs text-muted" %>
+      <%= schedule_form.time_field :started_at,
             class: "mt-1 w-full border border-rule bg-surface px-3 py-2 text-sm" %>
     </div>
     <% if schedule_form.object.persisted? %>

--- a/app/views/manage/play_sessions/index.html.erb
+++ b/app/views/manage/play_sessions/index.html.erb
@@ -9,7 +9,7 @@
       <div>
         <p class="font-display"><%= session.scenario.title %></p>
         <p class="font-mono text-xs text-muted">
-          <%= play_session_schedule(session) %> ／ <%= play_session_status_label(session) %>
+          <%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）
           ／ <%= session.participations.map { |p| p.person.display_name }.join("、").presence || "参加者なし" %>
         </p>
       </div>

--- a/app/views/play_sessions/index.html.erb
+++ b/app/views/play_sessions/index.html.erb
@@ -8,9 +8,8 @@
   <% @play_sessions.each do |session| %>
     <li>
       <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-4 no-underline text-ink hover:bg-paper" do %>
-        <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %></span>
+        <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）</span>
         <span class="font-display text-lg"><%= session.scenario.title %></span>
-        <span class="text-xs text-muted"><%= play_session_status_label(session) %></span>
         <span class="ml-auto text-xs text-muted">
           <%= session.participations.map { |p| p.person.display_name }.join("、") %>
         </span>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -17,16 +17,22 @@
 
   <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
     <dt class="text-muted">日時</dt>
-    <dd><%= play_session_schedule(@play_session) %>（<%= play_session_status_label(@play_session) %>）</dd>
-    <% @play_session.session_schedules.each do |schedule| %>
-      <% schedule.recording_links.each do |recording| %>
-        <dt class="text-muted">録画</dt>
-        <dd class="space-y-2 font-sans">
-          <%= render "shared/video_link", title: "録画", url: recording.url,
-                link_text: recording.url, rel: "noopener", show_url: false %>
-        </dd>
+    <dd class="space-y-4">
+      <% if @play_session.session_schedules.empty? %>
+        日程未定（<%= play_session_status_label(@play_session) %>）
       <% end %>
-    <% end %>
+      <% @play_session.session_schedules.each_with_index do |schedule, index| %>
+        <section data-session-schedule>
+          <p><%= play_session_schedule_time(schedule) %><%= "（#{play_session_status_label(@play_session)}）" if index == @play_session.session_schedules.size - 1 %></p>
+          <div class="mt-2 space-y-2 font-sans">
+            <% schedule.recording_links.each do |recording| %>
+              <%= render "shared/video_link", title: "録画", url: recording.url,
+                    link_text: recording.url, rel: "noopener", show_url: false %>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+    </dd>
     <% if @play_session.cocofolia_url.present? && policy(@play_session).show_cocofolia_url? %>
       <dt class="text-muted">ココフォリア</dt>
       <dd class="font-sans">

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -17,15 +17,15 @@
 
   <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
     <dt class="text-muted">日時</dt>
-    <dd><%= play_session_schedule(@play_session) %></dd>
-    <dt class="text-muted">状態</dt>
-    <dd class="font-sans"><%= play_session_status_label(@play_session) %></dd>
-    <% if @play_session.recording_url.present? %>
-      <dt class="text-muted">録画</dt>
-      <dd class="space-y-2 font-sans">
-        <%= render "shared/video_link", title: "録画", url: @play_session.recording_url,
-              link_text: @play_session.recording_url, rel: "noopener", show_url: false %>
-      </dd>
+    <dd><%= play_session_schedule(@play_session) %>（<%= play_session_status_label(@play_session) %>）</dd>
+    <% @play_session.session_schedules.each do |schedule| %>
+      <% schedule.recording_links.each do |recording| %>
+        <dt class="text-muted">録画</dt>
+        <dd class="space-y-2 font-sans">
+          <%= render "shared/video_link", title: "録画", url: recording.url,
+                link_text: recording.url, rel: "noopener", show_url: false %>
+        </dd>
+      <% end %>
     <% end %>
     <% if @play_session.cocofolia_url.present? && policy(@play_session).show_cocofolia_url? %>
       <dt class="text-muted">ココフォリア</dt>

--- a/app/views/scenarios/_play_session_history.html.erb
+++ b/app/views/scenarios/_play_session_history.html.erb
@@ -7,8 +7,7 @@
       <% sessions.each do |session| %>
         <li>
           <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-3 no-underline text-ink hover:bg-paper" do %>
-            <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %></span>
-            <span class="text-xs text-muted"><%= play_session_status_label(session) %></span>
+            <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）</span>
             <span class="ml-auto text-xs text-muted">
               <%= session.participations.map { |p| p.person.display_name }.join("、") %>
             </span>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,11 +26,12 @@ ja:
   time:
     formats:
       short: "%Y-%m-%d %H:%M"
+      session_schedule: "%Y年%-m月%-d日（%a） %H:%M"
   play_sessions:
     statuses:
-      scheduled: 予定
-      played: 実施済み
-      cancelled: 中止
+      scheduled: 開催予定
+      in_progress: 開催中
+      completed: 開催済
     roles:
       gm: GM
       player: PL

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,7 +26,6 @@ ja:
   time:
     formats:
       short: "%Y-%m-%d %H:%M"
-      session_schedule: "%Y年%-m月%-d日（%a） %H:%M"
   play_sessions:
     statuses:
       scheduled: 開催予定
@@ -39,3 +38,4 @@ ja:
   date:
     formats:
       long: "%Y年%-m月%-d日"
+      with_weekday: "%Y年%-m月%-d日（%a）"

--- a/db/migrate/20260811170106_create_session_schedules_and_recording_links.rb
+++ b/db/migrate/20260811170106_create_session_schedules_and_recording_links.rb
@@ -2,11 +2,12 @@ class CreateSessionSchedulesAndRecordingLinks < ActiveRecord::Migration[8.1]
   def up
     create_table :session_schedules do |t|
       t.references :play_session, null: false, foreign_key: true
-      t.datetime :started_at
+      t.date :scheduled_on
+      t.time :started_at
       t.integer :position, null: false, default: 0
       t.timestamps
     end
-    add_index :session_schedules, [ :play_session_id, :started_at ]
+    add_index :session_schedules, [ :play_session_id, :scheduled_on, :started_at ]
 
     create_table :recording_links do |t|
       t.references :session_schedule, null: false, foreign_key: true
@@ -16,26 +17,66 @@ class CreateSessionSchedulesAndRecordingLinks < ActiveRecord::Migration[8.1]
     end
 
     execute <<~SQL
-      INSERT INTO session_schedules (play_session_id, started_at, position, created_at, updated_at)
-      SELECT id,
-             CASE WHEN played_on IS NULL THEN NULL
-                  ELSE played_on + COALESCE(started_at, TIME '00:00') END,
-             0, created_at, updated_at
-      FROM play_sessions
-      WHERE played_on IS NOT NULL OR NULLIF(recording_url, '') IS NOT NULL
+      CREATE FUNCTION sync_legacy_play_session_schedule() RETURNS trigger AS $$
+      DECLARE
+        schedule_id bigint;
+        recording_id bigint;
+      BEGIN
+        IF TG_OP = 'INSERT' AND NEW.played_on IS NULL AND NEW.started_at IS NULL
+          AND NULLIF(NEW.recording_url, '') IS NULL THEN
+          RETURN NEW;
+        END IF;
+
+        SELECT id INTO schedule_id FROM session_schedules
+        WHERE play_session_id = NEW.id ORDER BY position, id LIMIT 1;
+
+        IF schedule_id IS NULL THEN
+          IF NEW.played_on IS NULL AND NEW.started_at IS NULL AND NULLIF(NEW.recording_url, '') IS NULL THEN
+            RETURN NEW;
+          END IF;
+
+          INSERT INTO session_schedules
+            (play_session_id, scheduled_on, started_at, position, created_at, updated_at)
+          VALUES (NEW.id, NEW.played_on, NEW.started_at, 0, NEW.created_at, NEW.updated_at)
+          RETURNING id INTO schedule_id;
+        ELSE
+          UPDATE session_schedules
+          SET scheduled_on = NEW.played_on, started_at = NEW.started_at, updated_at = NEW.updated_at
+          WHERE id = schedule_id;
+        END IF;
+
+        SELECT id INTO recording_id FROM recording_links
+        WHERE session_schedule_id = schedule_id ORDER BY position, id LIMIT 1;
+
+        IF NULLIF(NEW.recording_url, '') IS NULL THEN
+          DELETE FROM recording_links WHERE id = recording_id;
+        ELSIF recording_id IS NULL THEN
+          INSERT INTO recording_links
+            (session_schedule_id, url, position, created_at, updated_at)
+          VALUES (schedule_id, NEW.recording_url, 0, NEW.created_at, NEW.updated_at);
+        ELSE
+          UPDATE recording_links SET url = NEW.recording_url, updated_at = NEW.updated_at
+          WHERE id = recording_id;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER sync_legacy_play_session_schedule
+      AFTER INSERT OR UPDATE OF played_on, started_at, recording_url ON play_sessions
+      FOR EACH ROW EXECUTE FUNCTION sync_legacy_play_session_schedule();
     SQL
 
     execute <<~SQL
-      INSERT INTO recording_links (session_schedule_id, url, position, created_at, updated_at)
-      SELECT session_schedules.id, play_sessions.recording_url, 0,
-             play_sessions.created_at, play_sessions.updated_at
-      FROM play_sessions
-      INNER JOIN session_schedules ON session_schedules.play_session_id = play_sessions.id
-      WHERE NULLIF(play_sessions.recording_url, '') IS NOT NULL
+      UPDATE play_sessions SET played_on = played_on
+      WHERE played_on IS NOT NULL OR started_at IS NOT NULL OR NULLIF(recording_url, '') IS NOT NULL
     SQL
   end
 
   def down
+    execute "DROP TRIGGER IF EXISTS sync_legacy_play_session_schedule ON play_sessions"
+    execute "DROP FUNCTION IF EXISTS sync_legacy_play_session_schedule()"
     drop_table :recording_links
     drop_table :session_schedules
   end

--- a/db/migrate/20260811170106_create_session_schedules_and_recording_links.rb
+++ b/db/migrate/20260811170106_create_session_schedules_and_recording_links.rb
@@ -1,0 +1,42 @@
+class CreateSessionSchedulesAndRecordingLinks < ActiveRecord::Migration[8.1]
+  def up
+    create_table :session_schedules do |t|
+      t.references :play_session, null: false, foreign_key: true
+      t.datetime :started_at
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :session_schedules, [ :play_session_id, :started_at ]
+
+    create_table :recording_links do |t|
+      t.references :session_schedule, null: false, foreign_key: true
+      t.string :url, null: false
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    execute <<~SQL
+      INSERT INTO session_schedules (play_session_id, started_at, position, created_at, updated_at)
+      SELECT id,
+             CASE WHEN played_on IS NULL THEN NULL
+                  ELSE played_on + COALESCE(started_at, TIME '00:00') END,
+             0, created_at, updated_at
+      FROM play_sessions
+      WHERE played_on IS NOT NULL OR NULLIF(recording_url, '') IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      INSERT INTO recording_links (session_schedule_id, url, position, created_at, updated_at)
+      SELECT session_schedules.id, play_sessions.recording_url, 0,
+             play_sessions.created_at, play_sessions.updated_at
+      FROM play_sessions
+      INNER JOIN session_schedules ON session_schedules.play_session_id = play_sessions.id
+      WHERE NULLIF(play_sessions.recording_url, '') IS NOT NULL
+    SQL
+  end
+
+  def down
+    drop_table :recording_links
+    drop_table :session_schedules
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_153058) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -147,6 +147,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153058) do
     t.index ["scenario_id"], name: "index_purchase_links_on_scenario_id"
   end
 
+  create_table "recording_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "position", default: 0, null: false
+    t.bigint "session_schedule_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.index ["session_schedule_id"], name: "index_recording_links_on_session_schedule_id"
+  end
+
   create_table "scenario_authors", force: :cascade do |t|
     t.bigint "author_id", null: false
     t.datetime "created_at", null: false
@@ -186,6 +195,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153058) do
     t.datetime "updated_at", null: false
     t.index ["position"], name: "index_scenarios_on_position"
     t.index ["title"], name: "index_scenarios_on_title"
+  end
+
+  create_table "session_schedules", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "play_session_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "started_at"
+    t.datetime "updated_at", null: false
+    t.index ["play_session_id", "started_at"], name: "index_session_schedules_on_play_session_id_and_started_at"
+    t.index ["play_session_id"], name: "index_session_schedules_on_play_session_id"
   end
 
   create_table "site_settings", force: :cascade do |t|
@@ -236,10 +255,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153058) do
   add_foreign_key "person_roles", "people"
   add_foreign_key "play_sessions", "scenarios"
   add_foreign_key "purchase_links", "scenarios"
+  add_foreign_key "recording_links", "session_schedules"
   add_foreign_key "scenario_authors", "authors"
   add_foreign_key "scenario_authors", "scenarios"
   add_foreign_key "scenario_game_systems", "game_systems"
   add_foreign_key "scenario_game_systems", "scenarios"
+  add_foreign_key "session_schedules", "play_sessions"
   add_foreign_key "spoiler_reveals", "people"
   add_foreign_key "spoiler_reveals", "scenarios"
   add_foreign_key "stream_links", "scenarios"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,9 +201,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
     t.datetime "created_at", null: false
     t.bigint "play_session_id", null: false
     t.integer "position", default: 0, null: false
-    t.datetime "started_at"
+    t.date "scheduled_on"
+    t.time "started_at"
     t.datetime "updated_at", null: false
-    t.index ["play_session_id", "started_at"], name: "index_session_schedules_on_play_session_id_and_started_at"
+    t.index ["play_session_id", "scheduled_on", "started_at"], name: "idx_on_play_session_id_scheduled_on_started_at_3d7aa28832"
     t.index ["play_session_id"], name: "index_session_schedules_on_play_session_id"
   end
 

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -43,8 +43,16 @@ end
 FactoryBot.define do
   factory :play_session do
     scenario
-    played_on { Date.new(2026, 5, 1) }
-    status { :played }
+  end
+
+  factory :session_schedule do
+    play_session
+    started_at { Time.zone.local(2026, 5, 1, 20) }
+  end
+
+  factory :recording_link do
+    session_schedule
+    sequence(:url) { |n| "https://youtu.be/recording#{n}" }
   end
 
   factory :participation do

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -47,7 +47,8 @@ FactoryBot.define do
 
   factory :session_schedule do
     play_session
-    started_at { Time.zone.local(2026, 5, 1, 20) }
+    scheduled_on { Date.new(2026, 5, 1) }
+    started_at { "20:00" }
   end
 
   factory :recording_link do

--- a/spec/migrations/create_session_schedules_and_recording_links_spec.rb
+++ b/spec/migrations/create_session_schedules_and_recording_links_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260811170106_create_session_schedules_and_recording_links")
+
+RSpec.describe CreateSessionSchedulesAndRecordingLinks do
+  self.use_transactional_tests = false
+
+  around do |example|
+    verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    migrate(:down)
+    example.run
+  ensure
+    RecordingLink.delete_all if RecordingLink.table_exists?
+    SessionSchedule.delete_all if SessionSchedule.table_exists?
+    PlaySession.delete_all
+    Scenario.delete_all
+    ActiveRecord::Migration.verbose = verbose
+    ActiveRecord::Base.connection.clear_cache!
+  end
+
+  def migrate(direction)
+    described_class.new.migrate(direction)
+    ActiveRecord::Base.connection.schema_cache.clear!
+    ActiveRecord::Base.connection.clear_cache!
+    [ PlaySession, SessionSchedule, RecordingLink ].each(&:reset_column_information)
+  end
+
+  def insert_legacy_session(attributes)
+    scenario = create(:scenario)
+    now = Time.current
+    PlaySession.insert_all!([ {
+      scenario_id: scenario.id, status: 0, created_at: now, updated_at: now
+    }.merge(attributes) ])
+    PlaySession.order(:id).last
+  end
+
+  it "preserves an existing local date, optional time and recording" do
+    session = insert_legacy_session(
+      played_on: Date.new(2026, 5, 1), started_at: nil, recording_url: "https://youtu.be/legacy"
+    )
+
+    migrate(:up)
+
+    schedule = SessionSchedule.find_by!(play_session_id: session.id)
+    expect(schedule).to have_attributes(scheduled_on: Date.new(2026, 5, 1), started_at: nil)
+    expect(schedule.recording_links.sole.url).to eq("https://youtu.be/legacy")
+  end
+
+  it "syncs writes made by an old pod after the migration" do
+    session = insert_legacy_session(played_on: nil, started_at: nil, recording_url: nil)
+    migrate(:up)
+
+    PlaySession.where(id: session.id).update_all(
+      played_on: Date.new(2026, 5, 3), started_at: "21:00", recording_url: "https://youtu.be/late"
+    )
+
+    schedule = SessionSchedule.find_by!(play_session_id: session.id)
+    expect(schedule.scheduled_on).to eq(Date.new(2026, 5, 3))
+    expect(schedule.started_at.strftime("%H:%M")).to eq("21:00")
+    expect(schedule.recording_links.sole.url).to eq("https://youtu.be/late")
+
+    PlaySession.where(id: session.id).update_all(played_on: nil, started_at: nil, recording_url: nil)
+
+    expect(schedule.reload).to have_attributes(scheduled_on: nil, started_at: nil)
+    expect(schedule.recording_links).to be_empty
+  end
+end

--- a/spec/models/play_session_spec.rb
+++ b/spec/models/play_session_spec.rb
@@ -5,35 +5,51 @@ RSpec.describe PlaySession do
     expect(build(:play_session, scenario: nil)).not_to be_valid
   end
 
-  describe "schedule" do
-    it "allows a date with no time, for a session whose start is not fixed yet" do
-      expect(build(:play_session, played_on: Date.new(2026, 9, 1), started_at: nil)).to be_valid
+  describe "schedules" do
+    it "keeps multiple starts in chronological order" do
+      session = create(:play_session)
+      later = create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 3, 20))
+      earlier = create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+
+      expect(session.session_schedules.reload).to eq([ earlier, later ])
     end
 
-    it "allows neither, for a session with no date at all" do
-      expect(build(:play_session, played_on: nil, started_at: nil)).to be_valid
+    it "destroys schedules and their recording links with the session" do
+      schedule = create(:session_schedule)
+      create(:recording_link, session_schedule: schedule)
+
+      expect { schedule.play_session.destroy! }
+        .to change(SessionSchedule, :count).by(-1)
+        .and change(RecordingLink, :count).by(-1)
     end
   end
 
   describe "status" do
-    it "defaults to scheduled" do
-      expect(described_class.new.status).to eq("scheduled")
+    it "is scheduled before the first start" do
+      session = create(:play_session)
+      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+
+      expect(session.derived_status(Time.zone.local(2026, 5, 1, 19, 59))).to eq(:scheduled)
     end
 
-    it "covers scheduled, played and cancelled" do
-      expect(described_class.statuses.keys).to match_array(%w[scheduled played cancelled])
+    it "is in progress from the first start until the last start" do
+      session = create(:play_session)
+      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 3, 20))
+
+      expect(session.derived_status(Time.zone.local(2026, 5, 2, 20))).to eq(:in_progress)
     end
 
-    it "is not derived from the date, so a past date can still be cancelled" do
-      session = build(:play_session, played_on: 1.year.ago.to_date, status: :cancelled)
+    it "is completed from the last start" do
+      session = create(:play_session)
+      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
 
-      expect(session).to be_valid
-      expect(session).to be_cancelled
+      expect(session.derived_status(Time.zone.local(2026, 5, 1, 20))).to eq(:completed)
     end
-  end
 
-  it "rejects a recording URL that is not an http URL" do
-    expect(build(:play_session, recording_url: "javascript:alert(1)")).not_to be_valid
+    it "treats an undated session as scheduled" do
+      expect(create(:play_session).derived_status).to eq(:scheduled)
+    end
   end
 
   it "rejects a Cocofolia URL that is not an http URL" do
@@ -41,17 +57,12 @@ RSpec.describe PlaySession do
   end
 
   describe "ordering" do
-    it "puts a session with no start time after one with a time on the same day" do
-      timed = create(:play_session, played_on: Date.new(2026, 5, 1), started_at: "20:00")
-      untimed = create(:play_session, played_on: Date.new(2026, 5, 1), started_at: nil)
-
-      expect(described_class.newest_first.to_a).to eq([ timed, untimed ])
-    end
-
-    it "puts undated sessions last rather than letting the database decide" do
-      undated = create(:play_session, played_on: nil)
-      older = create(:play_session, played_on: Date.new(2026, 1, 1))
-      newer = create(:play_session, played_on: Date.new(2026, 6, 1))
+    it "orders by the first start and puts undated sessions last" do
+      undated = create(:play_session)
+      older = create(:play_session)
+      newer = create(:play_session)
+      create(:session_schedule, play_session: older, started_at: Time.zone.local(2026, 1, 1, 20))
+      create(:session_schedule, play_session: newer, started_at: Time.zone.local(2026, 6, 1, 20))
 
       expect(described_class.newest_first.to_a).to eq([ newer, older, undated ])
     end

--- a/spec/models/play_session_spec.rb
+++ b/spec/models/play_session_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe PlaySession do
   describe "schedules" do
     it "keeps multiple starts in chronological order" do
       session = create(:play_session)
-      later = create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 3, 20))
-      earlier = create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+      later = create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 3))
+      earlier = create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 1))
 
       expect(session.session_schedules.reload).to eq([ earlier, later ])
     end
@@ -27,22 +27,31 @@ RSpec.describe PlaySession do
   describe "status" do
     it "is scheduled before the first start" do
       session = create(:play_session)
-      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+      create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 1))
 
       expect(session.derived_status(Time.zone.local(2026, 5, 1, 19, 59))).to eq(:scheduled)
     end
 
     it "is in progress from the first start until the last start" do
       session = create(:play_session)
-      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
-      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 3, 20))
+      create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 1))
+      create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 3))
+
+      expect(session.derived_status(Time.zone.local(2026, 5, 2, 20))).to eq(:in_progress)
+    end
+
+    it "uses chronological boundaries even when nested schedules arrive in reverse order" do
+      session = build(:play_session, session_schedules_attributes: [
+        { scheduled_on: "2026-05-03", started_at: "20:00" },
+        { scheduled_on: "2026-05-01", started_at: "20:00" }
+      ])
 
       expect(session.derived_status(Time.zone.local(2026, 5, 2, 20))).to eq(:in_progress)
     end
 
     it "is completed from the last start" do
       session = create(:play_session)
-      create(:session_schedule, play_session: session, started_at: Time.zone.local(2026, 5, 1, 20))
+      create(:session_schedule, play_session: session, scheduled_on: Date.new(2026, 5, 1))
 
       expect(session.derived_status(Time.zone.local(2026, 5, 1, 20))).to eq(:completed)
     end
@@ -61,8 +70,8 @@ RSpec.describe PlaySession do
       undated = create(:play_session)
       older = create(:play_session)
       newer = create(:play_session)
-      create(:session_schedule, play_session: older, started_at: Time.zone.local(2026, 1, 1, 20))
-      create(:session_schedule, play_session: newer, started_at: Time.zone.local(2026, 6, 1, 20))
+      create(:session_schedule, play_session: older, scheduled_on: Date.new(2026, 1, 1))
+      create(:session_schedule, play_session: newer, scheduled_on: Date.new(2026, 6, 1))
 
       expect(described_class.newest_first.to_a).to eq([ newer, older, undated ])
     end

--- a/spec/models/recording_link_spec.rb
+++ b/spec/models/recording_link_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe RecordingLink do
+  it "rejects a URL that is not an http URL" do
+    expect(build(:recording_link, url: "javascript:alert(1)")).not_to be_valid
+  end
+end

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe "Manage navigation" do
     end
 
     it "can edit a session" do
-      session = create(:play_session, status: :scheduled)
+      session = create(:play_session)
 
-      patch manage_play_session_path(session), params: { play_session: { status: "played" } }
+      patch manage_play_session_path(session), params: { play_session: { note: "管理者が更新" } }
 
-      expect(session.reload).to be_played
+      expect(session.reload.note).to eq("管理者が更新")
     end
   end
 

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -47,13 +47,14 @@ RSpec.describe "Manage::PlaySessions" do
           scenario_id: scenario.id,
           session_schedules_attributes: [
             {
-              started_at: "2026-05-01T20:00",
+              scheduled_on: "2026-05-01",
+              started_at: "20:00",
               recording_links_attributes: [
                 { url: "https://youtu.be/abc" },
                 { url: "https://youtu.be/def" }
               ]
             },
-            { started_at: "2026-05-03T20:00" }
+            { scheduled_on: "2026-05-03", started_at: "20:00" }
           ],
           cocofolia_url: "https://ccfolia.com/rooms/example",
           participations_attributes: [
@@ -67,11 +68,14 @@ RSpec.describe "Manage::PlaySessions" do
       session = PlaySession.sole
       expect(response).to redirect_to(play_session_path(session))
       expect(session.scenario).to eq(scenario)
-      expect(session.session_schedules.map(&:started_at)).to eq([
-        Time.zone.local(2026, 5, 1, 20), Time.zone.local(2026, 5, 3, 20)
+      expect(session.session_schedules.map(&:scheduled_on)).to eq([
+        Date.new(2026, 5, 1), Date.new(2026, 5, 3)
       ])
       expect(session.session_schedules.first.recording_links.map(&:url)).to eq(
         %w[https://youtu.be/abc https://youtu.be/def]
+      )
+      expect(session).to have_attributes(
+        played_on: Date.new(2026, 5, 1), recording_url: "https://youtu.be/abc"
       )
       expect(session.participations.map(&:role)).to contain_exactly("gm", "player")
       expect(session.cocofolia_url).to eq("https://ccfolia.com/rooms/example")

--- a/spec/requests/manage/play_sessions_spec.rb
+++ b/spec/requests/manage/play_sessions_spec.rb
@@ -45,10 +45,16 @@ RSpec.describe "Manage::PlaySessions" do
       post manage_play_sessions_path, params: {
         play_session: {
           scenario_id: scenario.id,
-          played_on: "2026-05-01",
-          started_at: "20:00",
-          status: "played",
-          recording_url: "https://youtu.be/abc",
+          session_schedules_attributes: [
+            {
+              started_at: "2026-05-01T20:00",
+              recording_links_attributes: [
+                { url: "https://youtu.be/abc" },
+                { url: "https://youtu.be/def" }
+              ]
+            },
+            { started_at: "2026-05-03T20:00" }
+          ],
           cocofolia_url: "https://ccfolia.com/rooms/example",
           participations_attributes: [
             { person_id: gm.id, role: "gm" },
@@ -61,6 +67,12 @@ RSpec.describe "Manage::PlaySessions" do
       session = PlaySession.sole
       expect(response).to redirect_to(play_session_path(session))
       expect(session.scenario).to eq(scenario)
+      expect(session.session_schedules.map(&:started_at)).to eq([
+        Time.zone.local(2026, 5, 1, 20), Time.zone.local(2026, 5, 3, 20)
+      ])
+      expect(session.session_schedules.first.recording_links.map(&:url)).to eq(
+        %w[https://youtu.be/abc https://youtu.be/def]
+      )
       expect(session.participations.map(&:role)).to contain_exactly("gm", "player")
       expect(session.cocofolia_url).to eq("https://ccfolia.com/rooms/example")
       expect(session.participations.find(&:player?).character_sheet_url).to eq("https://charasheet.example/1")
@@ -163,13 +175,16 @@ RSpec.describe "Manage::PlaySessions" do
       expect { delete manage_play_session_path(session) }.to change(PlaySession, :count).by(-1)
     end
 
-    it "updates a session" do
-      session = create(:play_session, scenario:, status: :scheduled)
+    it "updates and removes nested schedules" do
+      session = create(:play_session, scenario:)
+      schedule = create(:session_schedule, play_session: session)
 
-      patch manage_play_session_path(session), params: { play_session: { status: "played" } }
+      patch manage_play_session_path(session), params: {
+        play_session: { session_schedules_attributes: [ { id: schedule.id, _destroy: "1" } ] }
+      }
 
       expect(response).to redirect_to(play_session_path(session))
-      expect(session.reload).to be_played
+      expect(session.reload.session_schedules).to be_empty
     end
   end
 

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "PlaySessions" do
   let(:scenario) { create(:scenario, title: "見本シナリオ") }
   let(:session) do
     create(:play_session, scenario:).tap do |play_session|
-      create(:session_schedule, play_session:, started_at: Time.zone.local(2026, 5, 1, 20))
+      create(:session_schedule, play_session:, scheduled_on: Date.new(2026, 5, 1))
     end
   end
 
@@ -135,7 +135,7 @@ RSpec.describe "PlaySessions" do
 
     it "shows every recording under its schedule" do
       second_schedule = create(:session_schedule, play_session: session,
-        started_at: Time.zone.local(2026, 5, 3, 20))
+        scheduled_on: Date.new(2026, 5, 3))
       create(:recording_link, session_schedule: session.session_schedules.first,
         url: "https://videos.example/first")
       create(:recording_link, session_schedule: second_schedule,
@@ -145,8 +145,14 @@ RSpec.describe "PlaySessions" do
       get play_session_path(session)
 
       expect(response.body).to include("https://videos.example/first", "https://videos.example/second")
-      expect(response.body).to include("2026年5月1日（金） 20:00、2026年5月3日（日） 20:00")
       expect(response.body).not_to include(">状態<")
+      page = Capybara.string(response.body)
+      schedule_sections = page.all("[data-session-schedule]")
+      expect(schedule_sections.first).to have_text("2026年5月1日（金） 20:00")
+        .and have_text("https://videos.example/first")
+        .and have_no_text("https://videos.example/second")
+      expect(schedule_sections[1]).to have_text("2026年5月3日（日） 20:00")
+        .and have_text("https://videos.example/second")
     end
 
     it "shows the start time without the placeholder date a time column carries" do

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe "PlaySessions" do
   let(:group) { create(:group) }
   let(:participant) { create(:person, display_name: "参加した人", groups: [ group ]) }
   let(:scenario) { create(:scenario, title: "見本シナリオ") }
-  let(:session) { create(:play_session, scenario:, played_on: Date.new(2026, 5, 1), status: :played) }
+  let(:session) do
+    create(:play_session, scenario:).tap do |play_session|
+      create(:session_schedule, play_session:, started_at: Time.zone.local(2026, 5, 1, 20))
+    end
+  end
 
   before do
     session.participations.create!(person: participant, role: :gm)
@@ -103,7 +107,7 @@ RSpec.describe "PlaySessions" do
         character_name: "探索者A",
         character_sheet_url: "https://charasheet.example/1234"
       )
-      session.update!(recording_url: "https://youtu.be/abc")
+      create(:recording_link, session_schedule: session.session_schedules.first, url: "https://youtu.be/abc")
       sign_in_as create(:person, groups: [ group ])
 
       get play_session_path(session)
@@ -114,7 +118,8 @@ RSpec.describe "PlaySessions" do
     end
 
     it "embeds a YouTube recording" do
-      session.update!(recording_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      create(:recording_link, session_schedule: session.session_schedules.first,
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
       sign_in_as create(:person, groups: [ group ])
 
       get play_session_path(session)
@@ -128,13 +133,28 @@ RSpec.describe "PlaySessions" do
       expect(page).to have_no_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
     end
 
-    it "shows the start time without the placeholder date a time column carries" do
-      session.update!(started_at: "20:00")
+    it "shows every recording under its schedule" do
+      second_schedule = create(:session_schedule, play_session: session,
+        started_at: Time.zone.local(2026, 5, 3, 20))
+      create(:recording_link, session_schedule: session.session_schedules.first,
+        url: "https://videos.example/first")
+      create(:recording_link, session_schedule: second_schedule,
+        url: "https://videos.example/second")
       sign_in_as create(:person, groups: [ group ])
 
       get play_session_path(session)
 
-      expect(response.body).to include("2026年5月1日 20:00")
+      expect(response.body).to include("https://videos.example/first", "https://videos.example/second")
+      expect(response.body).to include("2026年5月1日（金） 20:00、2026年5月3日（日） 20:00")
+      expect(response.body).not_to include(">状態<")
+    end
+
+    it "shows the start time without the placeholder date a time column carries" do
+      sign_in_as create(:person, groups: [ group ])
+
+      get play_session_path(session)
+
+      expect(response.body).to include("2026年5月1日（金） 20:00")
       expect(response.body).not_to include("2000-01-01")
     end
 


### PR DESCRIPTION
## What

- Add multiple schedules and per-schedule recording links to play sessions
- Derive session status from the first and last start times and show weekdays
- Backfill existing schedule and recording data into the new associations

## Why

Long-running scenarios can span multiple days and produce multiple recordings.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #50

<!-- Phase plan or ADR this PR belongs to -->