### PR TITLE
Improve scenario filter controls

### DIFF
--- a/app/javascript/controllers/author_filter_controller.js
+++ b/app/javascript/controllers/author_filter_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit({ target }) {
+    const names = Array.from(target.list.options, option => option.value)
+    if (names.includes(target.value)) this.element.requestSubmit()
+  }
+}

--- a/app/queries/scenario_listing.rb
+++ b/app/queries/scenario_listing.rb
@@ -22,15 +22,18 @@ class ScenarioListing
     [ "#{sort}_#{direction}", Arel.sql("#{SORTS.fetch(sort)} #{direction.upcase} NULLS LAST") ]
   }.freeze
 
-  attr_reader :view, :order, :authors, :game_systems, :player_count
+  attr_reader :view, :order, :authors, :game_systems, :player_count, :author_name
 
   def initialize(scope, params)
     @scope = scope
     @view = params[:view].to_s.presence_in(VIEWS) || VIEWS.first
     @order = params[:order].to_s.presence_in(ORDERS.keys)
     author_ids = Array(params[:author_ids].presence || params[:author_id]).map(&:to_s)
-    added_author = Author.find_by(name: params[:author_name].to_s.strip)
+    @author_name = params[:author_name].to_s.strip
+    added_author = Author.find_by(name: author_name)
+    added_author ||= AuthorAlias.find_by(name: author_name, visible: true)&.author
     author_ids << added_author.id.to_s if added_author
+    @author_name_error = author_name.present? && added_author.nil?
     @authors = Author.where(id: author_ids).order(:name).to_a
     game_system_ids = Array(params[:game_system_ids].presence || params[:game_system_id]).map(&:to_s)
     @game_systems = GameSystem.where(id: game_system_ids).order(:name).to_a
@@ -42,6 +45,15 @@ class ScenarioListing
   def filtered? = authors.any? || game_systems.any? || player_count.present?
 
   def author_options = Author.joins(:scenarios).merge(@scope).distinct.order(:name)
+
+  def author_suggestions
+    option_ids = author_options.unscope(:order).pluck(:id)
+    names = Author.where(id: option_ids).pluck(:name)
+    aliases = AuthorAlias.where(author_id: option_ids, visible: true).pluck(:name)
+    (names + aliases).uniq.sort
+  end
+
+  def author_name_error? = @author_name_error
 
   def game_system_options = GameSystem.joins(:scenarios).merge(@scope).distinct.order(:name)
 

--- a/app/queries/scenario_listing.rb
+++ b/app/queries/scenario_listing.rb
@@ -30,8 +30,7 @@ class ScenarioListing
     @order = params[:order].to_s.presence_in(ORDERS.keys)
     author_ids = Array(params[:author_ids].presence || params[:author_id]).map(&:to_s)
     @author_name = params[:author_name].to_s.strip
-    added_author = Author.find_by(name: author_name)
-    added_author ||= AuthorAlias.find_by(name: author_name, visible: true)&.author
+    added_author = Author.find_by(id: author_id_for_name(author_name))
     author_ids << added_author.id.to_s if added_author
     @author_name_error = author_name.present? && added_author.nil?
     @authors = Author.where(id: author_ids).order(:name).to_a
@@ -44,13 +43,11 @@ class ScenarioListing
 
   def filtered? = authors.any? || game_systems.any? || player_count.present?
 
-  def author_options = Author.joins(:scenarios).merge(@scope).distinct.order(:name)
+  def author_options = Author.where(id: author_option_ids).order(:name)
 
   def author_suggestions
-    option_ids = author_options.unscope(:order).pluck(:id)
-    names = Author.where(id: option_ids).pluck(:name)
-    aliases = AuthorAlias.where(author_id: option_ids, visible: true).pluck(:name)
-    (names + aliases).uniq.sort
+    selected_ids = authors.map(&:id)
+    author_names.filter_map { |name, ids| name if ids.one? && ids.intersect?(selected_ids) == false }.sort
   end
 
   def author_name_error? = @author_name_error
@@ -67,6 +64,24 @@ class ScenarioListing
   end
 
   private
