### PR TITLE
Separate registration and sign-in flows

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,6 @@
+class RegistrationsController < ApplicationController
+  skip_after_action :verify_authorized
+
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,8 +22,6 @@ class SessionsController < ApplicationController
 
   private
     def sign_in_notice(user)
-      return "ログインしました" if user.linked?
-
-      "ログインしました。管理者がメンバー登録するまで、閲覧できるのは公開ページだけです"
+      "ログインしました" if user.linked?
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,8 +40,9 @@
             <%= button_to "ログアウト", session_path, method: :delete,
                   class: "cursor-pointer text-muted underline" %>
           <% else %>
+            <%= link_to "新規登録", new_registration_path, class: "text-seal underline" %>
             <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
-            <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
+            <%= button_to "ログイン", "/auth/google_oauth2", method: :post,
                   form: { data: { turbo: false } },
                   class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
           <% end %>
@@ -50,6 +51,14 @@
     </header>
 
     <%= yield :sub_nav %>
+
+    <% if signed_in? && current_person.nil? %>
+      <div class="mx-auto w-full max-w-5xl px-5 pt-6">
+        <p class="border border-seal bg-surface px-4 py-3 text-sm text-seal" role="alert">
+          全機能を利用するには管理者の許可が必要です。管理者に連絡して、メンバー登録を依頼してください。
+        </p>
+      </div>
+    <% end %>
 
     <% if flash.any? %>
       <div class="mx-auto w-full max-w-5xl px-5 pt-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
 
     <% if signed_in? && current_person.nil? %>
       <div class="mx-auto w-full max-w-5xl px-5 pt-6">
-        <p class="border border-seal bg-surface px-4 py-3 text-sm text-seal" role="alert">
+        <p class="border border-seal bg-surface px-4 py-3 text-sm text-seal" role="status">
           全機能を利用するには管理者の許可が必要です。管理者に連絡して、メンバー登録を依頼してください。
         </p>
       </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, "新規登録" %>
+
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-display text-3xl tracking-wide">新規登録</h1>
+
+  <div class="mt-6 space-y-5 border border-rule bg-surface p-6 text-sm leading-7">
+    <p>
+      このサイトの全機能（セッション情報表示・お気に入りシナリオ機能など）を利用するにはGoogleアカウントでのログインと、管理者の許可が必要です。以下のステップで登録してください。
+    </p>
+
+    <ol class="list-decimal space-y-1 pl-6">
+      <li>下記のボタンを押してGoogleログインする</li>
+      <li>プロフィールを提供してよいかGoogleに聞かれるので許可する</li>
+      <li>管理者に連絡して許可してもらうのを待つ</li>
+    </ol>
+
+    <p>
+      なお、Googleアカウントの情報はこのサイト上では管理者以外の人に表示されることはありません。表示名は自由に設定できます。
+    </p>
+
+    <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
+    <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
+          form: { data: { turbo: false } },
+          class: "cursor-pointer bg-ink px-4 py-2 text-paper hover:bg-seal" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     constraints: { provider: /google_oauth2/ }
   get "/auth/failure", to: "sessions#failure"
   resource :session, only: [ :destroy ]
+  resource :registration, only: [ :new ]
 
   resources :scenarios, only: [ :index, :show ] do
     resource :favorite, only: [ :create, :destroy ]

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Registrations" do
+  it "explains the registration steps and provides Google sign-in" do
+    get new_registration_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("管理者の許可が必要です")
+    expect(response.body).to include("下記のボタンを押してGoogleログインする")
+    expect(response.body).to include("プロフィールを提供してよいかGoogleに聞かれるので許可する")
+    expect(response.body).to include("管理者に連絡して許可してもらうのを待つ")
+    expect(response.body).to include("管理者以外の人に表示されることはありません")
+
+    form = response.body.scan(%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m)
+      .find { |candidate| candidate.include?("Google でログイン") }
+    expect(form).to include('method="post"')
+    expect(form).to include('data-turbo="false"')
+    expect(form).to include("Google でログイン")
+  end
+
+  it "shows an approval request on every page while the account is unlinked" do
+    sign_in_as create(:user, person: nil)
+
+    get root_path
+
+    expect(response.body).to include("管理者に連絡して、メンバー登録を依頼してください")
+  end
+
+  it "does not show the approval request to an approved member" do
+    sign_in_as create(:person)
+
+    get root_path
+
+    expect(response.body).not_to include("メンバー登録を依頼してください")
+  end
+end

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "The sign-in button" do
+  it "shows separate registration and sign-in actions to signed-out visitors" do
+    get root_path
+
+    expect(response.body).to include(%(href="#{new_registration_path}"))
+    expect(response.body).to include(">新規登録</a>")
+    expect(response.body).to include(">ログイン</button>")
+  end
+
   # Turbo はフォーム送信を fetch に置き換えるため、Google への cross-origin リダイレクトを
   # 追えず、押しても何も起きなくなる。ブラウザに素の送信をさせる必要がある。
   it "opts out of Turbo so the browser follows the redirect to Google" do
@@ -38,5 +46,6 @@ RSpec.describe "The sign-in button" do
     get root_path
 
     expect(response.body).not_to include('action="/auth/google_oauth2"')
+    expect(response.body).not_to include(%(href="#{new_registration_path}"))
   end
 end

--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "A member's own pages" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
     visit root_path
-    click_button "Google でログイン"
+    click_button "ログイン"
 
     visit edit_person_path(person)
     fill_in "person[x_account]", with: "karia"


### PR DESCRIPTION
## What

Separate registration guidance from direct Google sign-in and show an approval notice for unlinked users.

## Why

Closes #36

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

