### PR TITLE
Fix the flaky sign-in race in the profile system spec

### DIFF
--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "A member's own pages" do
 
     visit scenario_path(scenario)
     click_button "お気に入りに入れる"
+    # ボタンの差し替えを待たずに visit すると、飛びかけた POST ごと捨てられる。
+    expect(page).to have_button("お気に入りを外す")
 
     visit person_path(person)
     expect(page).to have_content("見本シナリオ")

--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe "A member's own pages" do
     )
     visit root_path
     click_button "Googleでログイン"
+    # click_button も visit も遷移の完了を待たないため、ここで着地を待たないと
+    # 後から届いたログインのリダイレクトが次の visit を上書きする。
+    expect(page).to have_content("ログインしました")
 
     visit edit_person_path(person)
     fill_in "person[x_account]", with: "karia"


### PR DESCRIPTION
## What

Wait for the sign-in redirect to render before the next `visit` in `spec/system/profile_and_spoiler_spec.rb`.

## Why

This spec has been failing intermittently on `main` (`Unable to find field "person[x_account]"`). The failure screenshot from CI shows the browser sitting on the post-login root page, flash and all, at the moment the field was looked for.

Neither `click_button` nor `visit` waits for a navigation to finish, so the `visit` raced the OAuth round-trip and the late-arriving login redirect replaced the edit page. `editor_navigation_spec.rb` does the same sign-in but follows it with `click_button "メニュー"` — a retrying finder for an element that only renders when signed in — so it synchronises by accident and never flaked.

Only reproducible under the Chrome driver; locally `CHROME_BINARY` is unset, so system specs run on `:rack_test`, which is synchronous.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

Reproduced against real Chrome (Chrome for Testing 152) by running the spec in a loop: **1 failure in 40 runs before, 0 in 150 runs after**.

## Related
