### PR TITLE
Protect legacy content during UI migration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,10 @@
       </div>
     <% end %>
 
-    <main id="main-content" tabindex="-1" class="mx-auto w-full max-w-5xl grow px-4 py-8 sm:px-6 sm:py-10">
+    <% ui_theme = content_for(:ui_theme).presence || "legacy" %>
+    <% content_classes = ui_theme == "dark" ? "" : "bg-paper text-ink" %>
+    <main id="main-content" tabindex="-1" data-ui-theme="<%= ui_theme %>"
+          class="mx-auto w-full max-w-5xl grow px-4 py-8 sm:px-6 sm:py-10 <%= content_classes %>">
       <%= yield %>
     </main>
 

--- a/docs/plans/2026-08-22-ui-redesign.md
+++ b/docs/plans/2026-08-22-ui-redesign.md
@@ -115,6 +115,9 @@
 
 各移行 PR で次を行う。
 
+移行した画面のトップレベルテンプレートでは、`content_for :ui_theme, "dark"` を設定する。
+同時に、その画面を legacy content contrast の監査対象から外し、画面全体の axe 検査へ移す。
+
 1. `bin/rspec` と `prek run --all-files`
 2. 対象画面の system spec に axe のチェックを入れ、コントラストとラベルの関連付けを機械で確認する
 3. 320px、768px、1280px 相当の幅で、横方向のはみ出し、読み順、タップ領域を目視する

--- a/spec/requests/accessibility_spec.rb
+++ b/spec/requests/accessibility_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Accessibility" do
     expect(page).to have_css('nav[aria-label="主要"]')
     expect(page).to have_css('main#main-content[tabindex="-1"]')
     expect(page).to have_css("body.bg-ui-background.text-ui-text")
+    expect(page).to have_css('main[data-ui-theme="legacy"].bg-paper.text-ink')
   end
 
   it "announces alert flashes assertively" do

--- a/spec/requests/accessibility_spec.rb
+++ b/spec/requests/accessibility_spec.rb
@@ -9,7 +9,15 @@ RSpec.describe "Accessibility" do
     expect(page).to have_css('nav[aria-label="主要"]')
     expect(page).to have_css('main#main-content[tabindex="-1"]')
     expect(page).to have_css("body.bg-ui-background.text-ui-text")
-    expect(page).to have_css('main[data-ui-theme="legacy"].bg-paper.text-ink')
+    expect(page).to have_css("main[data-ui-theme]")
+  end
+
+  it "keeps not-yet-migrated content on the legacy surface" do
+    get new_registration_path
+
+    expect(Capybara.string(response.body)).to have_css(
+      'main[data-ui-theme="legacy"].bg-paper.text-ink'
+    )
   end
 
   it "announces alert flashes assertively" do

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Browsing scenarios" do
     )
 
     visit root_path
-    expect(page).to be_axe_clean.excluding("#main-content") if ENV["CHROME_BINARY"].present?
+    expect(page).to be_axe_clean if ENV["CHROME_BINARY"].present?
     expect(page).to have_content("シナリオ一覧")
     expect(page).to have_no_content("★")
 

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Legacy content contrast" do
+  it "keeps every not-yet-migrated screen accessible on its legacy surface" do
+    skip "Chrome is required for axe checks" unless ENV["CHROME_BINARY"].present?
+
+    visit new_registration_path
+    expect(page).to have_css('main[data-ui-theme="legacy"].bg-paper.text-ink')
+    expect(page).to be_axe_clean
+
+    admin = create(:person, roles: %w[admin gm])
+    current_user = create(:user, person: admin)
+    person = create(:person)
+    scenario = create(:scenario)
+    play_session = create(:play_session, scenario:)
+    author = create(:author)
+    game_system = create(:game_system)
+    group = create(:group)
+    user = create(:user)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: current_user.google_uid, info: { email: current_user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
+
+    legacy_paths = [
+      scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),
+      play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
+      people_path, person_path(person), new_person_path, edit_person_path(person),
+      authors_path, author_path(author), new_author_path, edit_author_path(author),
+      game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),
+      manage_groups_path, manage_group_path(group), edit_manage_group_path(group),
+      manage_users_path, manage_user_path(user), edit_manage_user_path(user),
+      manage_site_setting_path, edit_manage_site_setting_path
+    ]
+
+    legacy_paths.each do |path|
+      visit path
+      expect(page).to have_css('main[data-ui-theme="legacy"].bg-paper.text-ink'), path
+      expect(page).to be_axe_clean.checking_only("color-contrast")
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## What
- render not-yet-migrated `main` content on the legacy paper/text surface
- let migrated screens opt into the dark content surface with `content_for :ui_theme, "dark"`
- run axe color-contrast checks across every task 4-10 route

## Audit
On `#050608`, the exposed legacy tokens measure: `ink`/`border-ink` 1.12:1, `seal`/`border-seal` 2.40:1, `muted` 3.40:1, and `rule` 13.21:1. Unclassed text inherits `ui-text` at 18.86:1.

- Task 4, scenario detail: muted breadcrumbs/metadata (3.40), seal actions/favorite/purchase links and borders (2.40)
- Task 5, scenario forms: seal jacket actions (2.40) and muted return/support text (3.40); form interiors already have legacy surfaces
- Task 6, session list/detail: muted count, breadcrumbs and definition labels (3.40), seal create/edit/delete links (2.40), and the linked detail heading in ink (1.12)
- Task 7, session forms: muted return link (3.40); form interiors already have legacy surfaces
- Task 8, people/registration: seal create, profile and edit/delete links (2.40), muted profile/support/empty text (3.40); registration content already has a legacy surface
- Task 9, author/system/group management: seal create/detail actions (2.40), muted metadata/empty/return text (3.40); form and list interiors already have legacy surfaces
- Task 10, user/site settings: muted list help, definition labels and return links (3.40), seal detail/edit links (2.40)

On the temporary `paper` surface, ink is 15.57:1, seal is 7.27:1, and muted is 5.13:1. The pre-existing `rule`/paper border is 1.32:1; this PR does not worsen it and each screen migration will replace it with the new outline contract.

## Decision
This is a separate transition guard instead of partially migrating tasks 4-10 or reverting the dark application shell. It restores readable content with one layout-level default, preserves the planned PR boundaries, and lets each completed screen explicitly opt into the dark surface. PR #118 adds that opt-in for scenario lists and ordering.

## Verification
- `DISABLE_BOOTSNAP=1 bin/ci`
- `prek run --all-files`
- Chrome axe checks for registration and every task 4-10 list/detail/new/edit route