### PR TITLE
Preserve the current URL across sign-in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     reset_session
     session[:user_id] = user.id
 
-    redirect_to root_path, notice: sign_in_notice(user)
+    redirect_to return_to_url, notice: sign_in_notice(user)
   rescue KeyError, ActiveRecord::ActiveRecordError
     failure
   end
@@ -21,6 +21,10 @@ class SessionsController < ApplicationController
   end
 
   private
+    def return_to_url
+      url_from(request.env["omniauth.origin"]) || root_path
+    end
+
     def sign_in_notice(user)
       "ログインしました" if user.linked?
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
             <%= link_to "新規登録", new_registration_path, class: "text-seal underline" %>
             <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
             <%= button_to "ログイン", "/auth/google_oauth2", method: :post,
+                  params: { origin: request.fullpath },
                   form: { data: { turbo: false } },
                   class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
           <% end %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -20,6 +20,7 @@
 
     <%# Turbo はフォーム送信を横取りするが、Google への cross-origin リダイレクトを追えない。 %>
     <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
+          params: { origin: request.fullpath },
           form: { data: { turbo: false } },
           class: "cursor-pointer bg-ink px-4 py-2 text-paper hover:bg-seal" %>
   </div>

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Sessions" do
     OmniAuth.config.test_mode = false
   end
 
-  def sign_in
-    post "/auth/google_oauth2"
+  def sign_in(origin: nil)
+    post "/auth/google_oauth2", params: { origin: }.compact
     follow_redirect!
   end
 
@@ -31,6 +31,18 @@ RSpec.describe "Sessions" do
       expect { sign_in }.to change(User, :count).by(1)
 
       expect(User.sole.person).to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "returns to the URL where sign-in started" do
+      sign_in(origin: scenario_path(create(:scenario), view: "cards"))
+
+      expect(response).to redirect_to(%r{/scenarios/\d+\?view=cards\z})
+    end
+
+    it "does not redirect to another host" do
+      sign_in(origin: "https://example.com/phishing")
+
       expect(response).to redirect_to(root_path)
     end
 

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe "The sign-in button" do
     expect(form).to include('method="post"')
   end
 
+  it "passes the current URL through the sign-in flow" do
+    get root_path(order: "title_desc")
+
+    form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
+
+    expect(form).to include(%(name="origin" value="/?order=title_desc"))
+  end
+
   # Chrome は form-action をリダイレクト先にも当てる。self だけだと押しても Google へ進めない。
   it "allows the sign-in redirect to Google in form-action" do
     get root_path


### PR DESCRIPTION
## What

Return users to the page where they started Google sign-in, including query parameters. Only same-host return URLs are accepted.

## Why

Signing in should not discard the user’s current browsing context.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #56