### PR TITLE
Add person-specific scenario statuses

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -2,9 +2,10 @@ class ScenariosController < ApplicationController
   before_action :set_scenario, only: %i[show edit update destroy refresh_booth_image destroy_jacket]
 
   def index
+    @owner = Person.admins.first
     @listing = ScenarioListing.new(policy_scope(Scenario), params)
     @scenarios = @listing.scenarios.includes(:game_systems, :authors, :purchase_links,
-      jacket_attachment: :blob, booth_image_attachment: :blob)
+      :scenario_statuses, jacket_attachment: :blob, booth_image_attachment: :blob)
     authorize Scenario
   end
 
@@ -12,19 +13,34 @@ class ScenariosController < ApplicationController
     authorize @scenario
   end
 
-  def new = @scenario = authorize(Scenario.new)
+  def new
+    @scenario = authorize(Scenario.new)
+    set_scenario_status
+  end
 
-  def edit = authorize(@scenario)
+  def edit
+    authorize(@scenario)
+    set_scenario_status
+  end
 
   def create
     @scenario = authorize Scenario.new(scenario_params)
-    return redirect_to(@scenario, notice: "#{@scenario.title} を登録しました") if @scenario.save
+    set_scenario_status
+    @scenario_status.assign_attributes(scenario_status_params)
+    if save_scenario_and_status
+      return redirect_to(@scenario, notice: "#{@scenario.title} を登録しました")
+    end
     render :new, status: :unprocessable_content
   end
 
   def update
     authorize @scenario
-    return redirect_to(@scenario, notice: "#{@scenario.title} を更新しました") if @scenario.update(scenario_params)
+    set_scenario_status
+    @scenario.assign_attributes(scenario_params)
+    @scenario_status.assign_attributes(scenario_status_params)
+    if save_scenario_and_status
+      return redirect_to(@scenario, notice: "#{@scenario.title} を更新しました")
+    end
     render :edit, status: :unprocessable_content
   end
 
@@ -53,10 +69,28 @@ class ScenariosController < ApplicationController
     end
 
     def scenario_params
-      params.expect(scenario: [ :title, :synopsis, :preparation_note, :recommendation_note, :gm_experienced,
+      params.expect(scenario: [ :title, :synopsis, :preparation_note, :recommendation_note,
         :character_restriction, :character_sheet_deadline, :character_sheet_deadline_note, :player_count_min,
         :player_count_max, :duration_min_hours, :duration_max_hours, :jacket,
         { game_system_ids: [], author_ids: [], purchase_links_attributes: [ [ :id, :label, :url, :position, :_destroy ] ],
           stream_links_attributes: [ [ :id, :label, :url, :position, :_destroy ] ] } ])
+    end
+
+    def scenario_status_params
+      params.fetch(:scenario_status, ActionController::Parameters.new)
+        .permit(:gm_experienced, :pl_experienced, :read)
+    end
+
+    def set_scenario_status
+      @scenario_status = current_person.scenario_statuses.find_or_initialize_by(scenario: @scenario)
+    end
+
+    def save_scenario_and_status
+      Scenario.transaction do
+        next false unless @scenario.save
+
+        @scenario_status.scenario = @scenario
+        @scenario_status.save!
+      end
     end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,6 +13,8 @@ class Person < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_scenarios, through: :favorites, source: :scenario
   has_many :spoiler_reveals, dependent: :destroy
+  has_many :scenario_statuses, dependent: :destroy
+  has_many :owned_scenarios, through: :scenario_statuses, source: :scenario
   has_many :group_memberships, dependent: :destroy
   has_many :groups, through: :group_memberships
 

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -26,6 +26,7 @@ class Scenario < ApplicationRecord
   has_many :authors, through: :scenario_authors
   has_many :favorites, dependent: :destroy
   has_many :spoiler_reveals, dependent: :destroy
+  has_many :scenario_statuses, dependent: :destroy
   # セッションが残っているシナリオは消させない。消すと参加記録ごと失われる。
   has_many :play_sessions, dependent: :restrict_with_error
   has_many :purchase_links, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :scenario
@@ -66,6 +67,10 @@ class Scenario < ApplicationRecord
   end
 
   def sub_game_master_label = "サブ#{game_master_label}"
+
+  def status_for(person)
+    scenario_statuses.find { |status| status.person_id == person&.id }
+  end
 
   validates :title, presence: true
   validates :jacket,

--- a/app/models/scenario_status.rb
+++ b/app/models/scenario_status.rb
@@ -1,0 +1,14 @@
+class ScenarioStatus < ApplicationRecord
+  belongs_to :person
+  belongs_to :scenario
+
+  validates :person_id, uniqueness: { scope: :scenario_id }
+
+  def label
+    return "#{scenario.game_master_label}経験あり" if gm_experienced?
+    return "PL経験あり" if pl_experienced?
+    return "シナリオ既読" if read?
+
+    "シナリオ所持"
+  end
+end

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -81,11 +81,20 @@
     <legend class="px-2 font-display text-sm">評価と本文</legend>
 
     <div class="space-y-4">
-      <div>
-        <label class="inline-flex items-center gap-2 text-sm">
-          <%= form.check_box :gm_experienced %> <%= GameSystem::DEFAULT_GAME_MASTER_LABEL %>経験あり
-        </label>
-      </div>
+      <% [ [ :gm_experienced, "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}経験" ],
+           [ :pl_experienced, "PL経験" ], [ :read, "シナリオ既読" ] ].each do |attribute, label| %>
+        <fieldset>
+          <legend class="text-xs text-muted"><%= label %></legend>
+          <div class="mt-1 flex gap-4 text-sm">
+            <label class="inline-flex items-center gap-2">
+              <%= radio_button_tag "scenario_status[#{attribute}]", "1", @scenario_status.public_send(attribute), required: true %> あり
+            </label>
+            <label class="inline-flex items-center gap-2">
+              <%= radio_button_tag "scenario_status[#{attribute}]", "0", !@scenario_status.public_send(attribute), required: true %> なし
+            </label>
+          </div>
+        </fieldset>
+      <% end %>
 
       <p class="text-xs text-muted">
         並び順は<%= link_to "#{Scenario.model_name.human}の並び順", scenario_order_index_path, class: "text-seal" %>で決めます。

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -8,7 +8,7 @@
         <th scope="col" class="p-3"><%= GameSystem.model_name.human %></th>
         <th scope="col" class="p-3">人数</th>
         <th scope="col" class="p-3">目安時間</th>
-        <th scope="col" class="p-3"><%= GameSystem::DEFAULT_GAME_MASTER_LABEL %>経験</th>
+        <th scope="col" class="p-3">ステータス</th>
         <th scope="col" class="p-3">入手先</th>
         <% if policy(Scenario).update? %><th scope="col" class="p-3">操作</th><% end %>
       </tr>
@@ -23,7 +23,7 @@
           <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
           <td class="p-3 font-mono text-xs"><%= player_count_value(scenario) %></td>
           <td class="p-3 font-mono text-xs"><%= duration_value(scenario) %></td>
-          <td class="p-3 text-center"><%= scenario.gm_experienced? ? "☑#{scenario.game_master_label}経験あり" : "#{scenario.game_master_label}経験なし" %></td>
+          <td class="p-3 text-center"><%= scenario.status_for(@owner)&.label || "シナリオ所持" %></td>
           <td class="p-3 text-xs">
             <% scenario.purchase_links.each do |link| %>
               <% if link.url.present? %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,10 +1,11 @@
-<% content_for :title, "#{Scenario.model_name.human}一覧" %>
+<% list_title = @owner ? "#{@owner.display_name}が所持するTRPG#{Scenario.model_name.human}一覧" : "#{Scenario.model_name.human}一覧" %>
+<% content_for :title, list_title %>
 
 <%= turbo_frame_tag "scenario_list", data: { turbo_action: "advance" } do %>
 <div class="flex flex-wrap items-baseline justify-between gap-4">
   <div>
     <h1 class="font-display text-3xl tracking-wide">
-      <%= Scenario.model_name.human %>一覧<span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>
+      <%= list_title %><span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>
     </h1>
     <% if policy(Scenario).create? %>
       <p class="mt-3"><%= link_to "新規登録", new_scenario_path, data: { turbo_frame: "_top" }, class: "text-sm text-seal" %></p>

--- a/db/migrate/20260815000000_create_scenario_statuses.rb
+++ b/db/migrate/20260815000000_create_scenario_statuses.rb
@@ -1,0 +1,28 @@
+class CreateScenarioStatuses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :scenario_statuses do |t|
+      t.references :person, null: false, foreign_key: true
+      t.references :scenario, null: false, foreign_key: true
+      t.boolean :gm_experienced, null: false, default: false
+      t.boolean :pl_experienced, null: false, default: false
+      t.boolean :read, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :scenario_statuses, [ :person_id, :scenario_id ], unique: true
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          INSERT INTO scenario_statuses
+            (person_id, scenario_id, gm_experienced, pl_experienced, read, created_at, updated_at)
+          SELECT person_roles.person_id, scenarios.id, scenarios.gm_experienced, FALSE, FALSE,
+                 CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+          FROM person_roles CROSS JOIN scenarios
+          WHERE person_roles.name = 0
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_160305) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -198,6 +198,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_160305) do
     t.index ["scenario_id"], name: "index_scenario_game_systems_on_scenario_id"
   end
 
