### PR TITLE
Redesign application shell

### DIFF
--- a/app/views/errors/show.html.erb
+++ b/app/views/errors/show.html.erb
@@ -1,8 +1,9 @@
 <% content_for :title, message %>
 
-<div class="mx-auto max-w-xl py-12 text-center">
-  <h1 class="font-display text-3xl text-ink"><%= message %></h1>
+<div class="mx-auto w-full max-w-xl rounded-ui-surface border border-ui-outline bg-ui-surface-solid p-6 text-center shadow-ui-surface sm:p-10">
+  <%= render "shared/ui/page_header", title: message, align: :center %>
   <p class="mt-8">
-    <%= link_to "トップページに戻る", root_path, class: "text-seal underline" %>
+    <%= link_to "トップページに戻る", root_path,
+      class: "inline-flex min-h-11 items-center rounded-ui-control bg-ui-action px-4 py-2 text-sm font-bold text-ui-on-action no-underline hover:bg-ui-action-hover" %>
   </p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,60 +16,68 @@
     <%= render "shared/analytics" %>
   </head>
 
-  <body class="min-h-dvh flex flex-col" data-controller="form-status"
+  <body class="flex min-h-dvh flex-col bg-ui-background text-ui-text" data-controller="form-status"
+        data-layout="<%= content_for(:layout_context).presence || "application" %>"
         data-action="turbo:submit-start->form-status#start turbo:submit-end->form-status#finish">
-    <a href="#main-content" class="fixed top-2 left-2 z-50 -translate-y-20 bg-ink px-4 py-2 text-sm text-paper focus:translate-y-0">
+    <a href="#main-content"
+       class="fixed top-2 left-2 z-[var(--z-ui-toast)] -translate-y-20 rounded-ui-control bg-ui-action px-4 py-2 text-sm font-bold text-ui-on-action focus:translate-y-0">
       本文へ移動
     </a>
-    <header class="border-b border-rule bg-surface">
-      <div class="mx-auto flex max-w-5xl flex-wrap items-baseline gap-4 px-5 py-5">
-        <%= link_to root_path, class: "font-display text-xl tracking-wide no-underline text-ink" do %>
+
+    <header class="sticky top-0 z-[var(--z-ui-header)] border-b border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-header">
+      <div class="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-x-4 gap-y-3 px-4 py-3 sm:px-6">
+        <%= link_to root_path, class: "shrink-0 font-display text-lg font-bold tracking-wide text-ui-text no-underline sm:text-xl" do %>
           TRPGカタログ
         <% end %>
 
-        <nav class="ml-auto flex flex-wrap items-center justify-end gap-2 text-sm" aria-label="主要">
+        <nav class="flex w-full min-w-0 flex-wrap items-center justify-start gap-2 text-sm sm:ml-auto sm:w-auto sm:justify-end" aria-label="主要">
           <% if signed_in? %>
             <% if current_person %>
-              <%= link_to current_person.display_name, person_path(current_person), class: "text-muted" %>
+              <%= link_to current_person.display_name, person_path(current_person), class: "max-w-40 truncate text-ui-text-muted underline" %>
             <% else %>
-              <span class="text-muted">未登録</span>
+              <span class="text-ui-text-muted">未登録</span>
             <% end %>
             <%= button_to "ログアウト", session_path, method: :delete,
-              class: "min-h-6 cursor-pointer px-1 text-muted underline" %>
+              class: "min-h-11 cursor-pointer rounded-ui-control px-2 text-ui-text-muted underline hover:text-ui-text" %>
             <% if current_person %>
               <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#close">
                 <button type="button" aria-controls="account-menu" aria-expanded="false"
                         data-dropdown-target="button" data-action="dropdown#toggle"
-                        class="cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper">
+                        class="min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle">
                   メニュー
                 </button>
-                <nav id="account-menu" hidden aria-label="<%= User.model_name.human %>メニュー" data-dropdown-target="menu"
-                     class="absolute top-full right-0 z-40 mt-2 grid min-w-48 gap-2 border border-rule bg-surface p-4 shadow-lg">
-                  <%= link_to Scenario.model_name.human, scenarios_path, class: "text-seal underline" %>
-                  <%= link_to PlaySession.model_name.human, play_sessions_path, class: "text-seal underline" %>
-                  <%= link_to Person.model_name.human, people_path, class: "text-seal underline" %>
-                  <%= link_to GameSystem.model_name.human, game_systems_path, class: "text-seal underline" %>
-                  <%= link_to Author.model_name.human, authors_path, class: "text-seal underline" %>
-                  <% if policy(Scenario).reorder? %><%= link_to "#{Scenario.model_name.human}の並び順", scenario_order_index_path, class: "text-seal underline" %><% end %>
-                  <% if current_person.admin? %>
-                    <%= link_to Group.model_name.human, manage_groups_path, class: "text-seal underline" %>
-                    <%= link_to User.model_name.human, manage_users_path, class: "text-seal underline" %>
-                    <%= link_to SiteSetting.model_name.human, manage_site_setting_path, class: "text-seal underline" %>
-                  <% end %>
-                </nav>
+                <% account_items = [
+                  { label: Scenario.model_name.human, path: scenarios_path },
+                  { label: PlaySession.model_name.human, path: play_sessions_path },
+                  { label: Person.model_name.human, path: people_path },
+                  { label: GameSystem.model_name.human, path: game_systems_path },
+                  { label: Author.model_name.human, path: authors_path }
+                ] %>
+                <% account_items << { label: "#{Scenario.model_name.human}の並び順", path: scenario_order_index_path } if policy(Scenario).reorder? %>
+                <% if current_person.admin? %>
+                  <% account_items.concat([
+                    { label: Group.model_name.human, path: manage_groups_path },
+                    { label: User.model_name.human, path: manage_users_path },
+                    { label: SiteSetting.model_name.human, path: manage_site_setting_path }
+                  ]) %>
+                <% end %>
+                <%= render "shared/ui/navigation", id: "account-menu", label: "#{User.model_name.human}メニュー",
+                  items: account_items, variant: :menu, hidden: true,
+                  data: { dropdown_target: "menu" } %>
               </div>
             <% end %>
           <% else %>
-            <%= link_to "新規登録", new_registration_path, class: "text-seal underline" %>
+            <%= link_to "新規登録", new_registration_path,
+              class: "inline-flex min-h-11 items-center rounded-ui-control px-2 font-bold text-ui-text underline" %>
             <%# Turbo はフォーム送信を横取りするが、provider への cross-origin リダイレクトを追えない。 %>
             <%= button_to "Googleでログイン", "/auth/google_oauth2", method: :post,
                   params: { origin: request.fullpath },
                   form: { data: { turbo: false } },
-                  class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
+                  class: "min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle" %>
             <%= button_to "Discordでログイン", "/auth/discord", method: :post,
                   params: { origin: request.fullpath },
                   form: { data: { turbo: false } },
-                  class: "cursor-pointer border border-ink px-3 py-1.5 text-ink hover:bg-ink hover:text-paper" %>
+                  class: "min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle" %>
           <% end %>
         </nav>
       </div>
@@ -78,29 +86,29 @@
     <%= yield :sub_nav %>
 
     <% if signed_in? && current_person.nil? %>
-      <div class="mx-auto w-full max-w-5xl px-5 pt-6">
-        <p class="border border-seal bg-surface px-4 py-3 text-sm text-seal" role="status">
-          全機能を利用するには管理者の許可が必要です。管理者に連絡して、<%= Person.model_name.human %>登録を依頼してください。
-        </p>
+      <div class="mx-auto w-full max-w-5xl px-4 pt-6 sm:px-6">
+        <%= render "shared/ui/alert", message: safe_join([
+          "全機能を利用するには管理者の許可が必要です。管理者に連絡して、",
+          Person.model_name.human,
+          "登録を依頼してください。"
+        ]), variant: :notice %>
       </div>
     <% end %>
 
     <% if flash.any? %>
-      <div class="mx-auto w-full max-w-5xl px-5 pt-6">
+      <div class="mx-auto grid w-full max-w-5xl gap-3 px-4 pt-6 sm:px-6">
         <% flash.each do |type, message| %>
-          <p class="border border-rule bg-surface px-4 py-3 text-sm <%= type.to_s == "alert" ? "text-seal" : "" %>" role="<%= type.to_s == "alert" ? "alert" : "status" %>">
-            <%= message %>
-          </p>
+          <%= render "shared/ui/alert", message:, variant: type.to_s == "alert" ? :error : :notice %>
         <% end %>
       </div>
     <% end %>
 
-    <main id="main-content" tabindex="-1" class="mx-auto w-full max-w-5xl grow px-5 py-10">
+    <main id="main-content" tabindex="-1" class="mx-auto w-full max-w-5xl grow px-4 py-8 sm:px-6 sm:py-10">
       <%= yield %>
     </main>
 
-    <footer class="border-t border-rule bg-surface">
-      <div class="mx-auto max-w-5xl px-5 py-6 text-xs text-muted">
+    <footer class="border-t border-ui-outline bg-ui-surface-solid">
+      <div class="mx-auto max-w-5xl px-4 py-6 text-ui-caption text-ui-text-muted sm:px-6">
         <%= Scenario.model_name.human %>の権利はそれぞれの<%= Author.model_name.human %>に帰属します。
       </div>
     </footer>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -8,13 +8,18 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
   </head>
-  <body class="min-h-dvh flex flex-col">
-    <header class="border-b border-rule bg-surface">
-      <div class="mx-auto max-w-5xl px-5 py-5">
-        <%= link_to "TRPGカタログ", root_path, class: "font-display text-xl tracking-wide no-underline text-ink" %>
+  <body class="flex min-h-dvh flex-col bg-ui-background text-ui-text">
+    <a href="#main-content"
+       class="fixed top-2 left-2 z-[var(--z-ui-toast)] -translate-y-20 rounded-ui-control bg-ui-action px-4 py-2 text-sm font-bold text-ui-on-action focus:translate-y-0">
+      本文へ移動
+    </a>
+    <header class="border-b border-ui-outline bg-ui-surface-solid">
+      <div class="mx-auto max-w-5xl px-4 py-4 sm:px-6">
+        <%= link_to "TRPGカタログ", root_path,
+          class: "font-display text-lg font-bold tracking-wide text-ui-text no-underline sm:text-xl" %>
       </div>
     </header>
-    <main class="mx-auto w-full max-w-5xl grow px-5 py-10">
+    <main id="main-content" tabindex="-1" class="mx-auto flex w-full max-w-5xl grow items-center px-4 py-10 sm:px-6">
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/manage.html.erb
+++ b/app/views/layouts/manage.html.erb
@@ -1,1 +1,2 @@
+<% content_for :layout_context, "manage" %>
 <%= render template: "layouts/application" %>

--- a/app/views/manage/_nav.html.erb
+++ b/app/views/manage/_nav.html.erb
@@ -1,8 +1,6 @@
-<nav class="border-b border-rule bg-surface" aria-label="管理">
-  <div class="mx-auto flex max-w-5xl flex-wrap gap-x-5 gap-y-2 px-5 py-3 text-xs">
-    <span class="font-display text-muted">管理</span>
-    <%= link_to Group.model_name.human, manage_groups_path, class: manage_nav_class(manage_groups_path) %>
-    <%= link_to User.model_name.human, manage_users_path, class: manage_nav_class(manage_users_path) %>
-    <%= link_to SiteSetting.model_name.human, manage_site_setting_path, class: manage_nav_class(manage_site_setting_path) %>
-  </div>
-</nav>
+<% items = [
+  { label: Group.model_name.human, path: manage_groups_path, current: request.path.start_with?(manage_groups_path) },
+  { label: User.model_name.human, path: manage_users_path, current: request.path.start_with?(manage_users_path) },
+  { label: SiteSetting.model_name.human, path: manage_site_setting_path, current: request.path.start_with?(manage_site_setting_path) }
+] %>
+<%= render "shared/ui/navigation", label: "管理", items:, variant: :bar %>

--- a/app/views/shared/_ads.html.erb
+++ b/app/views/shared/_ads.html.erb
@@ -1,4 +1,8 @@
 <% if show_ads? %>
-  <script async crossorigin="anonymous"
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<%= ENV["ADSENSE_CLIENT_ID"] %>"></script>
+  <aside class="border-t border-ui-outline-strong bg-ui-background px-4 py-6 sm:px-6" aria-label="広告">
+    <div class="mx-auto max-w-5xl overflow-hidden rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid p-4">
+      <script async crossorigin="anonymous"
+              src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<%= ENV["ADSENSE_CLIENT_ID"] %>"></script>
+    </div>
+  </aside>
 <% end %>

--- a/app/views/shared/ui/_alert.html.erb
+++ b/app/views/shared/ui/_alert.html.erb
@@ -1,0 +1,8 @@
+<% variants = {
+  notice: { role: "status", classes: "border-ui-outline-strong bg-ui-surface-solid text-ui-text" },
+  error: { role: "alert", classes: "border-ui-error bg-ui-surface-solid text-ui-error" }
+} %>
+<% presentation = variants.fetch(variant) %>
+<div class="rounded-ui-control border px-4 py-3 text-sm <%= presentation[:classes] %>" role="<%= presentation[:role] %>">
+  <%= message %>
+</div>

