### PR TITLE
Redesign scenario lists and ordering

### DIFF
--- a/app/views/scenario_order/_scenarios.html.erb
+++ b/app/views/scenario_order/_scenarios.html.erb
@@ -1,9 +1,18 @@
-<tbody id="scenario_order" data-controller="sortable" data-sortable-url-value="<%= reorder_scenario_order_index_path %>" data-sortable-saved-message-value="保存しました" data-sortable-failed-message-value="保存できませんでした">
-  <% scenarios.each do |scenario| %>
-    <tr class="border-b border-rule last:border-b-0" data-sortable-target="row" data-sortable-id-param="<%= scenario.id %>">
-      <td class="p-3"><span class="sortable-handle cursor-move touch-none text-muted select-none" aria-hidden="true">⠿</span> <%= button_to "↑", move_scenario_order_path(scenario, direction: "up"), method: :patch, form: { class: "inline" }, aria: { label: "#{scenario.title}を1つ上へ" } %> <%= button_to "↓", move_scenario_order_path(scenario, direction: "down"), method: :patch, form: { class: "inline" }, aria: { label: "#{scenario.title}を1つ下へ" } %></td>
-      <td class="p-3 font-display"><%= link_to scenario.title, scenario_path(scenario), class: "text-seal" %></td>
-      <td class="p-3 text-right text-xs"><%= link_to "編集", edit_scenario_path(scenario), class: "text-seal" %></td>
-    </tr>
+<div id="scenario_order" class="grid gap-3" data-controller="sortable" data-sortable-url-value="<%= reorder_scenario_order_index_path %>" data-sortable-saved-message-value="保存しました" data-sortable-failed-message-value="保存できませんでした">
+  <% scenarios.each_with_index do |scenario, index| %>
+    <%= render "shared/ui/card", variant: :interactive, data: { sortable_target: "row", sortable_id_param: scenario.id } do %>
+      <article class="grid gap-3 p-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
+        <div class="flex items-center gap-2">
+          <span class="sortable-handle inline-flex min-h-11 min-w-11 cursor-move touch-none items-center justify-center text-xl text-ui-text-muted select-none" aria-hidden="true">⠿</span>
+          <span class="text-ui-caption text-ui-text-muted"><span class="sr-only">現在の並び順:</span><%= index + 1 %></span>
+        </div>
+        <h2 class="font-display text-base font-bold"><%= link_to scenario.title, scenario_path(scenario), class: "text-ui-text hover:text-ui-action" %></h2>
+        <div class="flex flex-wrap gap-2 sm:justify-end">
+          <%= form_with url: move_scenario_order_path(scenario, direction: "up"), method: :patch do %><%= ui_button("上へ", variant: :secondary, size: :small, type: "submit", disabled: index.zero?, aria: { label: "#{scenario.title}を1つ上へ" }) %><% end %>
+          <%= form_with url: move_scenario_order_path(scenario, direction: "down"), method: :patch do %><%= ui_button("下へ", variant: :secondary, size: :small, type: "submit", disabled: index == scenarios.length - 1, aria: { label: "#{scenario.title}を1つ下へ" }) %><% end %>
+          <%= link_to "編集", edit_scenario_path(scenario), class: "inline-flex min-h-11 items-center px-2 text-sm font-bold text-ui-action" %>
+        </div>
+      </article>
+    <% end %>
   <% end %>
-</tbody>
+</div>

--- a/app/views/scenario_order/index.html.erb
+++ b/app/views/scenario_order/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "#{Scenario.model_name.human}の並び順" %>
+<% content_for :ui_theme, "dark" %>
 <div class="space-y-6">
   <%= render "shared/ui/page_header", title: "#{Scenario.model_name.human}の並び順" %>
   <p class="max-w-3xl text-sm text-ui-text-muted">カードをドラッグするか、上へ・下へボタンを押すと保存されます。この並びが「GMのおすすめ順」になります。</p>

--- a/app/views/scenario_order/index.html.erb
+++ b/app/views/scenario_order/index.html.erb
@@ -1,10 +1,9 @@
 <% content_for :title, "#{Scenario.model_name.human}の並び順" %>
-<h1 class="font-display text-2xl"><%= Scenario.model_name.human %>の並び順</h1>
-<p class="mt-2 text-sm text-muted">行をドラッグするか↑↓を押すと保存されます。この並びが「GMのおすすめ順」になります。</p>
-<div class="mt-6 overflow-x-auto" role="region" aria-label="<%= Scenario.model_name.human %>の並び順と操作" tabindex="0">
-  <table class="w-full min-w-3xl border border-rule bg-surface text-sm">
-    <thead><tr><th scope="col" class="p-3">並び順</th><th scope="col" class="p-3"><%= Scenario.model_name.human %></th><th scope="col" class="p-3">操作</th></tr></thead>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: "#{Scenario.model_name.human}の並び順" %>
+  <p class="max-w-3xl text-sm text-ui-text-muted">カードをドラッグするか、上へ・下へボタンを押すと保存されます。この並びが「GMのおすすめ順」になります。</p>
+  <section aria-label="<%= Scenario.model_name.human %>の並び順と操作">
     <%= render "scenario_order/scenarios", scenarios: @scenarios %>
-  </table>
+  </section>
 </div>
-<div class="fixed right-6 bottom-6" role="status" aria-live="polite" data-controller="toast" data-action="sortable:saved@window->toast#show"></div>
+<div class="fixed right-4 bottom-4 z-[var(--z-ui-toast)] sm:right-6 sm:bottom-6" role="status" aria-live="polite" data-controller="toast" data-action="sortable:saved@window->toast#show"></div>

--- a/app/views/scenarios/_gallery.html.erb
+++ b/app/views/scenarios/_gallery.html.erb
@@ -1,45 +1,5 @@
-<ul class="mt-3 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
+<ul class="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
   <% scenarios.each do |scenario| %>
-    <li class="bg-surface">
-      <%= link_to scenario_path(scenario), data: { turbo_frame: "_top" },
-            class: "group flex h-full flex-col gap-3 p-4 no-underline text-ink" do %>
-        <div class="aspect-3/4 overflow-hidden bg-paper">
-          <% if scenario.jacket.attached? %>
-            <%= image_tag scenario.jacket.variant(:thumb), alt: "", loading: "lazy",
-                  class: "h-full w-full object-contain" %>
-          <% elsif scenario.booth_image.attached? %>
-            <%= image_tag scenario.booth_image.variant(:thumb), alt: "", loading: "lazy",
-                  class: "h-full w-full object-contain" %>
-          <% else %>
-            <span class="flex h-full items-center justify-center font-display text-sm text-muted">
-              画像なし
-            </span>
-          <% end %>
-        </div>
-
-        <h2 class="font-display text-lg leading-snug group-hover:text-seal">
-          <%= scenario.title %>
-        </h2>
-
-        <p class="text-xs text-muted">
-          <%= scenario.game_systems.map(&:name).join("／").presence || "#{GameSystem.model_name.human}未設定" %>
-        </p>
-
-        <dl class="mt-auto grid grid-cols-[4rem_1fr] gap-x-3 gap-y-1 font-mono text-xs">
-          <dt class="text-muted">人数</dt>
-          <dd><%= player_count_value(scenario) %></dd>
-          <dt class="text-muted">時間</dt>
-          <dd><%= duration_value(scenario) %></dd>
-        </dl>
-      <% end %>
-      <% if policy(scenario).update? || policy(scenario).destroy? %>
-        <div class="flex flex-wrap items-center gap-3 px-4 pb-4 text-xs">
-          <% if policy(scenario).update? %><%= link_to "編集", edit_scenario_path(scenario), data: { turbo_frame: "_top" }, class: "text-seal" %><% end %>
-          <%= render "shared/delete_button", record: scenario, path: scenario_path(scenario), label: "削除",
-                aria_label: "#{scenario.title} を削除",
-                confirm: "#{scenario.title} を削除しますか", class_name: "min-h-6 text-muted" %>
-        </div>
-      <% end %>
-    </li>
+    <li><%= render "shared/ui/scenario_card", scenario:, owner: @owner, presentation: :visual %></li>
   <% end %>
 </ul>

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -1,48 +1,25 @@
-<div class="mt-3 overflow-x-auto border border-rule bg-surface">
-  <table class="w-full min-w-3xl text-sm">
+<ul class="mt-4 grid gap-4 md:hidden">
+  <% scenarios.each do |scenario| %>
+    <li><%= render "shared/ui/scenario_card", scenario:, owner: @owner, presentation: :details %></li>
+  <% end %>
+</ul>
+
+<div class="mt-4 hidden overflow-hidden rounded-ui-card border border-ui-outline bg-ui-surface-solid md:block">
+  <table class="w-full text-sm">
     <caption class="sr-only">絞り込み条件に一致した<%= Scenario.model_name.human %></caption>
-    <thead class="border-b border-rule text-left text-xs text-muted">
+    <thead class="border-b border-ui-outline text-left text-ui-caption text-ui-text-muted">
       <tr>
-        <th scope="col" class="p-3"><%= Scenario.model_name.human %>名</th>
-        <th scope="col" class="p-3"><%= Author.model_name.human %></th>
-        <th scope="col" class="p-3"><%= GameSystem.model_name.human %></th>
-        <th scope="col" class="p-3">人数</th>
-        <th scope="col" class="p-3">目安時間</th>
-        <th scope="col" class="p-3">ステータス</th>
-        <th scope="col" class="p-3">入手先</th>
+        <th scope="col" class="p-3"><%= Scenario.model_name.human %>名</th><th scope="col" class="p-3"><%= Author.model_name.human %></th><th scope="col" class="p-3"><%= GameSystem.model_name.human %></th><th scope="col" class="p-3">人数</th><th scope="col" class="p-3">目安時間</th><th scope="col" class="p-3">ステータス</th><th scope="col" class="p-3">入手先</th>
         <% if policy(Scenario).update? || policy(Scenario).destroy? %><th scope="col" class="p-3">操作</th><% end %>
       </tr>
     </thead>
-    <tbody>
+    <tbody class="divide-y divide-ui-outline">
       <% scenarios.each do |scenario| %>
-        <tr class="border-b border-rule last:border-b-0 hover:bg-paper">
-          <td class="p-3">
-            <%= link_to scenario.title, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "font-display text-ink" %>
-          </td>
-          <td class="p-3 text-xs text-muted"><%= scenario.authors.map(&:name).join("、") %></td>
-          <td class="p-3 text-xs text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td>
-          <td class="p-3 font-mono text-xs"><%= player_count_value(scenario) %></td>
-          <td class="p-3 font-mono text-xs"><%= duration_value(scenario) %></td>
-          <td class="p-3 text-center"><%= scenario.status_for(@owner)&.label || "シナリオ所持" %></td>
-          <td class="p-3 text-xs">
-            <% scenario.purchase_links.each do |link| %>
-              <% if link.url.present? %>
-                <%= link_to link.label, link.url, target: "_blank", rel: "noopener nofollow", class: "text-seal" %>
-              <% else %>
-                <span class="text-muted"><%= link.label %></span>
-              <% end %>
-            <% end %>
-          </td>
-          <% if policy(Scenario).update? || policy(Scenario).destroy? %>
-            <td class="p-3 text-xs">
-              <div class="flex flex-wrap items-center gap-3">
-                <% if policy(scenario).update? %><%= link_to "編集", edit_scenario_path(scenario), data: { turbo_frame: "_top" }, class: "text-seal" %><% end %>
-                <%= render "shared/delete_button", record: scenario, path: scenario_path(scenario), label: "削除",
-                      aria_label: "#{scenario.title} を削除",
-                      confirm: "#{scenario.title} を削除しますか", class_name: "min-h-6 text-muted" %>
-              </div>
-            </td>
-          <% end %>
+        <tr class="hover:bg-ui-subtle">
+          <td class="p-3"><%= link_to scenario.title, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "font-bold text-ui-text hover:text-ui-action" %></td>
+          <td class="p-3 text-ui-caption text-ui-text-muted"><%= scenario.authors.map(&:name).join("、") %></td><td class="p-3 text-ui-caption text-ui-text-muted"><%= scenario.game_systems.map(&:name).join("／") %></td><td class="p-3 text-ui-caption"><%= player_count_value(scenario) %></td><td class="p-3 text-ui-caption"><%= duration_value(scenario) %></td><td class="p-3 text-ui-caption"><%= scenario.status_for(@owner)&.label || "シナリオ所持" %></td>
+          <td class="p-3 text-ui-caption"><% scenario.purchase_links.each do |purchase_link| %><%= purchase_link.url.present? ? link_to(purchase_link.label, purchase_link.url, target: "_blank", rel: "noopener nofollow", class: "text-ui-action") : purchase_link.label %><% end %></td>
+          <% if policy(Scenario).update? || policy(Scenario).destroy? %><td class="p-3"><div class="flex flex-wrap gap-2"><% if policy(scenario).update? %><%= link_to "編集", edit_scenario_path(scenario), data: { turbo_frame: "_top" }, class: "inline-flex min-h-11 items-center text-sm font-bold text-ui-action" %><% end %><% if policy(scenario).destroy? %><%= form_with url: scenario_path(scenario), method: :delete, data: { turbo_confirm: "#{scenario.title} を削除しますか" } do %><%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{scenario.title} を削除" }) %><% end %><% end %></div></td><% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/scenarios/_table.html.erb
+++ b/app/views/scenarios/_table.html.erb
@@ -1,10 +1,10 @@
-<ul class="mt-4 grid gap-4 md:hidden">
+<ul class="mt-4 grid gap-4 lg:hidden">
   <% scenarios.each do |scenario| %>
     <li><%= render "shared/ui/scenario_card", scenario:, owner: @owner, presentation: :details %></li>
   <% end %>
 </ul>
 
-<div class="mt-4 hidden overflow-hidden rounded-ui-card border border-ui-outline bg-ui-surface-solid md:block">
+<div class="mt-4 hidden overflow-hidden rounded-ui-card border border-ui-outline bg-ui-surface-solid lg:block">
   <table class="w-full text-sm">
     <caption class="sr-only">絞り込み条件に一致した<%= Scenario.model_name.human %></caption>
     <thead class="border-b border-ui-outline text-left text-ui-caption text-ui-text-muted">

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,5 +1,6 @@
 <% list_title = @owner ? "#{@owner.display_name}が所持するTRPG#{Scenario.model_name.human}一覧" : "#{Scenario.model_name.human}一覧" %>
 <% content_for :title, list_title %>
+<% content_for :ui_theme, "dark" %>
 
 <%= turbo_frame_tag "scenario_list", data: { turbo_action: "advance" } do %>
   <div class="space-y-6">

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -17,7 +17,7 @@
       </nav>
     </div>
 
-    <%= render "shared/ui/filter_panel", title: "絞り込み" do %>
+    <%= render "shared/ui/filter_panel", title: "絞り込み#{'（適用中）' if @listing.filtered?}" do %>
       <fieldset>
         <legend class="text-sm font-bold text-ui-text">人数</legend>
         <div class="mt-2 flex flex-wrap gap-2">
@@ -42,7 +42,7 @@
         <label class="block text-sm font-bold text-ui-text" for="author_name"><%= Author.model_name.human %></label>
         <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
           <div class="flex min-w-0 flex-wrap gap-2">
-            <% @listing.authors.each do |author| %><span class="inline-flex min-h-11 items-center gap-1 rounded-full border border-ui-outline-strong bg-ui-subtle px-3 text-sm"><%= author.name %><%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)), aria: { label: "#{author.name}を解除" }, class: "inline-flex min-h-7 min-w-7 items-center justify-center text-ui-action no-underline" %></span><% end %>
+            <% @listing.authors.each do |author| %><span class="inline-flex min-h-11 items-center rounded-full border border-ui-outline-strong bg-ui-subtle pl-3 text-sm"><%= author.name %><%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)), aria: { label: "#{author.name}を解除" }, class: "inline-flex min-h-11 min-w-11 items-center justify-center text-ui-action no-underline" %></span><% end %>
             <%= text_field_tag :author_name, (@listing.author_name if @listing.author_name_error?), list: "author-suggestions", autocomplete: "off", placeholder: "#{Author.model_name.human}名を入力", aria: { label: "#{Author.model_name.human}を追加", describedby: "author-help#{' author-error' if @listing.author_name_error?}", invalid: ("true" if @listing.author_name_error?) }, data: { action: "change->author-filter#submit" }, class: "min-h-11 min-w-0 flex-1 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text placeholder:text-ui-text-muted aria-invalid:border-ui-error" %>
           </div>
           <%= ui_button("追加", variant: :secondary, type: "submit") %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -2,109 +2,65 @@
 <% content_for :title, list_title %>
 
 <%= turbo_frame_tag "scenario_list", data: { turbo_action: "advance" } do %>
-<div class="flex flex-wrap items-baseline justify-between gap-4">
-  <div>
-    <h1 class="font-display text-3xl tracking-wide">
-      <%= list_title %><span class="ml-2 text-base text-muted" role="status">（全<%= @scenarios.size %>件）</span>
-    </h1>
-    <% if policy(Scenario).create? %>
-      <p class="mt-3"><%= link_to "新規登録", new_scenario_path, data: { turbo_frame: "_top" }, class: "text-sm text-seal" %></p>
+  <div class="space-y-6">
+    <div class="flex flex-wrap items-end justify-between gap-4">
+      <div class="space-y-3">
+        <%= render "shared/ui/page_header", title: list_title %>
+        <p class="text-sm text-ui-text-muted" role="status">全<%= @scenarios.size %>件</p>
+        <% if policy(Scenario).create? %><%= link_to "新規登録", new_scenario_path, data: { turbo_frame: "_top" }, class: "inline-flex min-h-11 items-center font-bold text-ui-action" %><% end %>
+      </div>
+      <nav class="flex rounded-ui-control border border-ui-outline-strong bg-ui-field-solid p-1 text-sm" aria-label="表示の切り替え">
+        <% [ [ "table", "表形式" ], [ "gallery", "ジャケット" ] ].each do |view, label| %>
+          <%= link_to label, root_path(@listing.params(view:)), aria: { current: ("page" if @listing.view == view) },
+                class: "inline-flex min-h-11 items-center rounded-[0.65rem] px-3 font-bold no-underline #{@listing.view == view ? 'bg-ui-action text-ui-on-action' : 'text-ui-text hover:bg-ui-subtle'}" %>
+        <% end %>
+      </nav>
+    </div>
+
+    <%= render "shared/ui/filter_panel", title: "絞り込み" do %>
+      <fieldset>
+        <legend class="text-sm font-bold text-ui-text">人数</legend>
+        <div class="mt-2 flex flex-wrap gap-2">
+          <% [ [ 1, "1人" ], [ 2, "2人" ], [ 3, "3人" ], [ 4, "4人" ], [ 5, "5人以上" ] ].each do |count, label| %>
+            <% selected = @listing.player_count == count %>
+            <%= button_to label, root_path, method: :get, params: @listing.params(player_count: (selected ? nil : count)), form: { class: "inline" }, aria: { pressed: selected }, class: "min-h-11 rounded-ui-control border px-3 py-2 text-sm font-bold #{selected ? 'border-ui-action bg-ui-action text-ui-on-action' : 'border-ui-outline-strong bg-ui-field-solid text-ui-text hover:bg-ui-subtle'}" %>
+          <% end %>
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend class="text-sm font-bold text-ui-text"><%= GameSystem.model_name.human %></legend>
+        <div class="mt-2 flex flex-wrap gap-2">
+          <% @listing.game_system_options.each do |game_system| %>
+            <% selected = @listing.game_systems.include?(game_system) %><% ids = selected ? @listing.game_systems.without(game_system).map(&:id) : @listing.game_systems.map(&:id) + [ game_system.id ] %>
+            <%= button_to game_system.name, root_path, method: :get, params: @listing.params(game_system_ids: ids.presence), form: { class: "inline" }, aria: { pressed: selected }, class: "min-h-11 rounded-ui-control border px-3 py-2 text-sm font-bold #{selected ? 'border-ui-action bg-ui-action text-ui-on-action' : 'border-ui-outline-strong bg-ui-field-solid text-ui-text hover:bg-ui-subtle'}" %>
+          <% end %>
+        </div>
+      </fieldset>
+      <%= form_with url: root_path, method: :get, data: { controller: "author-filter" }, class: "space-y-2" do |form| %>
+        <% @listing.params(author_ids: nil).each do |key, value| %><% Array(value).each do |item| %><%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %><% end %><% end %>
+        <% @listing.authors.each do |author| %><%= hidden_field_tag "author_ids[]", author.id, id: nil %><% end %>
+        <label class="block text-sm font-bold text-ui-text" for="author_name"><%= Author.model_name.human %></label>
+        <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+          <div class="flex min-w-0 flex-wrap gap-2">
+            <% @listing.authors.each do |author| %><span class="inline-flex min-h-11 items-center gap-1 rounded-full border border-ui-outline-strong bg-ui-subtle px-3 text-sm"><%= author.name %><%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)), aria: { label: "#{author.name}を解除" }, class: "inline-flex min-h-7 min-w-7 items-center justify-center text-ui-action no-underline" %></span><% end %>
+            <%= text_field_tag :author_name, (@listing.author_name if @listing.author_name_error?), list: "author-suggestions", autocomplete: "off", placeholder: "#{Author.model_name.human}名を入力", aria: { label: "#{Author.model_name.human}を追加", describedby: "author-help#{' author-error' if @listing.author_name_error?}", invalid: ("true" if @listing.author_name_error?) }, data: { action: "change->author-filter#submit" }, class: "min-h-11 min-w-0 flex-1 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text placeholder:text-ui-text-muted aria-invalid:border-ui-error" %>
+          </div>
+          <%= ui_button("追加", variant: :secondary, type: "submit") %>
+        </div>
+        <datalist id="author-suggestions"><% @listing.author_suggestions.each do |name| %><option value="<%= name %>"></option><% end %></datalist>
+        <p id="author-help" class="text-ui-caption text-ui-text-muted">候補から選択して追加します。<%= Author.model_name.human %>は複数選択できます。</p>
+        <% if @listing.author_name_error? %><p id="author-error" role="alert" class="text-ui-caption text-ui-error">候補から<%= Author.model_name.human %>を選択してください。</p><% end %>
+      <% end %>
+    <% end %>
+
+    <% if @scenarios.any? %>
+      <%= form_with url: root_path, method: :get, class: "grid gap-2 sm:ml-auto sm:grid-cols-[auto_minmax(12rem,auto)_auto] sm:items-center" do |form| %>
+        <% @listing.params(order: nil).each do |key, value| %><% Array(value).each do |item| %><%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %><% end %><% end %>
+        <%= label_tag :order, "並び順", class: "text-sm font-bold text-ui-text" %><%= select_tag :order, scenario_order_options(@listing), class: "min-h-11 min-w-0 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text" %><%= ui_button("並べ替える", type: "submit") %>
+      <% end %>
+      <%= render "scenarios/#{@listing.view}", scenarios: @scenarios %>
+    <% else %>
+      <%= render "shared/ui/empty_state", title: (@listing.filtered? ? "条件に合う#{Scenario.model_name.human}がありません。" : "まだ#{Scenario.model_name.human}が登録されていません。") %>
     <% end %>
   </div>
-
-  <nav class="flex items-center gap-3 text-xs" aria-label="表示の切り替え">
-    <%= link_to "表形式", root_path(@listing.params(view: "table")), class: list_view_class("table", @listing.view),
-          aria: { current: ("page" if @listing.view == "table") } %>
-    <%= link_to "ジャケット", root_path(@listing.params(view: "gallery")), class: list_view_class("gallery", @listing.view),
-          aria: { current: ("page" if @listing.view == "gallery") } %>
-  </nav>
-</div>
-
-<div class="mt-6 space-y-4 border border-rule bg-surface p-4">
-  <fieldset>
-    <legend class="text-xs text-muted">人数</legend>
-    <div class="mt-2 flex flex-wrap gap-2">
-      <% [ [ 1, "1人" ], [ 2, "2人" ], [ 3, "3人" ], [ 4, "4人" ], [ 5, "5人以上" ] ].each do |count, label| %>
-        <% selected = @listing.player_count == count %>
-        <%= button_to label, root_path, method: :get,
-              params: @listing.params(player_count: (selected ? nil : count)), form: { class: "inline" },
-              aria: { pressed: selected },
-              class: "cursor-pointer border px-3 py-1.5 text-sm #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
-      <% end %>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend class="text-xs text-muted"><%= GameSystem.model_name.human %></legend>
-    <div class="mt-2 flex flex-wrap gap-2">
-      <% @listing.game_system_options.each do |game_system| %>
-        <% selected = @listing.game_systems.include?(game_system) %>
-        <% ids = selected ? @listing.game_systems.without(game_system).map(&:id) : @listing.game_systems.map(&:id) + [ game_system.id ] %>
-        <%= button_to game_system.name, root_path, method: :get,
-              params: @listing.params(game_system_ids: ids.presence), form: { class: "inline" },
-              aria: { pressed: selected },
-              class: "cursor-pointer border px-3 py-1.5 text-sm #{selected ? 'border-ink bg-ink text-paper' : 'border-rule text-ink hover:border-ink'}" %>
-      <% end %>
-    </div>
-  </fieldset>
-
-  <%= form_with url: root_path, method: :get, data: { controller: "author-filter" }, class: "space-y-2" do |form| %>
-    <% @listing.params(author_ids: nil).each do |key, value| %>
-      <% Array(value).each do |item| %>
-        <%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %>
-      <% end %>
-    <% end %>
-    <% @listing.authors.each do |author| %>
-      <%= hidden_field_tag "author_ids[]", author.id, id: nil %>
-    <% end %>
-
-    <label class="block text-xs text-muted" for="author_name"><%= Author.model_name.human %></label>
-    <div class="flex flex-wrap items-center gap-2">
-      <% @listing.authors.each do |author| %>
-        <span class="inline-flex items-center gap-1 border border-rule bg-paper px-2 py-1 text-sm">
-          <%= author.name %>
-          <%= link_to "×", root_path(@listing.params(author_ids: @listing.authors.without(author).map(&:id).presence)),
-                aria: { label: "#{author.name}を解除" },
-                class: "inline-flex min-h-6 min-w-6 items-center justify-center text-seal no-underline" %>
-        </span>
-      <% end %>
-      <%= text_field_tag :author_name, (@listing.author_name if @listing.author_name_error?),
-            list: "author-suggestions", autocomplete: "off", placeholder: "#{Author.model_name.human}名を入力",
-            aria: { label: "#{Author.model_name.human}を追加", describedby: "author-help#{' author-error' if @listing.author_name_error?}",
-                    invalid: ("true" if @listing.author_name_error?) },
-            data: { action: "change->author-filter#submit" },
-            class: "min-w-48 border border-rule bg-paper px-3 py-2 text-sm" %>
-      <datalist id="author-suggestions">
-        <% @listing.author_suggestions.each do |name| %>
-          <option value="<%= name %>"></option>
-        <% end %>
-      </datalist>
-      <%= form.button "追加", name: nil, class: "border border-ink px-4 py-2 text-sm" %>
-    </div>
-    <p id="author-help" class="text-xs text-muted">候補から選択して追加します。<%= Author.model_name.human %>は複数選択できます。</p>
-    <% if @listing.author_name_error? %>
-      <p id="author-error" role="alert" class="text-sm text-seal">候補から<%= Author.model_name.human %>を選択してください。</p>
-    <% end %>
-  <% end %>
-</div>
-
-<% if @scenarios.any? %>
-  <%= form_with url: root_path, method: :get, class: "mt-8 flex items-center justify-end gap-2" do |form| %>
-    <% @listing.params(order: nil).each do |key, value| %>
-      <% Array(value).each do |item| %>
-        <%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %>
-      <% end %>
-    <% end %>
-
-    <%= label_tag :order, "並び順", class: "text-xs text-muted" %>
-    <%= select_tag :order, scenario_order_options(@listing), class: "border border-rule bg-paper px-3 py-2 text-sm" %>
-    <%= form.button "並べ替える", name: nil, class: "bg-ink px-4 py-2 text-sm text-paper" %>
-  <% end %>
-
-  <%= render "scenarios/#{@listing.view}", scenarios: @scenarios %>
-<% else %>
-  <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">
-    <%= @listing.filtered? ? "条件に合う#{Scenario.model_name.human}がありません。" : "まだ#{Scenario.model_name.human}が登録されていません。" %>
-  </p>
-<% end %>
 <% end %>

--- a/app/views/shared/ui/_badge.html.erb
+++ b/app/views/shared/ui/_badge.html.erb
@@ -1,0 +1,2 @@
+<% variants = { neutral: "border-ui-outline-strong bg-ui-subtle text-ui-text", accent: "border-ui-accent bg-ui-accent/15 text-ui-text" } %>
+<span class="inline-flex min-h-7 items-center rounded-full border px-2.5 py-1 text-ui-caption font-bold <%= variants.fetch(local_assigns.fetch(:variant, :neutral)) %>"><%= label %></span>

--- a/app/views/shared/ui/_card.html.erb
+++ b/app/views/shared/ui/_card.html.erb
@@ -1,0 +1,7 @@
+<% variants = {
+  default: "rounded-ui-card border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface",
+  interactive: "rounded-ui-card border border-ui-outline bg-ui-surface-solid transition-colors hover:border-ui-outline-strong supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface"
+} %>
+<%= tag.div id: local_assigns[:id], data: local_assigns.fetch(:data, {}), class: variants.fetch(local_assigns.fetch(:variant, :default)) do %>
+  <%= yield %>
+<% end %>

--- a/app/views/shared/ui/_empty_state.html.erb
+++ b/app/views/shared/ui/_empty_state.html.erb
@@ -1,0 +1,6 @@
+<%= render "shared/ui/card" do %>
+  <div class="px-5 py-10 text-center sm:px-8">
+    <h2 class="font-display text-lg font-bold text-ui-text"><%= title %></h2>
+    <% if local_assigns[:description].present? %><p class="mt-2 text-sm text-ui-text-muted"><%= description %></p><% end %>
+  </div>
+<% end %>

--- a/app/views/shared/ui/_filter_panel.html.erb
+++ b/app/views/shared/ui/_filter_panel.html.erb
@@ -1,0 +1,6 @@
+<details open class="group rounded-ui-surface border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface">
+  <summary class="flex min-h-11 cursor-pointer items-center justify-between px-4 py-3 text-sm font-bold text-ui-text marker:content-none md:hidden">
+    <%= title %><span aria-hidden="true" class="text-ui-text-muted group-open:rotate-180">⌄</span>
+  </summary>
+  <div class="hidden space-y-5 border-t border-ui-outline px-4 py-5 group-open:block md:!block md:border-t-0 md:px-6"><%= yield %></div>
+</details>

--- a/app/views/shared/ui/_filter_panel.html.erb
+++ b/app/views/shared/ui/_filter_panel.html.erb
@@ -1,6 +1,6 @@
-<details open class="group rounded-ui-surface border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface">
-  <summary class="flex min-h-11 cursor-pointer items-center justify-between px-4 py-3 text-sm font-bold text-ui-text marker:content-none md:hidden">
+<details class="group rounded-ui-surface border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface">
+  <summary class="flex min-h-11 cursor-pointer items-center justify-between px-4 py-3 text-sm font-bold text-ui-text marker:content-none">
     <%= title %><span aria-hidden="true" class="text-ui-text-muted group-open:rotate-180">⌄</span>
   </summary>
-  <div class="hidden space-y-5 border-t border-ui-outline px-4 py-5 group-open:block md:!block md:border-t-0 md:px-6"><%= yield %></div>
+  <div class="hidden space-y-5 border-t border-ui-outline px-4 py-5 group-open:block md:px-6"><%= yield %></div>
 </details>

--- a/app/views/shared/ui/_scenario_card.html.erb
+++ b/app/views/shared/ui/_scenario_card.html.erb
@@ -1,0 +1,42 @@
+<%= render "shared/ui/card", variant: :interactive do %>
+  <article class="flex h-full flex-col overflow-hidden">
+    <% if presentation == :visual %>
+      <%= link_to scenario_path(scenario), data: { turbo_frame: "_top" }, class: "group block no-underline" do %>
+        <div class="aspect-3/4 overflow-hidden bg-ui-field-solid">
+          <% image = scenario.jacket.attached? ? scenario.jacket : scenario.booth_image %>
+          <% if image.attached? %>
+            <%= image_tag image.variant(:thumb), alt: "", loading: "lazy", class: "h-full w-full object-contain" %>
+          <% else %>
+            <span class="flex h-full items-center justify-center text-sm text-ui-text-muted">画像なし</span>
+          <% end %>
+        </div>
+        <div class="space-y-3 p-4">
+          <h2 class="font-display text-lg font-bold leading-snug text-ui-text group-hover:text-ui-action"><%= scenario.title %></h2>
+          <p class="text-ui-caption text-ui-text-muted"><%= scenario.game_systems.map(&:name).join("／").presence || "#{GameSystem.model_name.human}未設定" %></p>
+          <div class="flex flex-wrap gap-2">
+            <%= render "shared/ui/badge", label: (player_count_value(scenario) || "人数未設定") %>
+            <%= render "shared/ui/badge", label: (duration_value(scenario) || "時間未設定") %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="space-y-4 p-4">
+        <h2><%= link_to scenario.title, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "font-display text-lg font-bold text-ui-text hover:text-ui-action" %></h2>
+        <dl class="grid grid-cols-[5rem_minmax(0,1fr)] gap-x-3 gap-y-2 text-ui-caption">
+          <dt class="text-ui-text-muted">作者</dt><dd><%= scenario.authors.map(&:name).join("、") %></dd>
+          <dt class="text-ui-text-muted">システム</dt><dd><%= scenario.game_systems.map(&:name).join("／") %></dd>
+          <dt class="text-ui-text-muted">人数</dt><dd><%= player_count_value(scenario) %></dd>
+          <dt class="text-ui-text-muted">時間</dt><dd><%= duration_value(scenario) %></dd>
+          <dt class="text-ui-text-muted">状態</dt><dd><%= scenario.status_for(owner)&.label || "シナリオ所持" %></dd>
+          <dt class="text-ui-text-muted">入手先</dt><dd class="flex flex-wrap gap-2"><% scenario.purchase_links.each do |purchase_link| %><%= purchase_link.url.present? ? link_to(purchase_link.label, purchase_link.url, target: "_blank", rel: "noopener nofollow", class: "text-ui-action") : purchase_link.label %><% end %></dd>
+        </dl>
+      </div>
+    <% end %>
+    <% if policy(scenario).update? || policy(scenario).destroy? %>
+      <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-ui-outline px-4 py-3">
+        <% if policy(scenario).update? %><%= link_to "編集", edit_scenario_path(scenario), data: { turbo_frame: "_top" }, class: "inline-flex min-h-11 items-center px-2 text-sm font-bold text-ui-action" %><% end %>
+        <% if policy(scenario).destroy? %><%= form_with url: scenario_path(scenario), method: :delete, data: { turbo_confirm: "#{scenario.title} を削除しますか" } do %><%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{scenario.title} を削除" }) %><% end %><% end %>
+      </div>
+    <% end %>
+  </article>
+<% end %>

--- a/spec/requests/accessibility_spec.rb
+++ b/spec/requests/accessibility_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe "Accessibility" do
     )
   end
 
-  it "makes the scenario management table reflow and names every column" do
+  it "makes scenario ordering a named card list with labelled controls" do
     sign_in_as create(:person, roles: %w[gm])
     create(:scenario)
 
     get scenario_order_index_path
 
     page = Capybara.string(response.body)
-    expect(page).to have_css('[role="region"][aria-label="シナリオの並び順と操作"][tabindex="0"] table')
-    expect(page).to have_css('th[scope="col"]', text: "操作")
+    expect(page).to have_css('section[aria-label="シナリオの並び順と操作"] #scenario_order')
+    expect(page).to have_css('button[aria-label$="を1つ上へ"]')
   end
 
   it "keeps labels visible for repeated session fields" do

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Manage::Scenarios" do
         authorized_get scenario_order_index_path
 
         page = Capybara.string(response.body)
-        expect(page).to have_css(%(tr[data-sortable-target="row"][data-sortable-id-param="#{scenario.id}"]))
+        expect(page).to have_css(%([data-sortable-target="row"][data-sortable-id-param="#{scenario.id}"]))
         expect(page).to have_css(".sortable-handle")
         expect(page).to have_no_css("[draggable], [data-action*='dragstart']")
       end

--- a/spec/requests/scenario_list_sort_and_filter_spec.rb
+++ b/spec/requests/scenario_list_sort_and_filter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
 
     frame = Capybara.string(response.body).find("turbo-frame#scenario_list")
     expect(frame["data-turbo-action"]).to eq("advance")
-    expect(frame).to have_button("1人")
+    expect(frame).to have_css("button", text: "1人", visible: :all)
     expect(frame).to have_select("並び順")
     expect(frame).to have_css("table")
     expect(frame).to have_css('a[data-turbo-frame="_top"]', text: "いちばん")
@@ -101,7 +101,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
     it "lists a scenario with two authors once" do
       get root_path(order: "author_asc")
 
-      expect(response.body.scan("最後の見本").size).to eq(1)
+      expect(Capybara.string(response.body).find("table")).to have_css("tr", text: "最後の見本", count: 1)
     end
 
     it "falls back to the GM order for an order it does not know" do
@@ -217,15 +217,15 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path
 
       document = Capybara.string(response.body)
-      party_size = document.all("fieldset")[0]
-      systems = document.all("fieldset")[1]
+      party_size = document.all("fieldset", visible: :all)[0]
+      systems = document.all("fieldset", visible: :all)[1]
 
-      expect(party_size).to have_css("legend", text: "人数")
-      expect(party_size).to have_button("1人")
-      expect(party_size).to have_button("5人以上")
-      expect(party_size).to have_css("button", count: 5)
-      expect(systems).to have_css("legend", text: "システム")
-      expect(systems).to have_css("button", count: 2)
+      expect(party_size).to have_css("legend", text: "人数", visible: :all)
+      expect(party_size).to have_css("button", text: "1人", visible: :all)
+      expect(party_size).to have_css("button", text: "5人以上", visible: :all)
+      expect(party_size).to have_css("button", count: 5, visible: :all)
+      expect(systems).to have_css("legend", text: "システム", visible: :all)
+      expect(systems).to have_css("button", count: 2, visible: :all)
       expect(document).to have_no_css('select[name="game_system_id"]')
       expect(document).to have_no_css('input[type="number"][name="player_count"]')
     end
@@ -234,9 +234,9 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(player_count: 5, game_system_ids: [ emoklore.id ])
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('button[aria-pressed="true"]', text: "5人以上")
-      expect(document).to have_css('button[aria-pressed="true"]', text: "エモクロア")
-      selected_form = document.find("button", text: "5人以上").ancestor("form")
+      expect(document).to have_css('button[aria-pressed="true"]', text: "5人以上", visible: :all)
+      expect(document).to have_css('button[aria-pressed="true"]', text: "エモクロア", visible: :all)
+      selected_form = document.find("button", text: "5人以上", visible: :all).ancestor("form", visible: :all)
       expect(selected_form).to have_no_css('input[name="player_count"]', visible: :all)
     end
 
@@ -244,10 +244,10 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(author_ids: [ ma_author.id ])
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('input[aria-label="作者を追加"][list="author-suggestions"]')
-      expect(document).to have_css('datalist#author-suggestions option[value="あ作者"]')
+      expect(document).to have_css('input[aria-label="作者を追加"][list="author-suggestions"]', visible: :all)
+      expect(document).to have_css('datalist#author-suggestions option[value="あ作者"]', visible: :all)
       expect(document).to have_css('input[type="hidden"][name="author_ids[]"]', visible: :all)
-      expect(document).to have_css('a[aria-label="ま作者を解除"]')
+      expect(document).to have_css('a[aria-label="ま作者を解除"]', visible: :all)
     end
 
     it "accepts an author alias from the suggestions" do
@@ -266,7 +266,7 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(author_name: "先生")
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください")
+      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください", visible: :all)
       expect(document).to have_no_css('datalist option[value="先生"]')
     end
 
@@ -284,8 +284,8 @@ RSpec.describe "Sorting and filtering the scenario list" do
       get root_path(author_name: "知らない作者")
 
       document = Capybara.string(response.body)
-      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください")
-      expect(document).to have_css('input[name="author_name"][aria-invalid="true"]')
+      expect(document).to have_css('[role="alert"]', text: "候補から作者を選択してください", visible: :all)
+      expect(document).to have_css('input[name="author_name"][aria-invalid="true"]', visible: :all)
     end
 
     it "filters the jacket view as well" do

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "The scenario list" do
 
       get root_path
 
-      expect(response.body[%r{<h1.*?</h1>}m]).to include("（全2件）")
+      expect(Capybara.string(response.body)).to have_css('[role="status"]', text: "全2件")
     end
 
     it "carries no explanation under the title" do
@@ -85,6 +85,18 @@ RSpec.describe "The scenario list" do
       get root_path
 
       expect(response.body).to include(root_path(view: "gallery"))
+    end
+
+    it "keeps the two views meaningfully different on narrow screens" do
+      get root_path
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("ul.md\\:hidden dl", visible: :all)
+      expect(page).to have_css("table", visible: :all)
+
+      get root_path(view: "gallery")
+
+      expect(Capybara.string(response.body)).to have_css(".aspect-3\\/4", visible: :all)
     end
 
     it "shows the jackets when asked" do

--- a/spec/requests/scenario_list_views_spec.rb
+++ b/spec/requests/scenario_list_views_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "The scenario list" do
       get root_path
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("ul.md\\:hidden dl", visible: :all)
+      expect(page).to have_css("ul.lg\\:hidden dl", visible: :all)
       expect(page).to have_css("table", visible: :all)
 
       get root_path(view: "gallery")

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe "Browsing scenarios" do
     )
 
     visit root_path
-    expect(page).to be_axe_clean.excluding("#main-content") if ENV["CHROME_BINARY"].present?
+    expect(page).to be_axe_clean if ENV["CHROME_BINARY"].present?
     expect(page).to have_content("シナリオ一覧")
     expect(page).to have_no_content("★")
 
-    click_link "カタシロ"
+    click_link "カタシロ", match: :first
 
     expect(page).to have_content("ディズム")
     expect(page).to have_content("CoC 7版")

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Responsive scenario lists" do
+  it "reflows both list modes and ordering without horizontal controls" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    scenario = create(:scenario, title: "狭い画面でも読める長いシナリオ名", player_count_min: 2,
+      duration_min_hours: 3, game_systems: [ create(:game_system, name: "長い名前のゲームシステム") ])
+    admin = create(:person, roles: %w[admin])
+    user = create(:user, person: admin)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      visit root_path
+      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+
+      if width < 768
+        expect(page).to have_no_css("table", visible: :visible)
+        expect(page).to have_css("dl", visible: :visible)
+        expect(page).to have_css("summary", text: "絞り込み", visible: :visible)
+      else
+        expect(page).to have_css("table", visible: :visible)
+      end
+      expect(page).to have_button("1人", visible: :visible)
+      expect(page).to be_axe_clean
+      save_screenshot("scenario-table-#{width}.png") if ENV["VISUAL_REVIEW"]
+
+      click_link "ジャケット"
+      expect(page).to have_css(".aspect-3\\/4", visible: :visible)
+      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+      save_screenshot("scenario-gallery-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+
+    visit root_path
+    click_button "Googleでログイン"
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      visit scenario_order_index_path
+      expect(page).to have_link(scenario.title)
+      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+      expect(page).to be_axe_clean
+      save_screenshot("scenario-order-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe "Responsive scenario lists" do
   it "reflows both list modes and ordering without horizontal controls" do
     skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
 
+    author = create(:author, name: "長い名前の作者")
     scenario = create(:scenario, title: "狭い画面でも読める長いシナリオ名", player_count_min: 2,
-      duration_min_hours: 3, game_systems: [ create(:game_system, name: "長い名前のゲームシステム") ])
+      duration_min_hours: 3, game_systems: [ create(:game_system, name: "長い名前のゲームシステム") ], authors: [ author ])
     admin = create(:person, roles: %w[admin])
     user = create(:user, person: admin)
     OmniAuth.config.test_mode = true
@@ -15,23 +16,29 @@ RSpec.describe "Responsive scenario lists" do
 
     [ 320, 768, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)
-      visit root_path
+      visit root_path(author_ids: [ author.id ])
       expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
 
-      if width < 768
+      if width < 1024
         expect(page).to have_no_css("table", visible: :visible)
         expect(page).to have_css("dl", visible: :visible)
-        expect(page).to have_css("summary", text: "絞り込み", visible: :visible)
       else
         expect(page).to have_css("table", visible: :visible)
       end
+      expect(page).to have_css("summary", text: "絞り込み", visible: :visible)
+      expect(page).to have_no_button("1人", visible: :visible)
+      find("summary", text: "絞り込み").click
       expect(page).to have_button("1人", visible: :visible)
+      remove_author = find(%(a[aria-label="#{author.name}を解除"]), visible: :visible)
+      expect(remove_author.rect.width).to be >= 44
+      expect(remove_author.rect.height).to be >= 44
       expect(page).to be_axe_clean
       save_screenshot("scenario-table-#{width}.png") if ENV["VISUAL_REVIEW"]
 
-      click_link "ジャケット"
+      visit root_path(view: "gallery", author_ids: [ author.id ])
       expect(page).to have_css(".aspect-3\\/4", visible: :visible)
       expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+      expect(page).to be_axe_clean
       save_screenshot("scenario-gallery-#{width}.png") if ENV["VISUAL_REVIEW"]
     end
 


### PR DESCRIPTION
## What
- migrate scenario filtering, list modes, and ordering to the Obsidian Glass components
- add reusable card, badge, empty state, filter panel, and scenario card primitives
- replace the ordering table with responsive sortable cards

## Narrow-screen list modes
The view toggle remains available because the modes stay meaningfully different at 320px: table mode becomes an image-free, information-focused card with author, system, party size, duration, status, and purchase links, while jacket mode remains image-first. This preserves the user choice without making both options produce the same mobile result. The comparison table itself is shown from 1024px upward.

## Contrast
All content left directly on `#050608` uses the new tokens. Measured ratios are:

- page heading `ui-text` (`#f4f7fb`): 18.86:1
- result count and supporting text `ui-text-muted` (`#a5afbd`): 9.14:1
- inactive view link `ui-text` (`#f4f7fb`): 18.86:1
- selected view text `ui-on-action` (`#07101a`) on `ui-action` (`#c7ddf7`): 13.76:1
- toggle/input outline `ui-outline-strong` (`#718198`) on `#050608`: 5.11:1

Axe runs on table-card mode, jacket mode, and scenario ordering at 320px, 768px, and 1280px.

## Migration boundary
PR #119 adds a separate transition guard for tasks 4-10: not-yet-migrated content stays on the legacy paper surface, while migrated screens opt into dark content with `content_for :ui_theme, "dark"`. This PR adds that opt-in to the scenario list and ordering screens. Keeping the guard separate avoids partially migrating later tasks or reverting the dark application shell.

## Verification
- `DISABLE_BOOTSNAP=1 bin/ci`
- `prek run --all-files`
- Chrome axe checks and visual review at 320px, 768px, and 1280px