+    def author_option_ids
+      @author_option_ids ||= Author.joins(:scenarios).merge(@scope).distinct.reorder(nil).pluck(:id)
+    end
+
+    def author_names
+      names = Hash.new { |hash, key| hash[key] = [] }
+      Author.where(id: author_option_ids).pluck(:name, :id).each { |name, id| names[name] << id }
+      AuthorAlias.where(author_id: author_option_ids, visible: true).pluck(:name, :author_id).each do |name, author_id|
+        names[name] << author_id
+      end
+      names.transform_values(&:uniq)
+    end
+
+    def author_id_for_name(name)
+      ids = author_names.fetch(name, [])
+      ids.first if ids.one?
+    end
+
     def filtered
       relation = @scope
       if authors.any?

--- a/app/queries/scenario_listing.rb
+++ b/app/queries/scenario_listing.rb
@@ -65,6 +65,10 @@ class ScenarioListing
       end
       return relation unless player_count
 
+      if player_count == 5
+        return relation.where("scenarios.player_count_max IS NULL OR scenarios.player_count_max >= 5")
+      end
+
       relation
         .where(player_count_min: ..player_count)
         .where("scenarios.player_count_max IS NULL OR scenarios.player_count_max >= :count", count: player_count)

--- a/app/queries/scenario_listing.rb
+++ b/app/queries/scenario_listing.rb
@@ -22,38 +22,46 @@ class ScenarioListing
     [ "#{sort}_#{direction}", Arel.sql("#{SORTS.fetch(sort)} #{direction.upcase} NULLS LAST") ]
   }.freeze
 
-  attr_reader :view, :order, :author, :game_system, :player_count
+  attr_reader :view, :order, :authors, :game_systems, :player_count
 
   def initialize(scope, params)
     @scope = scope
     @view = params[:view].to_s.presence_in(VIEWS) || VIEWS.first
     @order = params[:order].to_s.presence_in(ORDERS.keys)
-    @author = Author.find_by(id: params[:author_id].to_s)
-    @game_system = GameSystem.find_by(id: params[:game_system_id].to_s)
+    author_ids = Array(params[:author_ids].presence || params[:author_id]).map(&:to_s)
+    added_author = Author.find_by(name: params[:author_name].to_s.strip)
+    author_ids << added_author.id.to_s if added_author
+    @authors = Author.where(id: author_ids).order(:name).to_a
+    game_system_ids = Array(params[:game_system_ids].presence || params[:game_system_id]).map(&:to_s)
+    @game_systems = GameSystem.where(id: game_system_ids).order(:name).to_a
     @player_count = params[:player_count].to_s.to_i.then { |count| count if count.positive? }
   end
 
   def scenarios = ordered(filtered)
 
-  def filtered? = author.present? || game_system.present? || player_count.present?
+  def filtered? = authors.any? || game_systems.any? || player_count.present?
 
-  def authors = Author.joins(:scenarios).merge(@scope).distinct
+  def author_options = Author.joins(:scenarios).merge(@scope).distinct.order(:name)
 
-  def game_systems = GameSystem.joins(:scenarios).merge(@scope).distinct
+  def game_system_options = GameSystem.joins(:scenarios).merge(@scope).distinct.order(:name)
 
   def params(overrides = {})
     {
       view: (view unless view == VIEWS.first),
-      author_id: author&.id, game_system_id: game_system&.id, player_count:, order:
+      author_ids: (authors.map(&:id) if authors.any?),
+      game_system_ids: (game_systems.map(&:id) if game_systems.any?),
+      player_count:, order:
     }.merge(overrides).compact
   end
 
   private
     def filtered
       relation = @scope
-      relation = relation.where(id: ScenarioAuthor.where(author_id: author.id).select(:scenario_id)) if author
-      if game_system
-        relation = relation.where(id: ScenarioGameSystem.where(game_system_id: game_system.id).select(:scenario_id))
+      if authors.any?
+        relation = relation.where(id: ScenarioAuthor.where(author_id: authors.map(&:id)).select(:scenario_id))
+      end
+      if game_systems.any?
+        relation = relation.where(id: ScenarioGameSystem.where(game_system_id: game_systems.map(&:id)).select(:scenario_id))
       end
       return relation unless player_count
 

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-3 overflow-x-auto border border-rule bg-surface">
   <table class="w-full min-w-3xl text-sm">
+    <caption class="sr-only">絞り込み条件に一致したシナリオ</caption>
     <thead class="border-b border-rule text-left text-xs text-muted">
       <tr>
         <th scope="col" class="p-3">シナリオ名</th>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -13,52 +13,75 @@
   </nav>
 </div>
 
-<%= form_with url: root_path, method: :get, class: "mt-6 border border-rule bg-surface p-4" do |form| %>
-  <% if @listing.view != ScenarioListing::VIEWS.first %>
-    <%= hidden_field_tag :view, @listing.view %>
-  <% end %>
-  <% if @listing.order %>
-    <%= hidden_field_tag :order, @listing.order, id: nil %>
-  <% end %>
-
-  <div class="flex flex-wrap items-end gap-4">
-    <div>
-      <%= label_tag :author_id, "作者", class: "block text-xs text-muted" %>
-      <%= select_tag :author_id,
-            options_from_collection_for_select(@listing.authors, :id, :name, @listing.author&.id),
-            include_blank: "すべて", class: "mt-1 border border-rule bg-paper px-3 py-2 text-sm" %>
+<div class="mt-6 space-y-4 border border-rule bg-surface p-4">
+  <fieldset>
+    <legend class="text-xs text-muted">人数</legend>
+    <div class="mt-2 flex flex-wrap gap-2" aria-label="人数">
+      <% [ [ 1, "1人" ], [ 2, "2人" ], [ 3, "3人" ], [ 4, "4人" ], [ 5, "5人以上" ] ].each do |count, label| %>
+        <% selected = @listing.player_count == count %>
+        <%= link_to label, root_path(@listing.params(player_count: (selected ? nil : count))),
+              aria: { pressed: selected },
+              class: "border px-3 py-1.5 text-sm no-underline #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
+      <% end %>
     </div>
-    <div>
-      <%= label_tag :game_system_id, "システム", class: "block text-xs text-muted" %>
-      <%= select_tag :game_system_id,
-            options_from_collection_for_select(@listing.game_systems, :id, :name, @listing.game_system&.id),
-            include_blank: "すべて", class: "mt-1 border border-rule bg-paper px-3 py-2 text-sm" %>
-    </div>
-    <div>
-      <%= label_tag :player_count, "人数", class: "block text-xs text-muted" %>
-      <%= number_field_tag :player_count, @listing.player_count, min: 1, autocomplete: "off", placeholder: "すべて",
-            class: "mt-1 w-24 border border-rule bg-paper px-3 py-2 text-sm" %>
-    </div>
+  </fieldset>
 
-    <%= form.button "絞り込む", name: nil, class: "bg-ink px-5 py-2 text-sm text-paper" %>
+  <fieldset>
+    <legend class="text-xs text-muted">システム</legend>
+    <div class="mt-2 flex flex-wrap gap-2" aria-label="システム">
+      <% @listing.game_system_options.each do |game_system| %>
+        <% selected = @listing.game_systems.include?(game_system) %>
+        <% ids = selected ? @listing.game_systems.without(game_system).map(&:id) : @listing.game_systems.map(&:id) + [ game_system.id ] %>
+        <%= link_to game_system.name, root_path(@listing.params(game_system_ids: ids.presence)),
+              aria: { pressed: selected },
+              class: "border px-3 py-1.5 text-sm no-underline #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
+      <% end %>
+    </div>
+  </fieldset>
 
-    <% if @listing.filtered? %>
-      <%= link_to "絞り込みを解除", root_path(@listing.params(author_id: nil, game_system_id: nil, player_count: nil)),
-            class: "self-center text-sm text-seal" %>
+  <%= form_with url: root_path, method: :get, data: { controller: "author-filter" }, class: "space-y-2" do |form| %>
+    <% @listing.params(author_ids: nil).each do |key, value| %>
+      <% Array(value).each do |item| %>
+        <%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %>
+      <% end %>
     <% end %>
-  </div>
-<% end %>
+    <% @listing.authors.each do |author| %>
+      <%= hidden_field_tag "author_ids[]", author.id, id: nil %>
+    <% end %>
+
+    <label class="block text-xs text-muted" for="author_name">作者</label>
+    <div class="flex flex-wrap items-center gap-2">
+      <% @listing.authors.each do |author| %>
+        <span class="inline-flex items-center gap-1 border border-rule bg-paper px-2 py-1 text-sm">
+          <%= author.name %>
+          <%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)),
+                aria: { label: "#{author.name}を解除" }, class: "text-seal no-underline" %>
+        </span>
+      <% end %>
+      <%= text_field_tag :author_name, nil, list: "author-suggestions", autocomplete: "off", placeholder: "作者名を入力",
+            aria: { label: "作者を追加" }, data: { action: "change->author-filter#submit" },
+            class: "min-w-48 border border-rule bg-paper px-3 py-2 text-sm" %>
+      <datalist id="author-suggestions">
+        <% (@listing.author_options - @listing.authors).each do |author| %>
+          <option value="<%= author.name %>"></option>
+        <% end %>
+      </datalist>
+      <%= form.button "追加", name: nil, class: "border border-ink px-4 py-2 text-sm" %>
+    </div>
+  <% end %>
+</div>
 
 <% if @scenarios.any? %>
   <%= form_with url: root_path, method: :get, data: { controller: "auto-submit" },
         class: "mt-8 flex items-center justify-end gap-2" do |form| %>
     <% @listing.params(order: nil).each do |key, value| %>
-      <%= hidden_field_tag key, value, id: nil %>
+      <% Array(value).each do |item| %>
+        <%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %>
+      <% end %>
     <% end %>
 
     <%= label_tag :order, "並び順", class: "text-xs text-muted" %>
-    <%= select_tag :order, scenario_order_options(@listing),
-          data: { action: "change->auto-submit#submit" },
+    <%= select_tag :order, scenario_order_options(@listing), data: { action: "change->auto-submit#submit" },
           class: "border border-rule bg-paper px-3 py-2 text-sm" %>
     <noscript><%= form.button "並べ替える", name: nil, class: "bg-ink px-4 py-2 text-sm text-paper" %></noscript>
   <% end %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -19,9 +19,10 @@
     <div class="mt-2 flex flex-wrap gap-2" aria-label="人数">
       <% [ [ 1, "1人" ], [ 2, "2人" ], [ 3, "3人" ], [ 4, "4人" ], [ 5, "5人以上" ] ].each do |count, label| %>
         <% selected = @listing.player_count == count %>
-        <%= link_to label, root_path(@listing.params(player_count: (selected ? nil : count))),
+        <%= button_to label, root_path, method: :get,
+              params: @listing.params(player_count: (selected ? nil : count)), form: { class: "inline" },
               aria: { pressed: selected },
-              class: "border px-3 py-1.5 text-sm no-underline #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
+              class: "cursor-pointer border px-3 py-1.5 text-sm #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
       <% end %>
     </div>
   </fieldset>
@@ -32,9 +33,10 @@
       <% @listing.game_system_options.each do |game_system| %>
         <% selected = @listing.game_systems.include?(game_system) %>
         <% ids = selected ? @listing.game_systems.without(game_system).map(&:id) : @listing.game_systems.map(&:id) + [ game_system.id ] %>
-        <%= link_to game_system.name, root_path(@listing.params(game_system_ids: ids.presence)),
+        <%= button_to game_system.name, root_path, method: :get,
+              params: @listing.params(game_system_ids: ids.presence), form: { class: "inline" },
               aria: { pressed: selected },
-              class: "border px-3 py-1.5 text-sm no-underline #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
+              class: "cursor-pointer border px-3 py-1.5 text-sm #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
       <% end %>
     </div>
   </fieldset>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex flex-wrap items-baseline justify-between gap-4">
   <h1 class="font-display text-3xl tracking-wide">
-    シナリオ一覧<span class="ml-2 text-base text-muted">（全<%= @scenarios.size %>件）</span>
+    シナリオ一覧<span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>
   </h1>
 
   <nav class="flex items-center gap-3 text-xs" aria-label="表示の切り替え">