+  create_table "scenario_statuses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "gm_experienced", default: false, null: false
+    t.bigint "person_id", null: false
+    t.boolean "pl_experienced", default: false, null: false
+    t.boolean "read", default: false, null: false
+    t.bigint "scenario_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id", "scenario_id"], name: "index_scenario_statuses_on_person_id_and_scenario_id", unique: true
+    t.index ["person_id"], name: "index_scenario_statuses_on_person_id"
+    t.index ["scenario_id"], name: "index_scenario_statuses_on_scenario_id"
+  end
+
   create_table "scenarios", force: :cascade do |t|
     t.string "character_restriction"
     t.integer "character_sheet_deadline"
@@ -285,6 +298,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_160305) do
   add_foreign_key "scenario_authors", "scenarios"
   add_foreign_key "scenario_game_systems", "game_systems"
   add_foreign_key "scenario_game_systems", "scenarios"
+  add_foreign_key "scenario_statuses", "people"
+  add_foreign_key "scenario_statuses", "scenarios"
   add_foreign_key "session_schedules", "play_sessions"
   add_foreign_key "spoiler_reveals", "people"
   add_foreign_key "spoiler_reveals", "scenarios"

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -12,6 +12,14 @@ FactoryBot.define do
     player_count_min { 1 }
   end
 
+  factory :scenario_status do
+    scenario
+    person
+    gm_experienced { false }
+    pl_experienced { false }
+    read { false }
+  end
+
   factory :purchase_link do
     scenario
     label { "BOOTH" }

--- a/spec/models/scenario_status_spec.rb
+++ b/spec/models/scenario_status_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ScenarioStatus do
+  it "belongs to one person and scenario only once" do
+    status = create(:scenario_status)
+
+    duplicate = build(:scenario_status, person: status.person, scenario: status.scenario)
+
+    expect(duplicate).not_to be_valid
+  end
+
+  it "uses the highest-priority status label" do
+    scenario = create(:scenario, game_systems: [ create(:game_system, game_master_label: "KP") ])
+
+    expect(build(:scenario_status, scenario:, gm_experienced: true, pl_experienced: true, read: true).label)
+      .to eq("KP経験あり")
+    expect(build(:scenario_status, scenario:, pl_experienced: true, read: true).label).to eq("PL経験あり")
+    expect(build(:scenario_status, scenario:, read: true).label).to eq("シナリオ既読")
+    expect(build(:scenario_status, scenario:).label).to eq("シナリオ所持")
+  end
+end

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe "The scenario list" do
   end
 
   describe "the heading" do
+    it "names the administrator whose scenarios are listed" do
+      create(:person, display_name: "カーリア", roles: %w[admin])
+
+      get root_path
+
+      expect(response.body).to include("カーリアが所持するTRPGシナリオ一覧")
+    end
+
     it "counts the scenarios beside the title" do
       create(:scenario, title: "もう1本")
 
@@ -172,48 +180,50 @@ RSpec.describe "The scenario list" do
     end
   end
 
-  describe "GM experience" do
-    it "uses each scenario's game master label in the table" do
+  describe "scenario status" do
+    let!(:admin) { create(:person, roles: %w[admin]) }
+
+    it "uses each scenario's game master label for GM experience" do
       scenario.game_systems.first.update!(game_master_label: "DL")
+      create(:scenario_status, person: admin, scenario:, gm_experienced: true)
 
       get root_path
 
-      expect(Capybara.string(response.body).find("tr", text: scenario.title)).to have_text("☑DL経験あり")
+      expect(Capybara.string(response.body).find("tr", text: scenario.title)).to have_text("DL経験あり")
     end
 
-    it "marks only experienced scenarios in the table" do
-      inexperienced = create(:scenario, title: "未経験シナリオ", gm_experienced: false)
+    it "shows only the administrator's highest-priority label" do
+      create(:scenario_status, person: admin, scenario:, pl_experienced: true, read: true)
+      other = create(:person, roles: %w[gm])
+      create(:scenario_status, person: other, scenario:, gm_experienced: true)
 
       get root_path
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("th", text: "GM経験")
-      expect(page.find("tr", text: scenario.title)).to have_text("☑")
-      expect(page.find("tr", text: inexperienced.title)).to have_no_text("☑")
+      expect(page).to have_css("th", text: "ステータス")
+      expect(page.find("tr", text: scenario.title)).to have_text("PL経験あり")
+      expect(page.find("tr", text: scenario.title)).to have_no_text(/GM経験あり|シナリオ既読/)
     end
 
-    it "says the GM has experience on an experienced scenario page" do
-      get scenario_path(scenario)
+    it "falls back to ownership when the administrator has no positive status" do
+      create(:scenario_status, person: admin, scenario:)
 
-      expect(response.body).to include("☑GM経験あり")
+      get root_path
+
+      expect(Capybara.string(response.body).find("tr", text: scenario.title)).to have_text("シナリオ所持")
     end
 
-    it "says the GM has no experience on an inexperienced scenario page" do
-      scenario.update!(gm_experienced: false)
-
-      get scenario_path(scenario)
-
-      expect(response.body).to include("GM経験なし")
-      expect(response.body).not_to include("☑GM経験あり")
-    end
-
-    it "uses the new label on the edit screen" do
-      sign_in_as create(:person, roles: %w[gm])
+    it "offers yes and no radio buttons for all three values on the edit screen" do
+      editor = create(:person, roles: %w[gm])
+      create(:scenario_status, person: editor, scenario:, gm_experienced: true, read: true)
+      sign_in_as editor
 
       get edit_scenario_path(scenario)
 
-      expect(response.body).to include("GM経験あり")
-      expect(response.body).not_to include("回したことがある")
+      page = Capybara.string(response.body)
+      %w[gm_experienced pl_experienced read].each do |attribute|
+        expect(page).to have_css(%(input[type="radio"][name="scenario_status[#{attribute}]"]), count: 2)
+      end
     end
   end
 

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -216,4 +216,20 @@ RSpec.describe "Scenarios" do
       expect(response.body).to include("書籍購入者限定特典")
     end
   end
+
+  describe "PATCH /scenarios/:id" do
+    it "records scenario status for the signed-in editor" do
+      editor = create(:person, roles: %w[gm])
+      scenario = create(:scenario)
+      sign_in_as editor
+
+      patch scenario_path(scenario), params: {
+        scenario: { title: scenario.title, player_count_min: 1 },
+        scenario_status: { gm_experienced: "0", pl_experienced: "1", read: "1" }
+      }
+
+      status = editor.scenario_statuses.find_by!(scenario:)
+      expect(status).to have_attributes(gm_experienced: false, pl_experienced: true, read: true)
+    end
+  end
 end


### PR DESCRIPTION
## What

- Add GM experience, PL experience, and read status per person and scenario
- Edit the signed-in editor status with radio buttons
- Show the administrator name and highest-priority status on the scenario list

## Why

Replace the scenario-wide GM experience flag with status owned by each GM or administrator.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`

## Related

Closes #90