### PR TITLE
Record why URL detection stays ASCII-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,4 @@ TDD、commit の分け方、pre-commit の扱いは [README の「変更を出�
 - 編集画面から離れるリンクは「詳細に戻る」のように遷移先を明記する。未保存の新規作成画面では一覧へ戻す
 - 画面の部品を自前で書く前に、既存のライブラリを探す（ADR-0001 の「自前実装は避ける」）。importmap でも `bin/importmap pin <名前>` で npm のパッケージが入る。CSP が外部ホストのスクリプトを許していないため CDN からは読めないが、pin したものは `vendor/javascript/` に落ちるので自ホストから配れる
 - 部分更新は Turbo Frame と Turbo Stream で書く。素の `fetch` を足す前に、`favorites_controller.rb` の `turbo_stream.replace` を見る
+- `auto_link_urls` の URL 検出は ASCII 限定のまま変えない。`https://ja.wikipedia.org/wiki/日本` のような非 ASCII を含む URL は途中で切れるが、非 ASCII を許すと `https://example.com/pathです` のように空白を挟まず続く地の文を URL へ取り込み、404 を作る。切れたリンクより 404 を出さないほうを優先する。リンクを作らずプレーンテキストにする案は採らない

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ TDD、commit の分け方、pre-commit の扱いは [README の「変更を出�
 - 編集画面から離れるリンクは「詳細に戻る」のように遷移先を明記する。未保存の新規作成画面では一覧へ戻す
 - 画面の部品を自前で書く前に、既存のライブラリを探す（ADR-0001 の「自前実装は避ける」）。importmap でも `bin/importmap pin <名前>` で npm のパッケージが入る。CSP が外部ホストのスクリプトを許していないため CDN からは読めないが、pin したものは `vendor/javascript/` に落ちるので自ホストから配れる
 - 部分更新は Turbo Frame と Turbo Stream で書く。素の `fetch` を足す前に、`favorites_controller.rb` の `turbo_stream.replace` を見る
-- `auto_link_urls` の URL 検出は ASCII 限定のまま変えない。`https://ja.wikipedia.org/wiki/日本` のような非 ASCII を含む URL は途中で切れるが、非 ASCII を許すと `https://example.com/pathです` のように空白を挟まず続く地の文を URL へ取り込み、404 を作る。切れたリンクより 404 を出さないほうを優先する。リンクを作らずプレーンテキストにする案は採らない
+- `auto_link_urls` の URL 検出を非 ASCII へ広げない。広げると `https://example.com/pathです` のように空白を挟まず続く地の文を URL へ取り込み、確実に壊れたリンクになる。ASCII 限定でも `https://ja.wikipedia.org/wiki/日本` は `.../wiki/` へ切り詰められ、IDN は `href="https://"` になる。どちらも壊れるので、起きにくいほうを選んでいる。自由記述に URL はほぼ書かれず（URL は `PurchaseLink` などの専用カラムへ入る）、本番の非空フィールド 132 件のうち `http` を含むものは 0 件だった。リンクを作らずプレーンテキストにする案は採らない

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   YOUTUBE_VIDEO_ID = /\A[\w-]{11}\z/
-  # ASCII 限定は意図的。非 ASCII を許すと、URL の直後に空白なしで続く地の文を取り込んで 404 を作る。
+  # 非 ASCII を許すと URL 直後の地の文を取り込むため ASCII 限定。代償として非 ASCII を含む URL は途中で切れる。
   HTTP_URL = URI::DEFAULT_PARSER.make_regexp(%w[http https])
 
   def accessible_error_summary(record)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   YOUTUBE_VIDEO_ID = /\A[\w-]{11}\z/
+  # ASCII 限定は意図的。非 ASCII を許すと、URL の直後に空白なしで続く地の文を取り込んで 404 を作る。
   HTTP_URL = URI::DEFAULT_PARSER.make_regexp(%w[http https])
 
   def accessible_error_summary(record)


### PR DESCRIPTION
## What

Record that `auto_link_urls` detects ASCII-only URLs on purpose. No behaviour change.

## Why

The RFC2396 regex stops at the first non-ASCII byte, so `https://ja.wikipedia.org/wiki/日本` links to `https://ja.wikipedia.org/wiki/` — a different page. Widening the character class fixes that and breaks the opposite case: Japanese prose that continues straight after a URL with no space gets pulled into the href, producing a 404. The two cases are indistinguishable lexically.

A 404 is the worse failure, and dropping the link entirely is not on the table, so the current behaviour stays. Without a note, the truncation reads as an oversight and invites a "fix".

Production has no input for this helper today: across all 132 non-empty free-text fields, zero contain `http`. URLs live in `PurchaseLink`, `StreamLink` and the recording columns, which render through `link_to`.

## Verification

- [x] `bin/rspec` (657 examples, 0 failures)
- [x] `prek run --all-files`
