### PR TITLE
Open external links in new tabs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,18 @@
 module ApplicationHelper
   YOUTUBE_VIDEO_ID = /\A[\w-]{11}\z/
+  HTTP_URL = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+
+  def auto_link_urls(text)
+    cursor = 0
+    fragments = text.to_s.to_enum(:scan, HTTP_URL).map do
+      match = Regexp.last_match
+      preceding_text = ERB::Util.html_escape(text[cursor...match.begin(0)])
+      cursor = match.end(0)
+      safe_join([ preceding_text, link_to(match[0], match[0], target: "_blank", rel: "noopener") ])
+    end
+
+    safe_join([ *fragments, ERB::Util.html_escape(text.to_s[cursor..]) ])
+  end
 
   def youtube_embed_url(url)
     uri = URI.parse(url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,9 +6,10 @@ module ApplicationHelper
     cursor = 0
     fragments = text.to_s.to_enum(:scan, HTTP_URL).map do
       match = Regexp.last_match
+      url, suffix = split_url_suffix(match[0])
       preceding_text = ERB::Util.html_escape(text[cursor...match.begin(0)])
       cursor = match.end(0)
-      safe_join([ preceding_text, link_to(match[0], match[0], target: "_blank", rel: "noopener") ])
+      safe_join([ preceding_text, link_to(url, url, target: "_blank", rel: "noopener"), suffix ])
     end
 
     safe_join([ *fragments, ERB::Util.html_escape(text.to_s[cursor..]) ])
@@ -24,6 +25,14 @@ module ApplicationHelper
   end
 
   private
+    def split_url_suffix(url)
+      suffix = url.slice!(/[,.!?;:、。]+\z/) || ""
+      while url.end_with?(")") && url.count("(") < url.count(")")
+        suffix.prepend(url.slice!(-1))
+      end
+      [ url, suffix ]
+    end
+
     def youtube_video_id(uri)
       host = uri.host&.downcase
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -13,7 +13,7 @@
       <% if @person.x_account.present? %>
         <p class="mt-1 text-sm">
           <%= link_to "@#{@person.x_account}", "https://x.com/#{@person.x_account}",
-                rel: "noopener", class: "text-seal" %>
+                target: "_blank", rel: "noopener", class: "text-seal" %>
         </p>
       <% end %>
       <p class="mt-2 text-xs text-muted">

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -37,7 +37,7 @@
       <dt class="text-muted">ココフォリア</dt>
       <dd class="font-sans">
         <%= link_to @play_session.cocofolia_url, @play_session.cocofolia_url,
-              rel: "noopener", class: "text-seal" %>
+              target: "_blank", rel: "noopener", class: "text-seal" %>
       </dd>
     <% end %>
   </dl>
@@ -53,8 +53,8 @@
             <span class="text-muted"><%= participation.character_name %></span>
           <% end %>
           <% if participation.character_sheet_url.present? %>
-            <%= link_to "キャラクターシート", participation.character_sheet_url,
-                  rel: "noopener", class: "ml-auto text-xs text-seal" %>
+            <%= link_to participation.character_sheet_url, participation.character_sheet_url,
+                  target: "_blank", rel: "noopener", class: "ml-auto text-xs text-seal" %>
           <% end %>
         </li>
       <% end %>
@@ -64,7 +64,7 @@
   <% if @play_session.note.present? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">メモ</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @play_session.note %></p>
+      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@play_session.note) %></p>
     </section>
   <% end %>
 </article>

--- a/app/views/scenarios/_gm_supplementary_info.html.erb
+++ b/app/views/scenarios/_gm_supplementary_info.html.erb
@@ -3,11 +3,11 @@
     <h2 class="font-display text-xl">GMからの補足情報</h2>
     <dl class="mt-3 grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
       <dt class="text-muted">参加可能キャラの制限</dt>
-      <dd><%= scenario.character_restriction.presence || "制限なし" %></dd>
+      <dd><%= auto_link_urls(scenario.character_restriction.presence || "制限なし") %></dd>
       <dt class="text-muted">キャラシ提出期限</dt>
       <dd><%= character_sheet_deadline_label(scenario) %></dd>
       <dt class="text-muted">キャラシ提出期限の補足</dt>
-      <dd><%= scenario.character_sheet_deadline_note.presence || "補足なし" %></dd>
+      <dd><%= auto_link_urls(scenario.character_sheet_deadline_note.presence || "補足なし") %></dd>
     </dl>
   </section>
 <% end %>

--- a/app/views/scenarios/_preparation_note.html.erb
+++ b/app/views/scenarios/_preparation_note.html.erb
@@ -3,7 +3,7 @@
     <h2 class="font-display text-xl">プレーヤー向け事前情報</h2>
 
     <% if policy(scenario).show_preparation_note? %>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= scenario.preparation_note %></p>
+      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(scenario.preparation_note) %></p>
       <%= button_to "プレーヤー向け事前情報を閉じる", scenario_spoiler_reveal_path(scenario), method: :delete,
             class: "mt-3 cursor-pointer border border-rule px-4 py-3 text-sm text-muted" %>
     <% elsif policy(scenario).reveal_preparation_note? %>

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -26,7 +26,7 @@
           <td class="p-3 text-xs">
             <% scenario.purchase_links.each do |link| %>
               <% if link.url.present? %>
-                <%= link_to link.label, link.url, rel: "noopener nofollow", class: "text-seal" %>
+                <%= link_to link.label, link.url, target: "_blank", rel: "noopener nofollow", class: "text-seal" %>
               <% else %>
                 <span class="text-muted"><%= link.label %></span>
               <% end %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -53,14 +53,14 @@
   <% if @scenario.synopsis.present? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">あらすじ</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @scenario.synopsis %></p>
+      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.synopsis) %></p>
     </section>
   <% end %>
 
   <% if @scenario.recommendation_note.present? && policy(@scenario).show_recommendation_note? %>
     <section class="mt-10">
       <h2 class="font-display text-xl">GMからのオススメポイント</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= @scenario.recommendation_note %></p>
+      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.recommendation_note) %></p>
     </section>
   <% end %>
 
@@ -73,8 +73,9 @@
         <% @scenario.purchase_links.each do |link| %>
           <li>
             <% if link.url.present? %>
-              <%= link_to link.label, link.url, rel: "noopener nofollow", class: "text-seal" %>
-              <span class="font-mono text-xs text-muted"><%= link.url %></span>
+              <%= link_to link.label, link.url, target: "_blank", rel: "noopener nofollow", class: "text-seal" %>
+              <%= link_to link.url, link.url, target: "_blank", rel: "noopener nofollow",
+                    class: "font-mono text-xs text-muted" %>
             <% else %>
               <span><%= link.label %></span>
             <% end %>

--- a/app/views/shared/_video_link.html.erb
+++ b/app/views/shared/_video_link.html.erb
@@ -5,8 +5,8 @@
           allowfullscreen: true %>
   </div>
 <% else %>
-  <%= link_to link_text, url, rel:, class: "text-seal" %>
+  <%= link_to link_text, url, target: "_blank", rel:, class: "text-seal" %>
   <% if show_url %>
-    <span class="font-mono text-xs text-muted"><%= url %></span>
+    <%= link_to url, url, target: "_blank", rel:, class: "font-mono text-xs text-muted" %>
   <% end %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe ApplicationHelper do
 
       expect(Capybara.string(html)).to have_no_link
     end
+
+    it "keeps sentence punctuation and unmatched closing parentheses outside links" do
+      html = helper.auto_link_urls(
+        "参照（https://example.com/path）、次は https://example.net/docs, 完了。"
+      )
+
+      page = Capybara.string(html)
+      expect(page).to have_link("https://example.com/path", href: "https://example.com/path")
+      expect(page).to have_link("https://example.net/docs", href: "https://example.net/docs")
+      expect(html).to include("</a>）、次は", "</a>, 完了。")
+    end
+
+    it "keeps balanced parentheses in a URL" do
+      url = "https://en.wikipedia.org/wiki/Role-playing_game_(disambiguation)"
+
+      expect(Capybara.string(helper.auto_link_urls(url))).to have_link(url, href: url)
+    end
   end
 
   describe "#youtube_embed_url" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper do
+  describe "#auto_link_urls" do
+    it "links HTTP URLs in escaped plain text and opens them in a new tab" do
+      html = helper.auto_link_urls("参考: https://example.com/path?q=1&lang=ja\n<script>alert(1)</script>")
+
+      page = Capybara.string(html)
+      expect(page).to have_link(
+        "https://example.com/path?q=1&lang=ja",
+        href: "https://example.com/path?q=1&lang=ja",
+        target: "_blank"
+      )
+      expect(page).to have_css('a[rel="noopener"]')
+      expect(html).to include("&lt;script&gt;alert(1)&lt;/script&gt;")
+      expect(html).not_to include("<script>")
+    end
+
+    it "leaves non-HTTP schemes as plain text" do
+      html = helper.auto_link_urls("javascript:alert(1) ftp://example.com/file")
+
+      expect(Capybara.string(html)).to have_no_link
+    end
+  end
+
   describe "#youtube_embed_url" do
     it "converts supported YouTube URLs to embed URLs" do
       expect(helper.youtube_embed_url("https://youtu.be/dQw4w9WgXcQ?t=43"))

--- a/spec/requests/play_sessions_spec.rb
+++ b/spec/requests/play_sessions_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe "PlaySessions" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("参加した人", "遊んだ人", "探索者A")
       expect(response.body).to include("https://charasheet.example/1234", "https://youtu.be/abc")
+      expect(Capybara.string(response.body)).to have_link(
+        "https://charasheet.example/1234",
+        href: "https://charasheet.example/1234",
+        target: "_blank"
+      )
     end
 
     it "embeds a YouTube recording" do
@@ -165,12 +170,15 @@ RSpec.describe "PlaySessions" do
     end
 
     it "shows the note to a viewer who is allowed to see the session" do
-      session.update!(note: "覚え書きの見本")
+      session.update!(note: "覚え書きの見本 https://example.com/note")
       sign_in_as create(:person, groups: [ group ])
 
       get play_session_path(session)
 
       expect(response.body).to include("覚え書きの見本")
+      expect(Capybara.string(response.body)).to have_link(
+        "https://example.com/note", href: "https://example.com/note", target: "_blank"
+      )
     end
 
     it "shows the Cocofolia URL to a participant" do

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe "Scenarios" do
       expect(response.body).to include("この情報はGMが独自判断で記載しており、シナリオ公式の案内と異なる場合があります")
     end
 
+    it "opens external links in a new tab and links displayed URLs" do
+      scenario.update!(synopsis: "公式情報: https://example.com/info")
+      scenario.purchase_links.create!(label: "公式ストア", url: "https://example.com/store")
+
+      get scenario_path(scenario)
+
+      page = Capybara.string(response.body)
+      expect(page).to have_link("公式ストア", href: "https://example.com/store", target: "_blank")
+      expect(page).to have_link(
+        "https://example.com/store", href: "https://example.com/store", target: "_blank"
+      )
+      expect(page).to have_link(
+        "https://example.com/info", href: "https://example.com/info", target: "_blank"
+      )
+    end
+
     it "uses the imported BOOTH image when no jacket is attached" do
       scenario.booth_image.attach(
         io: File.open(Rails.root.join("spec/fixtures/files/dot.png")), filename: "booth-detail.png", content_type: "image/png"


### PR DESCRIPTION
## What

- Open external links in a new tab
- Link URL text in free-form fields and displayed link destinations
- Display character sheet URLs as link text

## Why

Align external-link behavior across the catalog.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #40