### PR TITLE
Add Obsidian UI foundation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :development do
 end
 
 group :test do
+  gem "axe-core-rspec"
   gem "capybara"
   gem "climate_control"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
+    axe-core-api (4.13.0)
+      dumb_delegator
+    axe-core-rspec (4.13.0)
+      axe-core-api (= 4.13.0)
     base64 (0.3.0)
     better_html (2.2.0)
       actionview (>= 7.0)
@@ -148,6 +152,7 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
+    dumb_delegator (1.1.0)
     erb (6.0.7)
     erb_lint (0.9.0)
       activesupport
@@ -505,6 +510,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations
   aws-sdk-s3
+  axe-core-rspec
   bootsnap
   brakeman
   bundler-audit

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -24,14 +24,50 @@
   --color-muted: #5c6472;
   --color-rule: #ccd1d9;
 
+  --color-ui-background: #050608;
+  --color-ui-surface-solid: #12161c;
+  --color-ui-surface: #12161ccc;
+  --color-ui-field-solid: #090c10;
+  --color-ui-field: #090c10cc;
+  --color-ui-subtle: #1a2029;
+  --color-ui-outline: #35404e;
+  --color-ui-outline-strong: #718198;
+  --color-ui-text: #f4f7fb;
+  --color-ui-text-muted: #a5afbd;
+  --color-ui-action: #c7ddf7;
+  --color-ui-action-hover: #dbeaff;
+  --color-ui-action-active: #aec9e8;
+  --color-ui-on-action: #07101a;
+  --color-ui-accent: #9284ff;
+  --color-ui-on-accent: #080612;
+  --color-ui-focus: #a9ceff;
+  --color-ui-danger: #ff8a80;
+  --color-ui-on-danger: #07101a;
+  --color-ui-error: #ffb4ab;
+
+  --radius-ui-surface: 1.875rem;
+  --radius-ui-card: 1.625rem;
+  --radius-ui-control: 0.875rem;
+  --text-ui-caption: 0.8125rem;
+  --text-ui-caption--line-height: 1.25rem;
+  --blur-ui-surface: 20px;
+  --blur-ui-header: 18px;
+  --shadow-ui-surface: 0 1.5rem 4rem rgb(0 0 0 / 35%);
+
   --font-display: "BIZ UDPGothic", sans-serif;
   --font-sans: "BIZ UDPGothic", sans-serif;
   --font-mono: "BIZ UDPGothic", sans-serif;
 }
 
+:root {
+  --z-ui-header: 30;
+  --z-ui-overlay: 40;
+  --z-ui-toast: 50;
+}
+
 @layer base {
   html {
-    color-scheme: light;
+    color-scheme: dark;
   }
 
   body {
@@ -46,7 +82,7 @@
   }
 
   :focus-visible {
-    outline: 2px solid var(--color-seal);
+    outline: 2px solid var(--color-ui-focus);
     outline-offset: 2px;
   }
 }

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -1,0 +1,75 @@
+module UiHelper
+  BUTTON_VARIANTS = {
+    primary: "border-transparent bg-ui-action text-ui-on-action hover:bg-ui-action-hover active:bg-ui-action-active",
+    secondary: "border-ui-outline-strong bg-ui-surface-solid text-ui-text hover:bg-ui-subtle active:bg-ui-field-solid",
+    danger: "border-transparent bg-ui-danger text-ui-on-danger hover:brightness-110 active:brightness-90"
+  }.freeze
+  BUTTON_SIZES = {
+    small: "px-3",
+    medium: "px-4"
+  }.freeze
+  INPUT_TYPES = {
+    text: :text_field,
+    email: :email_field,
+    password: :password_field,
+    search: :search_field,
+    telephone: :telephone_field,
+    url: :url_field
+  }.freeze
+
+  def ui_button(label, variant: :primary, size: :medium, type: "button", disabled: false, id: nil, data: {}, aria: {})
+    render "shared/ui/button",
+      label:,
+      variant_classes: BUTTON_VARIANTS.fetch(variant),
+      size_classes: BUTTON_SIZES.fetch(size),
+      type:,
+      disabled:,
+      id:,
+      data:,
+      aria:
+  end
+
+  def ui_field(form, attribute, label: nil, description: nil, required: false, &block)
+    description_id = form.field_id(attribute, :description) if description.present?
+    error_messages = form.object&.errors&.full_messages_for(attribute) || []
+    error_id = form.field_id(attribute, :error) if error_messages.any?
+    described_by = [ description_id, error_id ].compact.join(" ").presence
+    input = capture({ described_by: }, &block)
+
+    render "shared/ui/field",
+      form:,
+      attribute:,
+      label: label || form.object.class.human_attribute_name(attribute),
+      description:,
+      description_id:,
+      required:,
+      input:,
+      error_messages:,
+      error_id:
+  end
+
+  def ui_input(form, attribute, type: :text, described_by: nil, disabled: false, required: false, id: nil,
+    placeholder: nil, autocomplete: nil, inputmode: nil, data: {}, aria: {})
+    error_id = form.field_id(attribute, :error) if form.object&.errors&.[](attribute)&.any?
+    aria = aria.to_h.stringify_keys
+    aria["describedby"] = [ aria["describedby"], described_by, error_id ].compact.flat_map { |ids| ids.to_s.split }.uniq.join(" ").presence
+    data = data.to_h.merge(ui_error_id: error_id).compact
+    input_options = {
+      disabled:,
+      required:,
+      data:,
+      aria:,
+      class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text placeholder:text-ui-text-muted focus:border-ui-focus focus:outline-none focus:ring-2 focus:ring-ui-focus/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-ui-error aria-invalid:ring-1 aria-invalid:ring-ui-error"
+    }
+    input_options[:id] = id if id
+    input_options[:placeholder] = placeholder if placeholder
+    input_options[:autocomplete] = autocomplete if autocomplete
+    input_options[:inputmode] = inputmode if inputmode
+
+    render "shared/ui/input",
+      form:,
+      attribute:,
+      input_method: INPUT_TYPES.fetch(type),
+      input_options:
+  end
+end

--- a/app/views/shared/ui/_button.html.erb
+++ b/app/views/shared/ui/_button.html.erb
@@ -1,0 +1,7 @@
+<%= tag.button label,
+      type:,
+      disabled:,
+      id:,
+      data:,
+      aria:,
+      class: "inline-flex min-h-11 items-center justify-center gap-2 rounded-ui-control border py-2 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-focus focus-visible:ring-offset-2 focus-visible:ring-offset-ui-background disabled:cursor-not-allowed disabled:opacity-50 #{variant_classes} #{size_classes}" %>

--- a/app/views/shared/ui/_field.html.erb
+++ b/app/views/shared/ui/_field.html.erb
@@ -1,0 +1,19 @@
+<div class="space-y-2">
+  <%= form.label attribute, class: "block text-sm font-bold text-ui-text" do %>
+    <%= label %>
+    <% if required %>
+      <span class="text-ui-error" aria-hidden="true">*</span>
+      <span class="sr-only">必須</span>
+    <% end %>
+  <% end %>
+
+  <% if description.present? %>
+    <p id="<%= description_id %>" class="text-ui-caption text-ui-text-muted"><%= description %></p>
+  <% end %>
+
+  <%= input %>
+
+  <% if error_messages.any? %>
+    <p id="<%= error_id %>" class="text-ui-caption text-ui-error"><%= error_messages.join("、") %></p>
+  <% end %>
+</div>

--- a/app/views/shared/ui/_input.html.erb
+++ b/app/views/shared/ui/_input.html.erb
@@ -1,0 +1,1 @@
+<%= form.public_send input_method, attribute, **input_options %>

--- a/config/initializers/accessible_field_errors.rb
+++ b/config/initializers/accessible_field_errors.rb
@@ -9,12 +9,15 @@ ActionView::Base.field_error_proc = proc do |html_tag, instance|
     next html_tag
   end
 
-  error_id = "#{field['id']}_error"
+  external_error_id = field.delete("data-ui-error-id")&.to_s.presence
+  error_id = external_error_id.presence || "#{field['id']}_error"
   describedby = field["aria-describedby"].to_s.split
   field["aria-invalid"] = "true"
   field["aria-describedby"] = (describedby << error_id).uniq.join(" ")
   method_name = instance.instance_variable_get(:@method_name)
   message = instance.object.errors.full_messages_for(method_name).join("、")
   attribute = ERB::Util.html_escape(method_name)
+  next fragment.to_html.html_safe if external_error_id
+
   "#{fragment.to_html}<span id=\"#{ERB::Util.html_escape(error_id)}\" class=\"sr-only\" data-error-attribute=\"#{attribute}\">#{ERB::Util.html_escape(message)}</span>".html_safe
 end

--- a/spec/assets/ui_tokens_spec.rb
+++ b/spec/assets/ui_tokens_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe "UI design tokens" do
   end
 
   it "provides sufficient contrast for strong outlines and semantic colors" do
-    expect(contrast("#718198", "#12161c")).to be >= 3
-    expect(contrast("#ff8a80", "#050608")).to be >= 4.5
-    expect(contrast("#ffb4ab", "#050608")).to be >= 4.5
+    expect(contrast(token("ui-outline-strong"), token("ui-surface-solid"))).to be >= 3
+    expect(contrast(token("ui-outline-strong"), token("ui-field-solid"))).to be >= 3
+    expect(contrast(token("ui-on-danger"), token("ui-danger"))).to be >= 4.5
+    expect(contrast(token("ui-error"), token("ui-surface-solid"))).to be >= 4.5
+    expect(contrast(token("ui-error"), token("ui-field-solid"))).to be >= 4.5
   end
 
   it "keeps stacking tokens outside Tailwind's theme namespaces" do
@@ -28,6 +30,10 @@ RSpec.describe "UI design tokens" do
   end
 
   private
+    def token(name)
+      stylesheet.match(/--color-#{Regexp.escape(name)}:\s*(#[0-9a-f]{6});/i).captures.first
+    end
+
     def contrast(foreground, background)
       lighter, darker = [ luminance(foreground), luminance(background) ].sort.reverse
       (lighter + 0.05) / (darker + 0.05)

--- a/spec/assets/ui_tokens_spec.rb
+++ b/spec/assets/ui_tokens_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "UI design tokens" do
+  let(:stylesheet) { Rails.root.join("app/assets/tailwind/application.css").read }
+
+  it "keeps the legacy colors unchanged during migration" do
+    expect(stylesheet).to include(
+      "--color-ink: #14161c;",
+      "--color-paper: #eceef2;",
+      "--color-surface: #ffffff;",
+      "--color-seal: #93202f;",
+      "--color-muted: #5c6472;",
+      "--color-rule: #ccd1d9;"
+    )
+  end
+
+  it "provides sufficient contrast for strong outlines and semantic colors" do
+    expect(contrast("#718198", "#12161c")).to be >= 3
+    expect(contrast("#ff8a80", "#050608")).to be >= 4.5
+    expect(contrast("#ffb4ab", "#050608")).to be >= 4.5
+  end
+
+  it "keeps stacking tokens outside Tailwind's theme namespaces" do
+    theme = stylesheet[/@theme \{.*?^\}/m]
+
+    expect(theme).not_to include("--z-ui-")
+    expect(stylesheet).to include("--z-ui-header: 30;", "--z-ui-overlay: 40;", "--z-ui-toast: 50;")
+  end
+
+  private
+    def contrast(foreground, background)
+      lighter, darker = [ luminance(foreground), luminance(background) ].sort.reverse
+      (lighter + 0.05) / (darker + 0.05)
+    end
+
+    def luminance(color)
+      channels = color.delete_prefix("#").scan(/../).map { |channel| channel.to_i(16) / 255.0 }
+      red, green, blue = channels.map { |channel| channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055)**2.4 }
+      0.2126 * red + 0.7152 * green + 0.0722 * blue
+    end
+end

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe UiHelper, type: :helper do
+  describe "#ui_button" do
+    it "renders a semantic button with a controlled variant" do
+      html = helper.ui_button("保存", variant: :primary, type: "submit", data: { testid: "save" })
+      button = Capybara.string(html).find("button")
+
+      expect(button).to have_text("保存")
+      expect(button[:type]).to eq("submit")
+      expect(button["data-testid"]).to eq("save")
+      expect(button[:class]).to include("bg-ui-action", "min-h-11")
+    end
+
+    it "rejects an unknown variant" do
+      expect { helper.ui_button("保存", variant: :unknown) }.to raise_error(KeyError)
+    end
+  end
+
+  describe "#ui_field and #ui_input" do
+    let(:scenario) { Scenario.new }
+
+    it "associates the label and description with the input" do
+      html = render_field(label: "タイトル", description: "公開される名称です")
+      field = Capybara.string(html)
+
+      expect(field).to have_css('label[for="scenario_title"]', text: "タイトル")
+      expect(field).to have_css("#scenario_title_description", text: "公開される名称です")
+      expect(field).to have_css('#scenario_title[aria-describedby="scenario_title_description"]')
+      expect(field).to have_css("#scenario_title.text-base.min-h-11")
+    end
+
+    it "renders and associates a validation error without duplicate IDs" do
+      scenario.errors.add(:title, "を入力してください")
+      html = render_field(label: "タイトル")
+      field = Capybara.string(html)
+
+      expect(field).to have_css('#scenario_title[aria-invalid="true"][aria-describedby="scenario_title_error"]')
+      expect(field).to have_css("#scenario_title_error", text: "を入力してください", count: 1)
+      expect(field).to have_no_css("[data-ui-error-id]")
+    end
+
+    private
+      def render_field(label:, description: nil)
+        helper.form_with(model: scenario, url: "/") do |form|
+          helper.ui_field(form, :title, label:, description:) do |field|
+            helper.ui_input(form, :title, described_by: field[:described_by])
+          end
+        end
+      end
+  end
+end

--- a/spec/support/axe.rb
+++ b/spec/support/axe.rb
@@ -1,0 +1,1 @@
+require "axe-rspec"

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Browsing scenarios" do
     )
 
     visit root_path
+    expect(page).to be_axe_clean if ENV["CHROME_BINARY"].present?
     expect(page).to have_content("シナリオ一覧")
     expect(page).to have_no_content("★")
 


### PR DESCRIPTION
## What

- add Obsidian design tokens without changing legacy colors
- add shared button, field, and input primitives
- enable dark browser controls and axe checks for system specs

## Verification

- `bin/ci`
- `prek run --all-files`