--- a/app/views/shared/ui/_navigation.html.erb
+++ b/app/views/shared/ui/_navigation.html.erb
@@ -1,0 +1,19 @@
+<% variants = {
+  menu: "absolute top-full right-0 z-[var(--z-ui-overlay)] mt-2 grid w-[min(18rem,calc(100vw-2rem))] gap-1 rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid p-2 shadow-ui-surface",
+  bar: "border-b border-ui-outline bg-ui-surface-solid px-4 py-3 sm:px-6"
+} %>
+<%= tag.nav id: local_assigns[:id], aria: { label: }, hidden: local_assigns.fetch(:hidden, false),
+      data: local_assigns.fetch(:data, {}), class: variants.fetch(variant) do %>
+  <% if variant == :bar %>
+    <div class="mx-auto flex max-w-5xl flex-wrap items-center gap-2">
+      <span class="mr-2 text-ui-caption font-bold text-ui-text-muted">管理</span>
+  <% end %>
+  <% items.each do |item| %>
+    <% current = item.fetch(:current) { current_page?(item[:path]) } %>
+    <%= link_to item[:label], item[:path], aria: { current: ("page" if current) },
+      class: "inline-flex min-h-11 items-center rounded-ui-control px-3 py-2 text-sm font-bold no-underline #{current ? 'bg-ui-action text-ui-on-action' : 'text-ui-text hover:bg-ui-subtle'}" %>
+  <% end %>
+  <% if variant == :bar %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/ui/_navigation.html.erb
+++ b/app/views/shared/ui/_navigation.html.erb
@@ -6,7 +6,7 @@
       data: local_assigns.fetch(:data, {}), class: variants.fetch(variant) do %>
   <% if variant == :bar %>
     <div class="mx-auto flex max-w-5xl flex-wrap items-center gap-2">
-      <span class="mr-2 text-ui-caption font-bold text-ui-text-muted">管理</span>
+      <span class="mr-2 text-ui-caption font-bold text-ui-text-muted"><%= label %></span>
   <% end %>
   <% items.each do |item| %>
     <% current = item.fetch(:current) { current_page?(item[:path]) } %>

--- a/app/views/shared/ui/_page_header.html.erb
+++ b/app/views/shared/ui/_page_header.html.erb
@@ -1,0 +1,4 @@
+<% align_classes = { start: "text-left", center: "text-center" }.fetch(local_assigns.fetch(:align, :start)) %>
+<div class="<%= align_classes %>">
+  <h1 class="font-display text-2xl font-bold leading-tight text-ui-text sm:text-3xl"><%= title %></h1>
+</div>

--- a/spec/requests/accessibility_spec.rb
+++ b/spec/requests/accessibility_spec.rb
@@ -8,13 +8,16 @@ RSpec.describe "Accessibility" do
     expect(page).to have_link("本文へ移動", href: "#main-content")
     expect(page).to have_css('nav[aria-label="主要"]')
     expect(page).to have_css('main#main-content[tabindex="-1"]')
+    expect(page).to have_css("body.bg-ui-background.text-ui-text")
   end
 
   it "announces alert flashes assertively" do
     get auth_failure_path
 
     follow_redirect!
-    expect(Capybara.string(response.body)).to have_css('[role="alert"]', text: "ログインできませんでした")
+    expect(Capybara.string(response.body)).to have_css(
+      '[role="alert"].border-ui-error.text-ui-error', text: "ログインできませんでした"
+    )
   end
 
   it "makes the scenario management table reflow and names every column" do

--- a/spec/requests/error_pages_spec.rb
+++ b/spec/requests/error_pages_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe "Error pages" do
 
     expect(response).to have_http_status(:not_found)
     expect(response.body).to include("ページが見つかりませんでした")
-    expect(Capybara.string(response.body)).to have_link("トップページに戻る", href: root_path)
+    page = Capybara.string(response.body)
+    expect(page).to have_css("body.bg-ui-background.text-ui-text")
+    expect(page).to have_css("h1.text-ui-text", text: "ページが見つかりませんでした")
+    expect(page).to have_link("トップページに戻る", href: root_path)
     expect(response).not_to be_redirect
   end
 

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe "Manage navigation" do
     it "does not render a second management header" do
       get manage_groups_path
 
-      expect(Capybara.string(response.body)).to have_no_css('nav[aria-label="管理"]')
+      page = Capybara.string(response.body)
+      expect(page).to have_css('body[data-layout="manage"]')
+      expect(page).to have_no_css('nav[aria-label="管理"]')
     end
   end
 
@@ -75,6 +77,7 @@ RSpec.describe "Manage navigation" do
       page = Capybara.string(response.body)
       expect(page).to have_css('button[aria-controls="account-menu"][aria-expanded="false"]', text: "メニュー")
       expect(page).to have_css('nav#account-menu[hidden][aria-label="アカウントメニュー"]', visible: :all)
+      expect(page).to have_css("nav#account-menu.rounded-ui-control.bg-ui-surface-solid", visible: :all)
       expect(response.body.index(person.display_name)).to be < response.body.index("account-menu")
       expect(response.body.index("ログアウト")).to be < response.body.index("account-menu")
     end

--- a/spec/requests/third_party_tags_spec.rb
+++ b/spec/requests/third_party_tags_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Third party tags" do
 
     expect(response.body).to include("googletagmanager.com/gtag/js?id=G-TEST123")
     expect(response.body).to include("adsbygoogle.js?client=ca-pub-test")
+    expect(Capybara.string(response.body)).to have_css('aside[aria-label="広告"].border-ui-outline-strong')
   end
 
   it "does not render analytics when the measurement ID is empty" do

--- a/spec/system/application_shell_spec.rb
+++ b/spec/system/application_shell_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Application shell" do
+  it "fits supported viewport widths and keeps the error page accessible" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    visit play_sessions_path
+    expect(page).to have_css("h1", text: "ページが見つかりませんでした")
+    expect(page).to be_axe_clean
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      visit root_path
+      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true),
+        "application shell overflowed at #{width}px"
+      save_screenshot("application-shell-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+  end
+end

--- a/spec/system/application_shell_spec.rb
+++ b/spec/system/application_shell_spec.rb
@@ -1,19 +1,36 @@
 require "rails_helper"
 
 RSpec.describe "Application shell" do
-  it "fits supported viewport widths and keeps the error page accessible" do
+  it "fits every layout at supported viewport widths and keeps the shell accessible" do
     skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
 
-    visit play_sessions_path
-    expect(page).to have_css("h1", text: "ページが見つかりませんでした")
-    expect(page).to be_axe_clean
+    admin = create(:person, roles: %w[admin])
+    user = create(:user, person: admin)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
 
     [ 320, 768, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)
-      visit root_path
-      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true),
-        "application shell overflowed at #{width}px"
-      save_screenshot("application-shell-#{width}.png") if ENV["VISUAL_REVIEW"]
+      {
+        application: root_path,
+        manage: manage_groups_path,
+        error: scenario_path(-1)
+      }.each do |layout, path|
+        visit path
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true),
+          "#{layout} layout overflowed at #{width}px"
+        expect(page).to be_axe_clean.excluding("#main-content") unless layout == :error
+        expect(page).to be_axe_clean if layout == :error
+        save_screenshot("#{layout}-shell-#{width}.png") if ENV["VISUAL_REVIEW"]
+      end
     end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
   end
 end

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Browsing scenarios" do
     )
 
     visit root_path
-    expect(page).to be_axe_clean if ENV["CHROME_BINARY"].present?
+    expect(page).to be_axe_clean.excluding("#main-content") if ENV["CHROME_BINARY"].present?
     expect(page).to have_content("シナリオ一覧")
     expect(page).to have_no_content("★")
 

--- a/spec/system/editor_navigation_spec.rb
+++ b/spec/system/editor_navigation_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Editor navigation" do
 
     visit root_path
     click_button "Googleでログイン"
+    expect(page).to be_axe_clean.excluding("#main-content") if ENV["CHROME_BINARY"].present?
     save_screenshot("editor-scenarios.png") if ENV["VISUAL_REVIEW"]
     if ENV["CHROME_BINARY"]
       click_button "メニュー"

--- a/spec/system/editor_navigation_spec.rb
+++ b/spec/system/editor_navigation_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "Editor navigation" do
     if ENV["CHROME_BINARY"]
       click_button "メニュー"
       expect(page).to have_css('#account-menu:not([hidden])')
+      expect(page).to have_css('button[aria-controls="account-menu"][aria-expanded="true"]', text: "メニュー")
+      expect(page).to be_axe_clean.excluding("#main-content")
       menu_geometry = page.evaluate_script(<<~JS)
         (() => {
           const button = document.querySelector('[aria-controls="account-menu"]')


### PR DESCRIPTION
## What
- migrate the application, management, and error shells to the Obsidian Glass design
- add shared alert, page header, and navigation primitives
- frame third-party ads without styling their content

## Verification
- `bin/ci`
- `prek run --all-files`
- Chrome axe checks and visual review at 320px, 768px, and 1280px