### PR TITLE
Restore variant sharpening after image_processing 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ TRPG のシナリオとセッションのカタログサイト。
 ## 動かす
 
 必要なのは [mise](https://mise.jdx.dev/) と Docker と libvips の3つ。Ruby と Node は mise が入れる。
-libvips は Active Storage の variant 生成に使う。無いと起動時に落ちる（Ubuntu なら `libvips42t64`、macOS なら `brew install vips`）。
+libvips は Active Storage の variant 生成に使う。無いと起動時に落ちる（Debian/Ubuntu なら `libvips-tools`、macOS なら `brew install vips`）。
+本体の package 名は release ごとに変わる（Ubuntu 24.04 は `libvips42t64`、22.04 は `libvips42`）ため、名前が変わらない `libvips-tools` を CI でも使っている。
 
 ```bash
 mise install

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,7 +1,7 @@
 class Person < ApplicationRecord
   DISPLAY_NAME_ATTRIBUTE = :display_name
   has_one_attached :icon do |attachable|
-    attachable.variant :thumb, resize_to_fill: [ 160, 160 ], format: :webp, saver: { quality: 80 }
+    attachable.variant :thumb, resize_to_fill: [ 160, 160, { sharpen: true } ], format: :webp, saver: { quality: 80 }
   end
 
   has_many :users, dependent: :nullify

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -10,14 +10,16 @@ class Scenario < ApplicationRecord
     see_note: 4
   }, validate: { allow_nil: true }
 
+  # sharpen は image_processing 2.0 で既定が外れた。明示すると variant key も変わり、
+  # 1.x 時代に生成済みの画像が再生成されて見た目が揃う。
   has_one_attached :jacket do |attachable|
-    attachable.variant :thumb, resize_to_limit: [ 480, 640 ], format: :webp, saver: { quality: 80 }
-    attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
+    attachable.variant :thumb, resize_to_limit: [ 480, 640, { sharpen: true } ], format: :webp, saver: { quality: 80 }
+    attachable.variant :cover, resize_to_limit: [ 800, 1200, { sharpen: true } ], format: :webp, saver: { quality: 85 }
   end
 
   has_one_attached :booth_image do |attachable|
-    attachable.variant :thumb, resize_to_limit: [ 480, 640 ], format: :webp, saver: { quality: 80 }
-    attachable.variant :cover, resize_to_limit: [ 800, 1200 ], format: :webp, saver: { quality: 85 }
+    attachable.variant :thumb, resize_to_limit: [ 480, 640, { sharpen: true } ], format: :webp, saver: { quality: 80 }
+    attachable.variant :cover, resize_to_limit: [ 800, 1200, { sharpen: true } ], format: :webp, saver: { quality: 85 }
   end
 
   has_many :scenario_game_systems, dependent: :destroy

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe Person do
       expect(person.groups.map(&:name)).to contain_exactly("よく遊ぶ人たち", "ペア卓")
     end
   end
+
+  # resize_to_fill は resize_to_limit と別の引数の組み立てを通るため、別に見る。
+  describe "icon variant" do
+    it "keeps sharpening" do
+      variants = described_class.reflect_on_attachment(:icon).named_variants
+
+      expect(variants[:thumb].transformations[:resize_to_fill]).to eq([ 160, 160, { sharpen: true } ])
+    end
+
+    it "actually processes" do
+      person = create(:person)
+      person.icon.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/dot.png"), "image/png")
+      )
+
+      expect { person.icon.variant(:thumb).processed }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -33,9 +33,19 @@ RSpec.describe Scenario do
       %i[jacket booth_image].each do |attachment|
         variants = described_class.reflect_on_attachment(attachment).named_variants
 
-        expect(variants[:thumb].transformations).to include(resize_to_limit: [ 480, 640 ])
-        expect(variants[:cover].transformations).to include(resize_to_limit: [ 800, 1200 ])
+        expect(variants[:thumb].transformations[:resize_to_limit]).to start_with(480, 640)
+        expect(variants[:cover].transformations[:resize_to_limit]).to start_with(800, 1200)
       end
+    end
+
+    # 変換の指定が image_processing に渡らない形だと、宣言時ではなく描画時に初めて落ちる。
+    it "actually processes a variant" do
+      scenario = create(:scenario)
+      scenario.jacket.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/dot.png"), "image/png")
+      )
+
+      expect { scenario.jacket.variant(:thumb).processed }.not_to raise_error
     end
   end
 

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -33,8 +33,10 @@ RSpec.describe Scenario do
       %i[jacket booth_image].each do |attachment|
         variants = described_class.reflect_on_attachment(attachment).named_variants
 
-        expect(variants[:thumb].transformations[:resize_to_limit]).to start_with(480, 640)
-        expect(variants[:cover].transformations[:resize_to_limit]).to start_with(800, 1200)
+        # sharpen は既定に戻ると見た目が変わるうえ、variant key が同じままなので
+        # 生成済みの画像が直らない。値ごと固定する。
+        expect(variants[:thumb].transformations[:resize_to_limit]).to eq([ 480, 640, { sharpen: true } ])
+        expect(variants[:cover].transformations[:resize_to_limit]).to eq([ 800, 1200, { sharpen: true } ])
       end
     end
 


### PR DESCRIPTION
## What

Follow-ups from the review on #5.

- Pass `sharpen: true` to every `resize_to_limit` / `resize_to_fill` variant
- Add a spec that processes a variant, not just inspects its declaration
- Name the same libvips package in README and `ci.yml`

## Why

image_processing 2.0 changed `thumbnail`'s default from `sharpen: SHARPEN_MASK` to `sharpen: nil`, so variants silently lost post-resize sharpening. Since the transformations were unchanged, the variant key was unchanged too and the already-generated images would never be regenerated — the catalog would have served a mix of sharpened and unsharpened images indefinitely. Naming the option restores the 1.x look and changes the key, so everything regenerates once.

The existing variant spec only asserted on `named_variants`, which cannot catch an option that Active Storage forwards in a shape image_processing rejects — that surfaces at render time. The new spec fails with `Vips::Error: unknown option` when the shape is wrong (verified by deliberately breaking it).

README said `libvips42t64` while CI installed `libvips-tools`. `libvips-tools` is the name that survives Ubuntu releases, so both now say that.

Part of #97.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related