@@ -16,7 +16,7 @@
 <div class="mt-6 space-y-4 border border-rule bg-surface p-4">
   <fieldset>
     <legend class="text-xs text-muted">人数</legend>
-    <div class="mt-2 flex flex-wrap gap-2" aria-label="人数">
+    <div class="mt-2 flex flex-wrap gap-2">
       <% [ [ 1, "1人" ], [ 2, "2人" ], [ 3, "3人" ], [ 4, "4人" ], [ 5, "5人以上" ] ].each do |count, label| %>
         <% selected = @listing.player_count == count %>
         <%= button_to label, root_path, method: :get,
@@ -29,7 +29,7 @@
 
   <fieldset>
     <legend class="text-xs text-muted">システム</legend>
-    <div class="mt-2 flex flex-wrap gap-2" aria-label="システム">
+    <div class="mt-2 flex flex-wrap gap-2">
       <% @listing.game_system_options.each do |game_system| %>
         <% selected = @listing.game_systems.include?(game_system) %>
         <% ids = selected ? @listing.game_systems.without(game_system).map(&:id) : @listing.game_systems.map(&:id) + [ game_system.id ] %>
@@ -57,25 +57,32 @@
         <span class="inline-flex items-center gap-1 border border-rule bg-paper px-2 py-1 text-sm">
           <%= author.name %>
           <%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)),
-                aria: { label: "#{author.name}を解除" }, class: "text-seal no-underline" %>
+                aria: { label: "#{author.name}を解除" },
+                class: "inline-flex min-h-6 min-w-6 items-center justify-center text-seal no-underline" %>
         </span>
       <% end %>
-      <%= text_field_tag :author_name, nil, list: "author-suggestions", autocomplete: "off", placeholder: "作者名を入力",
-            aria: { label: "作者を追加" }, data: { action: "change->author-filter#submit" },
+      <%= text_field_tag :author_name, (@listing.author_name if @listing.author_name_error?),
+            list: "author-suggestions", autocomplete: "off", placeholder: "作者名を入力",
+            aria: { label: "作者を追加", describedby: "author-help#{' author-error' if @listing.author_name_error?}",
+                    invalid: ("true" if @listing.author_name_error?) },
+            data: { action: "change->author-filter#submit" },
             class: "min-w-48 border border-rule bg-paper px-3 py-2 text-sm" %>
       <datalist id="author-suggestions">
-        <% (@listing.author_options - @listing.authors).each do |author| %>
-          <option value="<%= author.name %>"></option>
+        <% @listing.author_suggestions.each do |name| %>
+          <option value="<%= name %>"></option>
         <% end %>
       </datalist>
       <%= form.button "追加", name: nil, class: "border border-ink px-4 py-2 text-sm" %>
     </div>
+    <p id="author-help" class="text-xs text-muted">候補から選択して追加します。作者は複数選択できます。</p>
+    <% if @listing.author_name_error? %>
+      <p id="author-error" role="alert" class="text-sm text-seal">候補から作者を選択してください。</p>
+    <% end %>
   <% end %>
 </div>
 
 <% if @scenarios.any? %>
-  <%= form_with url: root_path, method: :get, data: { controller: "auto-submit" },
-        class: "mt-8 flex items-center justify-end gap-2" do |form| %>
+  <%= form_with url: root_path, method: :get, class: "mt-8 flex items-center justify-end gap-2" do |form| %>
     <% @listing.params(order: nil).each do |key, value| %>
       <% Array(value).each do |item| %>
         <%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %>
@@ -83,9 +90,8 @@
     <% end %>
 
     <%= label_tag :order, "並び順", class: "text-xs text-muted" %>
-    <%= select_tag :order, scenario_order_options(@listing), data: { action: "change->auto-submit#submit" },
-          class: "border border-rule bg-paper px-3 py-2 text-sm" %>
-    <noscript><%= form.button "並べ替える", name: nil, class: "bg-ink px-4 py-2 text-sm text-paper" %></noscript>
+    <%= select_tag :order, scenario_order_options(@listing), class: "border border-rule bg-paper px-3 py-2 text-sm" %>
+    <%= form.button "並べ替える", name: nil, class: "bg-ink px-4 py-2 text-sm text-paper" %>
   <% end %>
 
   <%= render "scenarios/#{@listing.view}", scenarios: @scenarios %>

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe "Sorting and filtering the scenario list" do
       expect(response.body).not_to include("いちばん", "なかほど")
     end
 
+    it "treats five as the open-ended five-or-more bucket" do
+      get root_path(player_count: 5)
+
+      expect(response.body).to include("最後の見本")
+      expect(response.body).not_to include("いちばん", "なかほど")
+    end
+
     it "applies two filters at once" do
       get root_path(game_system_ids: [ emoklore.id ], player_count: 2)
 
@@ -193,10 +200,10 @@ RSpec.describe "Sorting and filtering the scenario list" do
 
       document = Capybara.string(response.body)
 
-      expect(document).to have_css('[aria-label="人数"] a', count: 5)
-      expect(document).to have_link("1人")
-      expect(document).to have_link("5人以上")
-      expect(document).to have_css('[aria-label="システム"] a', count: 2)
+      expect(document).to have_css('[aria-label="人数"] button', count: 5)
+      expect(document).to have_button("1人")
+      expect(document).to have_button("5人以上")
+      expect(document).to have_css('[aria-label="システム"] button', count: 2)
       expect(document).to have_no_css('select[name="game_system_id"]')
       expect(document).to have_no_css('input[type="number"][name="player_count"]')
     end
@@ -205,9 +212,10 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('[aria-label="人数"] a[aria-pressed="true"]', text: "5人以上")
-      expect(document).to have_css('[aria-label="システム"] a[aria-pressed="true"]', text: "エモクロア")
-      expect(document.find('[aria-label="人数"] a', text: "5人以上")[:href]).not_to include("player_count")
+      expect(document).to have_css('[aria-label="人数"] button[aria-pressed="true"]', text: "5人以上")
+      expect(document).to have_css('[aria-label="システム"] button[aria-pressed="true"]', text: "エモクロア")
+      selected_form = document.find('[aria-label="人数"] button', text: "5人以上").ancestor("form")
+      expect(selected_form).to have_no_css('input[name="player_count"]', visible: :all)
     end
 
     it "offers author suggestions and removable selected author tags" do
@@ -229,7 +237,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
     end
 
     it "says so when nothing matches" do
-      get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
+      get root_path(player_count: 4, game_system_ids: [ emoklore.id ])
 
       expect(response.body).to include("条件に合うシナリオがありません")
     end

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -121,10 +121,10 @@ RSpec.describe "Sorting and filtering the scenario list" do
     end
 
     it "keeps the current filter when the order changes" do
-      get root_path(game_system_id: emoklore.id)
+      get root_path(game_system_ids: [ emoklore.id ])
 
       expect(Capybara.string(response.body))
-        .to have_css(%(form input[type="hidden"][name="game_system_id"][value="#{emoklore.id}"]), visible: :all)
+        .to have_css(%(form input[type="hidden"][name="game_system_ids[]"][value="#{emoklore.id}"]), visible: :all)
     end
 
     it "keeps the jacket view when the order changes" do
@@ -143,18 +143,16 @@ RSpec.describe "Sorting and filtering the scenario list" do
   end
 
   describe "filtering" do
-    it "keeps only the scenarios of one author" do
-      get root_path(author_id: ma_author.id)
+    it "keeps the scenarios of any selected author" do
+      get root_path(author_ids: [ ma_author.id, a_author.id ])
 
-      expect(response.body).to include("なかほど", "最後の見本")
-      expect(response.body).not_to include("いちばん")
+      expect(response.body).to include("いちばん", "なかほど", "最後の見本")
     end
 
-    it "keeps only the scenarios of one system" do
-      get root_path(game_system_id: emoklore.id)
+    it "keeps the scenarios of any selected system" do
+      get root_path(game_system_ids: [ emoklore.id, coc.id ])
 
-      expect(response.body).to include("いちばん", "最後の見本")
-      expect(response.body).not_to include("なかほど")
+      expect(response.body).to include("いちばん", "なかほど", "最後の見本")
     end
 
     it "keeps the scenarios that a party of that size can play" do
@@ -172,48 +170,58 @@ RSpec.describe "Sorting and filtering the scenario list" do
     end
 
     it "applies two filters at once" do
-      get root_path(game_system_id: emoklore.id, player_count: 2)
+      get root_path(game_system_ids: [ emoklore.id ], player_count: 2)
 
       expect(response.body).to include("いちばん")
       expect(response.body).not_to include("なかほど", "最後の見本")
     end
 
     it "combines a filter with a sort" do
-      get root_path(author_id: ma_author.id, order: "title_desc")
+      get root_path(author_ids: [ ma_author.id ], order: "title_desc")
 
       expect_order("最後の見本", "なかほど")
     end
 
     it "ignores an author who does not exist" do
-      get root_path(author_id: 0)
+      get root_path(author_ids: [ 0 ])
 
       expect(response.body).to include("いちばん", "なかほど", "最後の見本")
     end
 
-    it "offers a way to clear the filters" do
-      get root_path(author_id: ma_author.id)
-
-      expect(response.body).to include("絞り込みを解除")
-    end
-
-    it "does not offer to clear anything when nothing is filtered" do
-      get root_path
-
-      expect(response.body).not_to include("絞り込みを解除")
-    end
-
-    it "offers author and system menus and a numeric party-size input" do
+    it "offers toggle buttons for party size and systems" do
       get root_path
 
       document = Capybara.string(response.body)
 
-      expect(document).to have_css('select[name="author_id"]')
-      expect(document).to have_css('select[name="game_system_id"]')
-      expect(document).to have_css('input[type="number"][name="player_count"][min="1"]')
+      expect(document).to have_css('[aria-label="人数"] a', count: 5)
+      expect(document).to have_link("1人")
+      expect(document).to have_link("5人以上")
+      expect(document).to have_css('[aria-label="システム"] a', count: 2)
+      expect(document).to have_no_css('select[name="game_system_id"]')
+      expect(document).to have_no_css('input[type="number"][name="player_count"]')
+    end
+
+    it "marks selected buttons and links them to deselect themselves" do
+      get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
+
+      document = Capybara.string(response.body)
+      expect(document).to have_css('[aria-label="人数"] a[aria-pressed="true"]', text: "5人以上")
+      expect(document).to have_css('[aria-label="システム"] a[aria-pressed="true"]', text: "エモクロア")
+      expect(document.find('[aria-label="人数"] a', text: "5人以上")[:href]).not_to include("player_count")
+    end
+
+    it "offers author suggestions and removable selected author tags" do
+      get root_path(author_ids: [ ma_author.id ])
+
+      document = Capybara.string(response.body)
+      expect(document).to have_css('input[aria-label="作者を追加"][list="author-suggestions"]')
+      expect(document).to have_css('datalist#author-suggestions option[value="あ作者"]')
+      expect(document).to have_css('input[type="hidden"][name="author_ids[]"]', visible: :all)
+      expect(document).to have_css('a[aria-label="ま作者を解除"]')
     end
 
     it "filters the jacket view as well" do
-      get root_path(view: "gallery", game_system_id: emoklore.id)
+      get root_path(view: "gallery", game_system_ids: [ emoklore.id ])
 
       expect(response.body).not_to include("<table")
       expect(response.body).to include("いちばん")
@@ -221,7 +229,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
     end
 
     it "says so when nothing matches" do
-      get root_path(player_count: 5, game_system_id: emoklore.id)
+      get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
 
       expect(response.body).to include("条件に合うシナリオがありません")
     end
@@ -229,7 +237,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
 
   describe "what the list gives away" do
     it "keeps the recommendation out of the response whatever the filter" do
-      get root_path(author_id: ma_author.id, order: "player_count_desc")
+      get root_path(author_ids: [ ma_author.id ], order: "player_count_desc")
 
       expect(response.body).not_to include("★", "おすすめ度")
       expect(response.body).not_to match(/recommendation/i)

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -240,6 +240,27 @@ RSpec.describe "Sorting and filtering the scenario list" do
       expect(response.body).not_to include("いちばん")
     end
 
+    it "rejects an alias shared by multiple authors" do
+      AuthorAlias.create!(author: ma_author, name: "先生")
+      AuthorAlias.create!(author: a_author, name: "先生")
+
+      get root_path(author_name: "先生")
+
+      document = Capybara.string(response.body)
+      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください")
+      expect(document).to have_no_css('datalist option[value="先生"]')
+    end
+
+    it "does not suggest names belonging to a selected author" do
+      AuthorAlias.create!(author: ma_author, name: "ま先生")
+
+      get root_path(author_ids: [ ma_author.id ])
+
+      document = Capybara.string(response.body)
+      expect(document).to have_no_css('datalist option[value="ま作者"]')
+      expect(document).to have_no_css('datalist option[value="ま先生"]')
+    end
+
     it "identifies a name that was not selected from the author suggestions" do
       get root_path(author_name: "知らない作者")
 

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -112,12 +112,11 @@ RSpec.describe "Sorting and filtering the scenario list" do
       expect(Capybara.string(response.body)).to have_no_css("th a")
     end
 
-    # プルダウンは JS が送信する。無い相手には noscript のボタンだけが残る。
-    it "carries a submit button for a visitor without JavaScript" do
+    it "uses an explicit submit button so changing the menu does not navigate unexpectedly" do
       get root_path
 
       expect(Capybara.string(response.body))
-        .to have_css('form noscript button[type="submit"]', text: "並べ替える", visible: :all)
+        .to have_css('form button[type="submit"]', text: "並べ替える")
     end
 
     it "keeps the current filter when the order changes" do
@@ -199,11 +198,15 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path
 
       document = Capybara.string(response.body)
+      party_size = document.all("fieldset")[0]
+      systems = document.all("fieldset")[1]
 
-      expect(document).to have_css('[aria-label="人数"] button', count: 5)
-      expect(document).to have_button("1人")
-      expect(document).to have_button("5人以上")
-      expect(document).to have_css('[aria-label="システム"] button', count: 2)
+      expect(party_size).to have_css("legend", text: "人数")
+      expect(party_size).to have_button("1人")
+      expect(party_size).to have_button("5人以上")
+      expect(party_size).to have_css("button", count: 5)
+      expect(systems).to have_css("legend", text: "システム")
+      expect(systems).to have_css("button", count: 2)
       expect(document).to have_no_css('select[name="game_system_id"]')
       expect(document).to have_no_css('input[type="number"][name="player_count"]')
     end
@@ -212,9 +215,9 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('[aria-label="人数"] button[aria-pressed="true"]', text: "5人以上")
-      expect(document).to have_css('[aria-label="システム"] button[aria-pressed="true"]', text: "エモクロア")
-      selected_form = document.find('[aria-label="人数"] button', text: "5人以上").ancestor("form")
+      expect(document).to have_css('button[aria-pressed="true"]', text: "5人以上")
+      expect(document).to have_css('button[aria-pressed="true"]', text: "エモクロア")
+      selected_form = document.find("button", text: "5人以上").ancestor("form")
       expect(selected_form).to have_no_css('input[name="player_count"]', visible: :all)
     end
 
@@ -226,6 +229,23 @@ RSpec.describe "Sorting and filtering the scenario list" do
       expect(document).to have_css('datalist#author-suggestions option[value="あ作者"]')
       expect(document).to have_css('input[type="hidden"][name="author_ids[]"]', visible: :all)
       expect(document).to have_css('a[aria-label="ま作者を解除"]')
+    end
+
+    it "accepts an author alias from the suggestions" do
+      AuthorAlias.create!(author: ma_author, name: "ま先生")
+
+      get root_path(author_name: "ま先生")
+
+      expect(response.body).to include("なかほど", "最後の見本")
+      expect(response.body).not_to include("いちばん")
+    end
+
+    it "identifies a name that was not selected from the author suggestions" do
+      get root_path(author_name: "知らない作者")
+
+      document = Capybara.string(response.body)
+      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください")
+      expect(document).to have_css('input[name="author_name"][aria-invalid="true"]')
     end
 
     it "filters the jacket view as well" do


### PR DESCRIPTION
## What

- Replace party-size and game-system inputs with toggle controls
- Support OR filtering across multiple systems and authors
- Add suggested, removable author tags

## Why

Make the small filter sets faster to use and allow combined system and author searches.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #75
