### PR TITLE
Render application error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   private
 
   def render_not_found
-    render "errors/show", status: :not_found,
+    render "errors/show", status: :not_found, formats: [ :html ],
       locals: { message: "ページが見つかりませんでした" }, layout: "error"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,12 +9,19 @@ class ApplicationController < ActionController::Base
   after_action :verify_authorized
 
   # 存在を伏せるため 403 ではなく 404 を返す。
-  rescue_from Pundit::NotAuthorizedError, with: -> { head :not_found }
-  rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }
+  rescue_from Pundit::NotAuthorizedError, with: :render_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  private
+
+  def render_not_found
+    render "errors/show", status: :not_found,
+      locals: { message: "ページが見つかりませんでした" }, layout: "error"
+  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ActionController::Base
+  def show
+    status = params[:code].to_i
+    message = status < 500 ? "ページが見つかりませんでした" : "サーバーでエラーが発生しました"
+
+    render status:, locals: { message: }, layout: "error"
+  end
+end

--- a/app/views/errors/show.html.erb
+++ b/app/views/errors/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, message %>
+
+<div class="mx-auto max-w-xl py-12 text-center">
+  <h1 class="font-display text-3xl text-ink"><%= message %></h1>
+  <p class="mt-8">
+    <%= link_to "トップページに戻る", root_path, class: "text-seal underline" %>
+  </p>
+</div>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <title><%= content_for(:title) %> | TRPGカタログ</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csp_meta_tag %>
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+  </head>
+  <body class="min-h-dvh flex flex-col">
+    <header class="border-b border-rule bg-surface">
+      <div class="mx-auto max-w-5xl px-5 py-5">
+        <%= link_to "TRPGカタログ", root_path, class: "font-display text-xl tracking-wide no-underline text-ink" %>
+      </div>
+    </header>
+    <main class="mx-auto w-full max-w-5xl grow px-5 py-10">
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module TrpgCatalog
     config.i18n.default_locale = :ja
     config.i18n.available_locales = [ :ja ]
     config.time_zone = "Asia/Tokyo"
+    config.exceptions_app = routes
 
     # config.eager_load_paths << Rails.root.join("extras")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,6 @@ Rails.application.routes.draw do
   get "sitemap.xml", to: "sitemaps#show", defaults: { format: "xml" }
 
   root "scenarios#index"
+
+  match "/:code", to: "errors#show", via: :all, constraints: { code: /[45]\d{2}/ }
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -8,11 +8,8 @@ RSpec.describe ApplicationController do
   end
 
   it "answers 404 rather than 403 when authorization fails" do
-    controller = described_class.new
-    allow(controller).to receive(:head)
+    handler = described_class.rescue_handlers.to_h.fetch("Pundit::NotAuthorizedError")
 
-    controller.rescue_with_handler(Pundit::NotAuthorizedError.new)
-
-    expect(controller).to have_received(:head).with(:not_found)
+    expect(handler).to eq(:render_not_found)
   end
 end

--- a/spec/requests/error_pages_spec.rb
+++ b/spec/requests/error_pages_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Error pages" do
+  around do |example|
+    original = Rails.application.env_config["action_dispatch.show_detailed_exceptions"]
+    Rails.application.env_config["action_dispatch.show_detailed_exceptions"] = false
+    example.run
+  ensure
+    Rails.application.env_config["action_dispatch.show_detailed_exceptions"] = original
+  end
+
+  it "renders the site 404 page at an unknown URL" do
+    get "/missing-page"
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include("ページが見つかりませんでした")
+    expect(Capybara.string(response.body)).to have_link("トップページに戻る", href: root_path)
+    expect(response).not_to be_redirect
+  end
+
+  it "renders the site 404 page when authorization hides a page" do
+    get play_sessions_path
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include("ページが見つかりませんでした")
+  end
+
+  it "renders the site 500 page" do
+    post "/500"
+
+    expect(response).to have_http_status(:internal_server_error)
+    expect(response.body).to include("サーバーでエラーが発生しました")
+    expect(Capybara.string(response.body)).to have_link("トップページに戻る", href: root_path)
+    expect(response).not_to be_redirect
+  end
+end

--- a/spec/requests/error_pages_spec.rb
+++ b/spec/requests/error_pages_spec.rb
@@ -25,12 +25,26 @@ RSpec.describe "Error pages" do
     expect(response.body).to include("ページが見つかりませんでした")
   end
 
-  it "renders the site 500 page" do
-    post "/500"
+  it "renders the site 404 page for a non-HTML authorization request" do
+    get play_sessions_path, as: :json
 
-    expect(response).to have_http_status(:internal_server_error)
-    expect(response.body).to include("サーバーでエラーが発生しました")
-    expect(Capybara.string(response.body)).to have_link("トップページに戻る", href: root_path)
-    expect(response).not_to be_redirect
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include("ページが見つかりませんでした")
+  end
+
+  it "renders the site 500 page through the exception application" do
+    env = Rack::MockRequest.env_for("/original-path")
+    env["PATH_INFO"] = "/500"
+    env["action_dispatch.original_path"] = "/original-path"
+    env["action_dispatch.exception"] = RuntimeError.new("unexpected failure")
+
+    status, headers, body = Rails.application.config.exceptions_app.call(env)
+    response_body = body.each.to_a.join
+
+    expect(status).to eq(500)
+    expect(headers).not_to include("location")
+    expect(response_body).to include("サーバーでエラーが発生しました")
+    expect(Capybara.string(response_body)).to have_link("トップページに戻る", href: root_path)
+    expect(env["action_dispatch.original_path"]).to eq("/original-path")
   end
 end


### PR DESCRIPTION
## What

Render branded error pages for 4xx and 5xx responses without redirecting away from the requested URL.

## Why

Visitors currently receive a browser error page when an application response has no body.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #48