### PR TITLE
Update Brakeman to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
## What

Update Brakeman from 8.0.5 to 8.0.6.

## Why

Brakeman 8.0.5 exits with code 5 when checking for the latest version, causing `scan_ruby` to fail.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Unblocks #79
