### PR TITLE
Cap each CI job with timeout-minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   image:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
@@ -29,6 +30,7 @@ jobs:
 
   scan_js:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
@@ -44,6 +46,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
@@ -73,6 +76,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       postgres:
@@ -126,6 +130,7 @@ jobs:
   # Dockerfile の破損が main に入ってから分かるのを防ぐ。push はしない。
   image:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

Set `timeout-minutes` on every workflow job: 5 for `scan_ruby` / `scan_js` / `lint`, 10 for `test`, 15 for `image` — in `ci.yml`, and 15 for the release `image` job in `build.yml`.

## Why

In #104 the `test` job hung on the first `apt-get install libvips-tools` step and ran until the 6-hour GitHub Actions job limit cancelled it. Without `timeout-minutes`, any runner hiccup costs 6 hours.

Measured runs are test 1m15s / lint 19s / scan_ruby 23s / scan_js 11s / image 58s, so each cap sits at roughly 5-10x its measurement to absorb cold-cache spikes, with `image` at 15 min because a cache miss there means a full Docker build.

`build.yml` is covered for the same reason: its `concurrency` group is keyed on `github.ref`, so a hung tag build is never cancelled by a later push to `main`.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

<!-- Phase plan or ADR this PR belongs to -->
