### PR TITLE
Move the remaining build actions off Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Derive image metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Attest the image provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## What

Bump the two actions in `build.yml` that Dependabot has not reached yet, both onto the Node 24 runtime.

- `docker/metadata-action` v5.10.0 -> v6.2.0
- `actions/attest-build-provenance` v2.4.0 -> v4.2.2

## Why

The Build workflow warns that these still target Node.js 20. Dependabot's default 5-PR limit is already used up by the open action bumps, so it will not propose these until those merge. Inputs used here are unchanged in both majors.

Part of #97.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

The Build workflow only runs on `main`, so the Node 20 warning can only be confirmed gone after merge.

## Related
