### PR TITLE
Add alias management for systems, authors, and members

### DIFF
--- a/app/controllers/manage/masters_controller.rb
+++ b/app/controllers/manage/masters_controller.rb
@@ -52,7 +52,8 @@ module Manage
       end
 
       def record_params
-        params.expect(model_class.model_name.param_key.to_sym => [ :name ])
+        params.expect(model_class.model_name.param_key.to_sym => [ :name, :display_alias_id,
+          { aliases_attributes: [ [ :id, :name, :visible, :position, :_destroy ] ] } ])
       end
   end
 end

--- a/app/controllers/manage/masters_controller.rb
+++ b/app/controllers/manage/masters_controller.rb
@@ -52,8 +52,8 @@ module Manage
       end
 
       def record_params
-        params.expect(model_class.model_name.param_key.to_sym => [ :name, :display_alias_id,
-          { aliases_attributes: [ [ :id, :name, :visible, :position, :_destroy ] ] } ])
+        params.expect(model_class.model_name.param_key.to_sym => [ :name, :display_alias_key,
+          { aliases_attributes: [ [ :id, :name, :visible, :position, :selection_key, :_destroy ] ] } ])
       end
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -31,8 +31,8 @@ class PeopleController < ApplicationController
 
     # グループ所属はここでは受け取らない。管理画面（管理者のみ）で扱う。
     def person_params
-      params.expect(person: [ :display_name, :display_alias_id, :x_account, :icon,
-        { aliases_attributes: [ [ :id, :name, :context, :visible, :position, :_destroy ] ],
+      params.expect(person: [ :display_name, :display_alias_key, :x_account, :icon,
+        { aliases_attributes: [ [ :id, :name, :context, :visible, :position, :selection_key, :_destroy ] ],
           person_aliases_attributes: [ [ :id, :name, :context, :visible, :position, :_destroy ] ] } ])
     end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,7 +3,7 @@ class PeopleController < ApplicationController
 
   def index
     authorize Person
-    @people = policy_scope(Person).includes(:person_aliases, :groups).with_attached_icon
+    @people = policy_scope(Person).includes(:aliases, :groups).with_attached_icon
   end
 
   def show
@@ -31,7 +31,8 @@ class PeopleController < ApplicationController
 
     # グループ所属はここでは受け取らない。管理画面（管理者のみ）で扱う。
     def person_params
-      params.expect(person: [ :display_name, :x_account, :icon,
-        { person_aliases_attributes: [ [ :id, :name, :context, :position, :_destroy ] ] } ])
+      params.expect(person: [ :display_name, :display_alias_id, :x_account, :icon,
+        { aliases_attributes: [ [ :id, :name, :context, :visible, :position, :_destroy ] ],
+          person_aliases_attributes: [ [ :id, :name, :context, :visible, :position, :_destroy ] ] } ])
     end
 end

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -2,11 +2,31 @@ import { Controller } from "@hotwired/stimulus"
 
 // 入手先と配信リンクの行を増やす。増やした行は保存時にまとめて送られる。
 export default class extends Controller {
-  static targets = ["template", "anchor"]
+  static targets = ["template", "anchor", "aliasName", "aliasSelect"]
   static values = { token: { type: String, default: "NEW_RECORD" } }
+
+  connect() {
+    this.syncAliasOptions()
+  }
 
   add() {
     const html = this.templateTarget.innerHTML.replaceAll(this.tokenValue, new Date().getTime())
     this.anchorTarget.insertAdjacentHTML("beforebegin", html)
+    this.syncAliasOptions()
+  }
+
+  syncAliasOptions() {
+    if (!this.hasAliasSelectTarget) return
+
+    const selected = this.aliasSelectTarget.value
+    const options = [new Option(this.aliasSelectTarget.dataset.baseLabel, "")]
+
+    this.aliasNameTargets.forEach((input) => {
+      const name = input.value.trim()
+      if (name !== "") options.push(new Option(name, input.dataset.selectionKey))
+    })
+
+    this.aliasSelectTarget.replaceChildren(...options)
+    if (options.some((option) => option.value === selected)) this.aliasSelectTarget.value = selected
   }
 }

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // 入手先と配信リンクの行を増やす。増やした行は保存時にまとめて送られる。
 export default class extends Controller {
-  static targets = ["template", "anchor", "aliasName", "aliasSelect"]
+  static targets = ["template", "anchor", "aliasRow", "aliasSelect"]
   static values = { token: { type: String, default: "NEW_RECORD" } }
 
   connect() {
@@ -21,9 +21,14 @@ export default class extends Controller {
     const selected = this.aliasSelectTarget.value
     const options = [new Option(this.aliasSelectTarget.dataset.baseLabel, "")]
 
-    this.aliasNameTargets.forEach((input) => {
-      const name = input.value.trim()
-      if (name !== "") options.push(new Option(name, input.dataset.selectionKey))
+    this.aliasRowTargets.forEach((row) => {
+      const name = row.querySelector("[data-alias-name]")
+      const visible = row.querySelector("[data-alias-visible]")
+      const destroy = row.querySelector("[data-alias-destroy]")
+
+      if (name.value.trim() !== "" && visible.checked && !destroy.checked) {
+        options.push(new Option(name.value.trim(), name.dataset.selectionKey))
+      }
     })
 
     this.aliasSelectTarget.replaceChildren(...options)

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,4 +1,9 @@
 class Author < ApplicationRecord
+  DISPLAY_NAME_ATTRIBUTE = :name
+
+  has_many :aliases, -> { order(:position, :id) }, class_name: "AuthorAlias", dependent: :destroy,
+    inverse_of: :author
+  include HasAliases
   has_many :scenario_authors, dependent: :destroy
   has_many :scenarios, through: :scenario_authors
 

--- a/app/models/author_alias.rb
+++ b/app/models/author_alias.rb
@@ -1,4 +1,6 @@
 class AuthorAlias < ApplicationRecord
+  attr_accessor :selection_key
+
   belongs_to :author
 
   validates :name, presence: true

--- a/app/models/author_alias.rb
+++ b/app/models/author_alias.rb
@@ -1,0 +1,5 @@
+class AuthorAlias < ApplicationRecord
+  belongs_to :author
+
+  validates :name, presence: true
+end

--- a/app/models/concerns/has_aliases.rb
+++ b/app/models/concerns/has_aliases.rb
@@ -2,31 +2,45 @@ module HasAliases
   extend ActiveSupport::Concern
 
   included do
-    attr_accessor :display_alias_id
+    attr_accessor :display_alias_key
 
     accepts_nested_attributes_for :aliases, allow_destroy: true,
       reject_if: ->(attrs) { attrs["id"].blank? && attrs["name"].blank? }
 
     before_validation :promote_selected_alias
+    after_validation :restore_names_after_failed_promotion
   end
 
   def visible_aliases = aliases.select(&:visible?)
 
   private
     def promote_selected_alias
-      selected_id = display_alias_id.presence
-      return if selected_id.blank?
+      selected_key = display_alias_key.presence
+      return if selected_key.blank? || @promotion_applied
 
-      selected = aliases.detect { |item| item.id.to_s == selected_id.to_s && !item.marked_for_destruction? }
+      selected = aliases.detect do |item|
+        [ item.selection_key, item.id ].compact.map(&:to_s).include?(selected_key.to_s) && !item.marked_for_destruction?
+      end
       unless selected&.visible?
-        errors.add(:display_alias_id, "は表示する名前から選んでください")
+        errors.add(:display_alias_key, "は表示する名前から選んでください")
         return
       end
 
-      previous_name = alias_display_name
+      @promoted_alias = selected
+      @previous_display_name = alias_display_name
+      @promotion_applied = true
       self.alias_display_name = selected.name
-      selected.name = previous_name
+      selected.name = @previous_display_name
       selected.visible = true
+    end
+
+    def restore_names_after_failed_promotion
+      return unless errors.any? && @promotion_applied
+
+      selected_name = alias_display_name
+      self.alias_display_name = @previous_display_name
+      @promoted_alias.name = selected_name
+      @promotion_applied = false
     end
 
     def alias_display_name

--- a/app/models/concerns/has_aliases.rb
+++ b/app/models/concerns/has_aliases.rb
@@ -1,0 +1,39 @@
+module HasAliases
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :display_alias_id
+
+    accepts_nested_attributes_for :aliases, allow_destroy: true,
+      reject_if: ->(attrs) { attrs["id"].blank? && attrs["name"].blank? }
+
+    before_validation :promote_selected_alias
+  end
+
+  def visible_aliases = aliases.select(&:visible?)
+
+  private
+    def promote_selected_alias
+      selected_id = display_alias_id.presence
+      return if selected_id.blank?
+
+      selected = aliases.detect { |item| item.id.to_s == selected_id.to_s && !item.marked_for_destruction? }
+      unless selected&.visible?
+        errors.add(:display_alias_id, "は表示する名前から選んでください")
+        return
+      end
+
+      previous_name = alias_display_name
+      self.alias_display_name = selected.name
+      selected.name = previous_name
+      selected.visible = true
+    end
+
+    def alias_display_name
+      public_send(self.class::DISPLAY_NAME_ATTRIBUTE)
+    end
+
+    def alias_display_name=(value)
+      public_send("#{self.class::DISPLAY_NAME_ATTRIBUTE}=", value)
+    end
+end

--- a/app/models/game_system.rb
+++ b/app/models/game_system.rb
@@ -1,4 +1,9 @@
 class GameSystem < ApplicationRecord
+  DISPLAY_NAME_ATTRIBUTE = :name
+
+  has_many :aliases, -> { order(:position, :id) }, class_name: "GameSystemAlias", dependent: :destroy,
+    inverse_of: :game_system
+  include HasAliases
   has_many :scenario_game_systems, dependent: :destroy
   has_many :scenarios, through: :scenario_game_systems
 

--- a/app/models/game_system_alias.rb
+++ b/app/models/game_system_alias.rb
@@ -1,4 +1,6 @@
 class GameSystemAlias < ApplicationRecord
+  attr_accessor :selection_key
+
   belongs_to :game_system
 
   validates :name, presence: true

--- a/app/models/game_system_alias.rb
+++ b/app/models/game_system_alias.rb
@@ -1,0 +1,5 @@
+class GameSystemAlias < ApplicationRecord
+  belongs_to :game_system
+
+  validates :name, presence: true
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,11 +1,15 @@
 class Person < ApplicationRecord
+  DISPLAY_NAME_ATTRIBUTE = :display_name
   has_one_attached :icon do |attachable|
     attachable.variant :thumb, resize_to_fill: [ 160, 160 ], format: :webp, saver: { quality: 80 }
   end
 
   has_one :user, dependent: :nullify
   has_many :person_roles, dependent: :destroy
-  has_many :person_aliases, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :person
+  has_many :aliases, -> { order(:position, :id) }, class_name: "PersonAlias", dependent: :destroy,
+    inverse_of: :person
+  alias_method :person_aliases, :aliases
+  include HasAliases
   has_many :favorites, dependent: :destroy
   has_many :favorite_scenarios, through: :favorites, source: :scenario
   has_many :spoiler_reveals, dependent: :destroy
@@ -30,8 +34,7 @@ class Person < ApplicationRecord
   def player? = true
 
   # 既存行の名前を空にしたときは無視せず検証に落とす。新規の空行だけ捨てる。
-  accepts_nested_attributes_for :person_aliases, allow_destroy: true,
-    reject_if: ->(attrs) { attrs["id"].blank? && attrs["name"].blank? }
+  alias_method :person_aliases_attributes=, :aliases_attributes=
 
   # 未知の値が入った行は名前を引けない。表示側でロケール全体を出さないよう落とす。
   def roles = person_roles.map(&:name).compact

--- a/app/models/person_alias.rb
+++ b/app/models/person_alias.rb
@@ -1,4 +1,6 @@
 class PersonAlias < ApplicationRecord
+  attr_accessor :selection_key
+
   belongs_to :person
 
   validates :name, presence: true

--- a/app/views/manage/masters/edit.html.erb
+++ b/app/views/manage/masters/edit.html.erb
@@ -7,10 +7,8 @@
     <p class="text-sm text-seal"><%= @record.errors.full_messages.join("、") %></p>
   <% end %>
 
-  <div>
-    <%= form.label :name, "名前", class: "block text-xs text-muted" %>
-    <%= form.text_field :name, class: "mt-1 w-64 border border-rule bg-paper px-3 py-2 text-sm" %>
-  </div>
+  <%= render "shared/alias_fields", form: form, display_attribute: :name,
+        alias_class: @record.class.reflect_on_association(:aliases).klass %>
 
   <div class="flex gap-4">
     <%= form.submit "更新", class: "bg-ink px-5 py-2 text-sm text-paper" %>

--- a/app/views/manage/masters/show.html.erb
+++ b/app/views/manage/masters/show.html.erb
@@ -6,6 +6,10 @@
     <%= link_to "編集", url_for(action: :edit, id: @record), class: "text-sm text-seal" %>
   </div>
 
+  <% if @record.visible_aliases.any? %>
+    <p class="mt-3 text-sm text-muted">別名: <%= @record.visible_aliases.map(&:name).join("、") %></p>
+  <% end %>
+
   <% if @record.respond_to?(:scenarios) %>
     <section class="mt-8">
       <h2 class="font-display text-xl">シナリオ</h2>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -11,10 +11,6 @@
     <legend class="px-2 font-display text-sm">あなたのこと</legend>
     <div class="grid gap-4 sm:grid-cols-2">
       <div>
-        <%= form.label :display_name, "表示名", class: "block text-xs text-muted" %>
-        <%= form.text_field :display_name, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-      </div>
-      <div>
         <%= form.label :x_account, "X のアカウント名（@ は不要）", class: "block text-xs text-muted" %>
         <%= form.text_field :x_account, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
       </div>
@@ -25,26 +21,7 @@
     </div>
   </fieldset>
 
-  <fieldset class="border border-rule bg-surface p-5">
-    <legend class="px-2 font-display text-sm">別名</legend>
-    <p class="text-xs text-muted">Discord のサーバごとに名前を変えている場合に使います。</p>
-
-    <div class="mt-3 space-y-3" data-controller="nested-form">
-      <template data-nested-form-target="template">
-        <%= form.fields_for :person_aliases, PersonAlias.new, child_index: "NEW_RECORD" do |row| %>
-          <%= render "alias_row", row: row %>
-        <% end %>
-      </template>
-
-      <%= form.fields_for :person_aliases do |row| %>
-        <%= render "alias_row", row: row %>
-      <% end %>
-
-      <div data-nested-form-target="anchor"></div>
-
-      <button type="button" data-action="nested-form#add" class="cursor-pointer text-sm text-seal">別名を足す</button>
-    </div>
-  </fieldset>
+  <%= render "shared/alias_fields", form: form, display_attribute: :display_name, alias_class: PersonAlias %>
 
   <p class="text-xs text-muted">グループの所属は管理者が設定します。</p>
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -13,8 +13,8 @@
         </span>
         <span>
           <span class="block font-display"><%= member.display_name %></span>
-          <% if member.person_aliases.any? %>
-            <span class="block text-xs text-muted"><%= member.person_aliases.map(&:name).join("、") %></span>
+          <% if member.visible_aliases.any? %>
+            <span class="block text-xs text-muted"><%= member.visible_aliases.map(&:name).join("、") %></span>
           <% end %>
         </span>
       <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -31,11 +31,11 @@
     </div>
   </div>
 
-  <% if @person.person_aliases.any? %>
+  <% if @person.visible_aliases.any? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">別名</h2>
       <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-        <% @person.person_aliases.each do |person_alias| %>
+        <% @person.visible_aliases.each do |person_alias| %>
           <li class="flex items-baseline gap-4 p-3">
             <span class="font-display"><%= person_alias.name %></span>
             <span class="text-xs text-muted"><%= person_alias.context %></span>

--- a/app/views/shared/_alias_fields.html.erb
+++ b/app/views/shared/_alias_fields.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="mt-3 space-y-3" data-controller="nested-form"
-       data-action="input->nested-form#syncAliasOptions">
+       data-action="input->nested-form#syncAliasOptions change->nested-form#syncAliasOptions">
     <template data-nested-form-target="template">
       <%= form.fields_for :aliases, alias_class.new, child_index: "NEW_RECORD" do |row| %>
         <%= render "shared/alias_row", form: form, row: row %>

--- a/app/views/shared/_alias_fields.html.erb
+++ b/app/views/shared/_alias_fields.html.erb
@@ -2,14 +2,18 @@
   <legend class="px-2 font-display text-sm">名前</legend>
   <p class="text-xs text-muted">表示名は一覧や詳細で使われ、常に公開されます。</p>
 
-  <div class="mt-3 grid gap-2 sm:grid-cols-[auto_1fr_auto_auto]">
-    <span class="self-center text-xs text-muted">表示名</span>
-    <%= form.text_field display_attribute, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
-    <span class="self-center text-xs text-muted">表示</span>
-    <span></span>
+  <div class="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+    <%= form.text_field display_attribute, class: "w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+    <label class="inline-flex items-center gap-1 text-xs text-muted">
+      <%= check_box_tag nil, nil, true, disabled: true %> 表示
+    </label>
+    <label class="inline-flex items-center gap-1 text-xs text-muted">
+      <%= check_box_tag nil, nil, false, disabled: true %> 削除
+    </label>
   </div>
 
-  <div class="mt-3 space-y-3" data-controller="nested-form">
+  <div class="mt-3 space-y-3" data-controller="nested-form"
+       data-action="input->nested-form#syncAliasOptions">
     <template data-nested-form-target="template">
       <%= form.fields_for :aliases, alias_class.new, child_index: "NEW_RECORD" do |row| %>
         <%= render "shared/alias_row", form: form, row: row %>
@@ -22,5 +26,18 @@
 
     <div data-nested-form-target="anchor"></div>
     <button type="button" data-action="nested-form#add" class="cursor-pointer text-sm text-seal">名前を足す</button>
+
+    <div class="pt-3">
+      <%= form.label :display_alias_key, "表示名", class: "block text-xs text-muted" %>
+      <%= form.select :display_alias_key,
+            [ [ "#{form.object.public_send(display_attribute)}（現在の表示名）", "" ] ] +
+              form.object.aliases.map { |item| [ item.name, item.selection_key.presence || item.id ] },
+            {},
+            class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm",
+            data: {
+              nested_form_target: "aliasSelect",
+              base_label: "#{form.object.public_send(display_attribute)}（現在の表示名）"
+            } %>
+    </div>
   </div>
 </fieldset>

--- a/app/views/shared/_alias_fields.html.erb
+++ b/app/views/shared/_alias_fields.html.erb
@@ -1,0 +1,26 @@
+<fieldset class="border border-rule bg-surface p-5">
+  <legend class="px-2 font-display text-sm">名前</legend>
+  <p class="text-xs text-muted">表示名は一覧や詳細で使われ、常に公開されます。</p>
+
+  <div class="mt-3 grid gap-2 sm:grid-cols-[auto_1fr_auto_auto]">
+    <span class="self-center text-xs text-muted">表示名</span>
+    <%= form.text_field display_attribute, class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+    <span class="self-center text-xs text-muted">表示</span>
+    <span></span>
+  </div>
+
+  <div class="mt-3 space-y-3" data-controller="nested-form">
+    <template data-nested-form-target="template">
+      <%= form.fields_for :aliases, alias_class.new, child_index: "NEW_RECORD" do |row| %>
+        <%= render "shared/alias_row", form: form, row: row %>
+      <% end %>
+    </template>
+
+    <%= form.fields_for :aliases do |row| %>
+      <%= render "shared/alias_row", form: form, row: row %>
+    <% end %>
+
+    <div data-nested-form-target="anchor"></div>
+    <button type="button" data-action="nested-form#add" class="cursor-pointer text-sm text-seal">名前を足す</button>
+  </div>
+</fieldset>

--- a/app/views/shared/_alias_row.html.erb
+++ b/app/views/shared/_alias_row.html.erb
@@ -1,11 +1,8 @@
 <div class="grid gap-2 sm:grid-cols-[auto_1fr_auto_auto]">
-  <% if row.object.persisted? && row.object.visible? %>
-    <label class="inline-flex items-center gap-1 text-xs text-muted">
-      <%= form.radio_button :display_alias_id, row.object.id %> 表示名
-    </label>
-  <% else %>
-    <span class="self-center text-xs text-muted">別名</span>
-  <% end %>
+  <% selection_key = row.object.id || row.index %>
+  <label class="inline-flex items-center gap-1 text-xs text-muted">
+    <%= form.radio_button :display_alias_key, selection_key %> 表示名
+  </label>
   <%= row.text_field :name, placeholder: "別名", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
   <label class="inline-flex items-center gap-1 text-xs text-muted">
     <%= row.check_box :visible %> 表示
@@ -14,4 +11,9 @@
     <%= row.check_box :_destroy %> 削除
   </label>
   <%= row.hidden_field :id if row.object.persisted? %>
+  <%= row.hidden_field :selection_key, value: selection_key %>
+  <% if row.object.respond_to?(:context) %>
+    <%= row.text_field :context, placeholder: "どこでの名前か",
+          class: "border border-rule bg-paper px-3 py-2 text-sm sm:col-start-2" %>
+  <% end %>
 </div>

--- a/app/views/shared/_alias_row.html.erb
+++ b/app/views/shared/_alias_row.html.erb
@@ -1,12 +1,12 @@
-<div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+<div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]" data-nested-form-target="aliasRow">
   <% selection_key = row.object.selection_key.presence || row.object.id || row.index %>
   <%= row.text_field :name, placeholder: "別名", class: "w-full border border-rule bg-paper px-3 py-2 text-sm",
-        data: { nested_form_target: "aliasName", selection_key: selection_key } %>
+        data: { alias_name: true, selection_key: selection_key } %>
   <label class="inline-flex items-center gap-1 text-xs text-muted">
-    <%= row.check_box :visible %> 表示
+    <%= row.check_box :visible, data: { alias_visible: true } %> 表示
   </label>
   <label class="inline-flex items-center gap-1 text-xs text-muted">
-    <%= row.check_box :_destroy %> 削除
+    <%= row.check_box :_destroy, data: { alias_destroy: true } %> 削除
   </label>
   <%= row.hidden_field :id if row.object.persisted? %>
   <%= row.hidden_field :selection_key, value: selection_key %>

--- a/app/views/shared/_alias_row.html.erb
+++ b/app/views/shared/_alias_row.html.erb
@@ -1,9 +1,7 @@
-<div class="grid gap-2 sm:grid-cols-[auto_1fr_auto_auto]">
-  <% selection_key = row.object.id || row.index %>
-  <label class="inline-flex items-center gap-1 text-xs text-muted">
-    <%= form.radio_button :display_alias_key, selection_key %> 表示名
-  </label>
-  <%= row.text_field :name, placeholder: "別名", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+<div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+  <% selection_key = row.object.selection_key.presence || row.object.id || row.index %>
+  <%= row.text_field :name, placeholder: "別名", class: "w-full border border-rule bg-paper px-3 py-2 text-sm",
+        data: { nested_form_target: "aliasName", selection_key: selection_key } %>
   <label class="inline-flex items-center gap-1 text-xs text-muted">
     <%= row.check_box :visible %> 表示
   </label>
@@ -14,6 +12,6 @@
   <%= row.hidden_field :selection_key, value: selection_key %>
   <% if row.object.respond_to?(:context) %>
     <%= row.text_field :context, placeholder: "どこでの名前か",
-          class: "border border-rule bg-paper px-3 py-2 text-sm sm:col-start-2" %>
+          class: "w-full border border-rule bg-paper px-3 py-2 text-sm sm:col-start-1" %>
   <% end %>
 </div>

--- a/app/views/shared/_alias_row.html.erb
+++ b/app/views/shared/_alias_row.html.erb
@@ -1,0 +1,17 @@
+<div class="grid gap-2 sm:grid-cols-[auto_1fr_auto_auto]">
+  <% if row.object.persisted? && row.object.visible? %>
+    <label class="inline-flex items-center gap-1 text-xs text-muted">
+      <%= form.radio_button :display_alias_id, row.object.id %> 表示名
+    </label>
+  <% else %>
+    <span class="self-center text-xs text-muted">別名</span>
+  <% end %>
+  <%= row.text_field :name, placeholder: "別名", class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+  <label class="inline-flex items-center gap-1 text-xs text-muted">
+    <%= row.check_box :visible %> 表示
+  </label>
+  <label class="inline-flex items-center gap-1 text-xs text-muted">
+    <%= row.check_box :_destroy %> 削除
+  </label>
+  <%= row.hidden_field :id if row.object.persisted? %>
+</div>

--- a/db/migrate/20260812000000_add_aliases.rb
+++ b/db/migrate/20260812000000_add_aliases.rb
@@ -1,0 +1,21 @@
+class AddAliases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :person_aliases, :visible, :boolean, null: false, default: true
+
+    create_table :game_system_aliases do |t|
+      t.references :game_system, null: false, foreign_key: true
+      t.string :name, null: false
+      t.boolean :visible, null: false, default: true
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    create_table :author_aliases do |t|
+      t.references :author, null: false, foreign_key: true
+      t.string :name, null: false
+      t.boolean :visible, null: false, default: true
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "author_aliases", force: :cascade do |t|
+    t.bigint "author_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visible", default: true, null: false
+    t.index ["author_id"], name: "index_author_aliases_on_author_id"
+  end
+
   create_table "authors", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
@@ -57,6 +67,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
     t.index ["person_id", "scenario_id"], name: "index_favorites_on_person_id_and_scenario_id", unique: true
     t.index ["person_id"], name: "index_favorites_on_person_id"
     t.index ["scenario_id"], name: "index_favorites_on_scenario_id"
+  end
+
+  create_table "game_system_aliases", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "game_system_id", null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visible", default: true, null: false
+    t.index ["game_system_id"], name: "index_game_system_aliases_on_game_system_id"
   end
 
   create_table "game_systems", force: :cascade do |t|
@@ -111,6 +131,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
     t.bigint "person_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.boolean "visible", default: true, null: false
     t.index ["person_id"], name: "index_person_aliases_on_person_id"
   end
 
@@ -246,8 +267,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_170106) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "author_aliases", "authors"
   add_foreign_key "favorites", "people"
   add_foreign_key "favorites", "scenarios"
+  add_foreign_key "game_system_aliases", "game_systems"
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "people"
   add_foreign_key "participations", "people"

--- a/spec/models/aliases_spec.rb
+++ b/spec/models/aliases_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Aliases" do
+  shared_examples "a named record with aliases" do |factory, display_attribute, alias_class|
+    let(:record) { create(factory) }
+
+    it "holds multiple visible and hidden names" do
+      record.aliases.create!(name: "公開名", visible: true)
+      record.aliases.create!(name: "非公開名", visible: false)
+
+      expect(record.visible_aliases.map(&:name)).to eq([ "公開名" ])
+    end
+
+    it "promotes a visible alias and keeps the former display name" do
+      former_name = record.public_send(display_attribute)
+      selected = record.aliases.create!(name: "新しい表示名", visible: true)
+
+      expect(record.update(display_alias_id: selected.id)).to be(true)
+      expect(record.reload.public_send(display_attribute)).to eq("新しい表示名")
+      expect(selected.reload.attributes.slice("name", "visible")).to eq("name" => former_name, "visible" => true)
+    end
+
+    it "does not promote a hidden alias" do
+      selected = record.aliases.create!(name: "非公開名", visible: false)
+
+      expect(record.update(display_alias_id: selected.id)).to be(false)
+      expect(record.errors[:display_alias_id]).to be_present
+    end
+
+    it "removes aliases with the parent" do
+      record.aliases.create!(name: "別名")
+
+      expect { record.destroy! }.to change(alias_class, :count).by(-1)
+    end
+  end
+
+  describe GameSystem do
+    it_behaves_like "a named record with aliases", :game_system, :name, GameSystemAlias
+  end
+
+  describe Author do
+    it_behaves_like "a named record with aliases", :author, :name, AuthorAlias
+  end
+
+  describe Person do
+    it_behaves_like "a named record with aliases", :person, :display_name, PersonAlias
+  end
+end

--- a/spec/models/aliases_spec.rb
+++ b/spec/models/aliases_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Aliases" do
       former_name = record.public_send(display_attribute)
       selected = record.aliases.create!(name: "新しい表示名", visible: true)
 
-      expect(record.update(display_alias_id: selected.id)).to be(true)
+      expect(record.update(display_alias_key: selected.id)).to be(true)
       expect(record.reload.public_send(display_attribute)).to eq("新しい表示名")
       expect(selected.reload.attributes.slice("name", "visible")).to eq("name" => former_name, "visible" => true)
     end
@@ -23,8 +23,17 @@ RSpec.describe "Aliases" do
     it "does not promote a hidden alias" do
       selected = record.aliases.create!(name: "非公開名", visible: false)
 
-      expect(record.update(display_alias_id: selected.id)).to be(false)
-      expect(record.errors[:display_alias_id]).to be_present
+      expect(record.update(display_alias_key: selected.id)).to be(false)
+      expect(record.errors[:display_alias_key]).to be_present
+    end
+
+    it "restores the names when another validation rejects the promotion" do
+      selected = record.aliases.create!(name: "新しい表示名", visible: true)
+      record.public_send("#{display_attribute}=", "")
+
+      expect(record.update(display_alias_key: selected.id)).to be(false)
+      expect(record.public_send(display_attribute)).to eq("")
+      expect(selected.name).to eq("新しい表示名")
     end
 
     it "removes aliases with the parent" do

--- a/spec/requests/manage/masters_spec.rb
+++ b/spec/requests/manage/masters_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe "Manage masters" do
       expect(response.body).to include(public_send(member_path, record), "詳細に戻る")
     end
 
+    it "aligns name fields and chooses the display name from a select" do
+      record.aliases.create!(name: "別名")
+      sign_in_as create(:person, roles: %w[gm])
+
+      get public_send(edit_path, record), headers: headers
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("input.w-full", count: 2)
+      expect(page).to have_css("input[type=checkbox][disabled]", count: 2)
+      expect(page).to have_no_css("input[type=radio]")
+      expect(page).to have_select("#{factory}[display_alias_key]", options: [ "既存（現在の表示名）", "別名" ])
+    end
+
     it "renders a detail with links to its edit screen and list" do
       sign_in_as create(:person, roles: %w[gm])
 

--- a/spec/requests/manage/masters_spec.rb
+++ b/spec/requests/manage/masters_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe "Manage masters" do
       expect(record.reload.name).to eq("改名")
     end
 
+    it "adds aliases and promotes a visible one to the display name" do
+      sign_in_as create(:person, roles: %w[gm])
+      patch public_send(member_path, record), params: {
+        factory => { aliases_attributes: [ { name: "別名", visible: "1" } ] }
+      }
+      selected = record.reload.aliases.sole
+
+      patch public_send(member_path, record), params: {
+        factory => { name: record.name, display_alias_id: selected.id }
+      }
+
+      expect(record.reload.name).to eq("別名")
+      expect(selected.reload.name).to eq("既存")
+    end
+
     it "destroys a record" do
       sign_in_as create(:person, roles: %w[gm])
       record

--- a/spec/requests/manage/masters_spec.rb
+++ b/spec/requests/manage/masters_spec.rb
@@ -80,11 +80,26 @@ RSpec.describe "Manage masters" do
       selected = record.reload.aliases.sole
 
       patch public_send(member_path, record), params: {
-        factory => { name: record.name, display_alias_id: selected.id }
+        factory => { name: record.name, display_alias_key: selected.id }
       }
 
       expect(record.reload.name).to eq("別名")
       expect(selected.reload.name).to eq("既存")
+    end
+
+    it "adds an alias and selects it as the display name in one update" do
+      sign_in_as create(:person, roles: %w[gm])
+
+      patch public_send(member_path, record), params: {
+        factory => {
+          name: record.name,
+          display_alias_key: "new-name",
+          aliases_attributes: [ { name: "新しい表示名", visible: "1", selection_key: "new-name" } ]
+        }
+      }
+
+      expect(record.reload.name).to eq("新しい表示名")
+      expect(record.aliases.sole.name).to eq("既存")
     end
 
     it "destroys a record" do

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe "People" do
 
       expect(response.body).to include("べつの名前", "とあるサーバ")
     end
+
+    it "does not expose hidden aliases" do
+      person.person_aliases.create!(name: "公開名", visible: true)
+      person.person_aliases.create!(name: "秘密名", visible: false)
+      sign_in_as other
+
+      get person_path(person)
+
+      expect(response.body).to include("公開名")
+      expect(response.body).not_to include("秘密名")
+    end
   end
 
   describe "editing" do
@@ -116,6 +127,18 @@ RSpec.describe "People" do
       }
 
       expect(person.reload.person_aliases.map(&:name)).to eq([ "A" ])
+    end
+
+    it "lets the person choose a visible alias as their display name" do
+      selected = person.person_aliases.create!(name: "新しい名前", visible: true)
+      sign_in_as person
+
+      patch person_path(person), params: {
+        person: { display_name: "本人", display_alias_id: selected.id }
+      }
+
+      expect(person.reload.display_name).to eq("新しい名前")
+      expect(selected.reload.name).to eq("本人")
     end
   end
 

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -134,11 +134,25 @@ RSpec.describe "People" do
       sign_in_as person
 
       patch person_path(person), params: {
-        person: { display_name: "本人", display_alias_id: selected.id }
+        person: { display_name: "本人", display_alias_key: selected.id }
       }
 
       expect(person.reload.display_name).to eq("新しい名前")
       expect(selected.reload.name).to eq("本人")
+    end
+
+    it "keeps the context field available while editing aliases" do
+      person.person_aliases.create!(name: "別名", context: "古いサーバ")
+      sign_in_as person
+
+      patch person_path(person), params: {
+        person: {
+          display_name: "本人",
+          aliases_attributes: [ { id: person.person_aliases.sole.id, name: "別名", context: "新しいサーバ" } ]
+        }
+      }
+
+      expect(person.reload.person_aliases.sole.context).to eq("新しいサーバ")
     end
   end
 

--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "A member's own pages" do
     fill_in "person[x_account]", with: "karia"
     # 既存の別名の行が出ていること自体も確かめる。
     expect(page).to have_field(with: "古い別名")
-    fill_in "person[person_aliases_attributes][0][name]", with: "べつの名前"
+    fill_in "person[aliases_attributes][0][name]", with: "べつの名前"
     click_button "保存"
 
     expect(page).to have_content("@karia")


### PR DESCRIPTION
## What

Add visible and hidden aliases for game systems, authors, and members, with promotion of a visible alias to the display name.

## Why

Support the naming rules described in #46 while keeping one required display name for references across the site.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #46