### PR TITLE
Move scenario list updates onto Turbo

### DIFF
--- a/app/controllers/manage/scenarios_controller.rb
+++ b/app/controllers/manage/scenarios_controller.rb
@@ -16,7 +16,15 @@ module Manage
     def move
       authorize @scenario, :reorder?
       @scenario.move(params[:direction].to_s)
-      redirect_to manage_scenarios_path
+      @scenarios = Scenario.includes(:game_systems, :authors).gm_ordered
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace("manage_scenarios",
+            partial: "manage/scenarios/scenarios", locals: { scenarios: @scenarios })
+        end
+        format.html { redirect_to manage_scenarios_path }
+      end
     end
 
     def refresh_booth_image

--- a/app/views/manage/scenarios/_scenarios.html.erb
+++ b/app/views/manage/scenarios/_scenarios.html.erb
@@ -1,0 +1,30 @@
+<tbody id="manage_scenarios"
+       data-controller="sortable"
+       data-sortable-url-value="<%= reorder_manage_scenarios_path %>"
+       data-sortable-saved-message-value="保存しました"
+       data-sortable-failed-message-value="保存できませんでした">
+  <% scenarios.each do |scenario| %>
+    <tr class="border-b border-rule last:border-b-0"
+        draggable="true"
+        data-sortable-target="row"
+        data-sortable-id-param="<%= scenario.id %>"
+        data-action="dragstart->sortable#start dragover->sortable#over drop->sortable#drop dragend->sortable#finish">
+      <td class="p-3 whitespace-nowrap">
+        <span class="cursor-move text-muted select-none" aria-hidden="true">⠿</span>
+        <%= button_to "↑", move_manage_scenario_path(scenario, direction: "up"), method: :patch,
+              form: { class: "inline" }, class: "px-1 text-seal",
+              aria: { label: "#{scenario.title} を1つ上へ" } %>
+        <%= button_to "↓", move_manage_scenario_path(scenario, direction: "down"), method: :patch,
+              form: { class: "inline" }, class: "px-1 text-seal",
+              aria: { label: "#{scenario.title} を1つ下へ" } %>
+      </td>
+      <td class="p-3 font-display"><%= scenario.title %></td>
+      <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
+      <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
+      <td class="p-3 text-right">
+        <%= link_to "詳細", scenario_path(scenario), class: "mr-3 text-seal" %>
+        <%= link_to "編集", edit_manage_scenario_path(scenario), class: "text-seal" %>
+      </td>
+    </tr>
+  <% end %>
+</tbody>

--- a/app/views/manage/scenarios/index.html.erb
+++ b/app/views/manage/scenarios/index.html.erb
@@ -19,35 +19,7 @@
       <th class="p-3"></th>
     </tr>
   </thead>
-  <tbody data-controller="sortable"
-         data-sortable-url-value="<%= reorder_manage_scenarios_path %>"
-         data-sortable-saved-message-value="保存しました"
-         data-sortable-failed-message-value="保存できませんでした">
-    <% @scenarios.each do |scenario| %>
-      <tr class="border-b border-rule last:border-b-0"
-          draggable="true"
-          data-sortable-target="row"
-          data-sortable-id-param="<%= scenario.id %>"
-          data-action="dragstart->sortable#start dragover->sortable#over drop->sortable#drop dragend->sortable#finish">
-        <td class="p-3 whitespace-nowrap">
-          <span class="cursor-move text-muted select-none" aria-hidden="true">⠿</span>
-          <%= button_to "↑", move_manage_scenario_path(scenario, direction: "up"), method: :patch,
-                form: { class: "inline" }, class: "px-1 text-seal",
-                aria: { label: "#{scenario.title} を1つ上へ" } %>
-          <%= button_to "↓", move_manage_scenario_path(scenario, direction: "down"), method: :patch,
-                form: { class: "inline" }, class: "px-1 text-seal",
-                aria: { label: "#{scenario.title} を1つ下へ" } %>
-        </td>
-        <td class="p-3 font-display"><%= scenario.title %></td>
-        <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
-        <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
-        <td class="p-3 text-right">
-          <%= link_to "詳細", scenario_path(scenario), class: "mr-3 text-seal" %>
-          <%= link_to "編集", edit_manage_scenario_path(scenario), class: "text-seal" %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
+  <%= render "scenarios", scenarios: @scenarios %>
 </table>
 
 <div class="fixed right-6 bottom-6"

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -1,7 +1,8 @@
 <ul class="mt-3 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
   <% scenarios.each do |scenario| %>
     <li class="bg-surface">
-      <%= link_to scenario_path(scenario), class: "group flex h-full flex-col gap-3 p-4 no-underline text-ink" do %>
+      <%= link_to scenario_path(scenario), data: { turbo_frame: "_top" },
+            class: "group flex h-full flex-col gap-3 p-4 no-underline text-ink" do %>
         <div class="aspect-3/4 overflow-hidden bg-paper">
           <% if scenario.jacket.attached? %>
             <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -16,7 +16,7 @@
       <% scenarios.each do |scenario| %>
         <tr class="border-b border-rule last:border-b-0 hover:bg-paper">
           <td class="p-3">
-            <%= link_to scenario.title, scenario_path(scenario), class: "font-display text-ink" %>
+            <%= link_to scenario.title, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "font-display text-ink" %>
           </td>
           <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
           <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "シナリオ一覧" %>
 
-<%= turbo_frame_tag "scenario_list" do %>
+<%= turbo_frame_tag "scenario_list", data: { turbo_action: "advance" } do %>
 <div class="flex flex-wrap items-baseline justify-between gap-4">
   <h1 class="font-display text-3xl tracking-wide">
     シナリオ一覧<span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "シナリオ一覧" %>
 
+<%= turbo_frame_tag "scenario_list" do %>
 <div class="flex flex-wrap items-baseline justify-between gap-4">
   <h1 class="font-display text-3xl tracking-wide">
     シナリオ一覧<span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>
@@ -99,4 +100,5 @@
   <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">
     <%= @listing.filtered? ? "条件に合うシナリオがありません。" : "まだシナリオが登録されていません。" %>
   </p>
+<% end %>
 <% end %>

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -173,6 +173,19 @@ RSpec.describe "Manage::Scenarios" do
         expect(Scenario.gm_ordered.pluck(:title)).to eq([ "した", "うえ" ])
       end
 
+      it "replaces the table body after moving one row with Turbo" do
+        create(:scenario, title: "うえ")
+        bottom = create(:scenario, title: "した")
+
+        patch move_manage_scenario_path(bottom, direction: "up"),
+          headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        document = Capybara.string(response.body)
+        expect(document).to have_css('turbo-stream[action="replace"][target="manage_scenarios"]')
+        expect(response.body.index("した")).to be < response.body.index("うえ")
+      end
+
       it "offers those buttons on every row" do
         scenario = create(:scenario, title: "カタシロ")
 

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe "Sorting and filtering the scenario list" do
     Capybara.string(response.body).find('select[name="order"]')
   end
 
+  it "puts the interactive list controls and results in one Turbo Frame" do
+    get root_path
+
+    frame = Capybara.string(response.body).find("turbo-frame#scenario_list")
+    expect(frame).to have_button("1人")
+    expect(frame).to have_select("並び順")
+    expect(frame).to have_css("table")
+  end
+
+  it "still renders a complete HTML page on a cold request" do
+    get root_path(order: "title_desc")
+
+    expect(response.media_type).to eq("text/html")
+    expect(response.body).to include("<html", "<title>", "turbo-frame")
+    expect_order("最後の見本", "なかほど", "いちばん")
+  end
+
   describe "sorting" do
     it "opens on the order the GM arranged" do
       get root_path

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe "Sorting and filtering the scenario list" do
     get root_path
 
     frame = Capybara.string(response.body).find("turbo-frame#scenario_list")
+    expect(frame["data-turbo-action"]).to eq("advance")
     expect(frame).to have_button("1人")
     expect(frame).to have_select("並び順")
     expect(frame).to have_css("table")
+    expect(frame).to have_css('a[data-turbo-frame="_top"]', text: "いちばん")
   end
 
   it "still renders a complete HTML page on a cold request" do


### PR DESCRIPTION
## What

- Replace the manage scenario table body with a Turbo Stream after ↑↓ moves
- Update public scenario list controls and results within a Turbo Frame
- Preserve complete HTML rendering for cold requests and non-Turbo fallbacks

## Why

Move the independent partial-update candidates from issue #58 onto Hotwire. The drag-and-drop portion remains dependent on #57.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #58