### PR TITLE
Redesign people and registration screens

### DIFF
--- a/app/views/manage/people/_form.html.erb
+++ b/app/views/manage/people/_form.html.erb
@@ -1,54 +1,15 @@
-<%= form_with model: person, class: "mt-6 space-y-4 border border-rule bg-surface p-5" do |form| %>
+<%= form_with model: person, class: "space-y-6" do |form| %>
   <%= accessible_error_summary(person) %>
-
-  <div class="grid gap-4 sm:grid-cols-2">
-    <div>
-      <%= form.label :display_name, "表示名", class: "block text-xs text-muted" %>
-      <%= form.text_field :display_name, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+  <section class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+    <div class="grid gap-5 sm:grid-cols-2">
+      <%= ui_field(form, :display_name, label: "表示名", required: true) do |field| %><%= ui_input(form, :display_name, described_by: field[:described_by], required: true) %><% end %>
+      <%= ui_field(form, :x_account, label: "X のアカウント名") do |field| %><%= ui_input(form, :x_account, described_by: field[:described_by]) %><% end %>
+      <div class="sm:col-span-2"><%= form.label :icon, "アイコン", class: "mb-1 block text-sm font-bold" %><%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm" %></div>
     </div>
-    <div>
-      <%= form.label :x_account, "X のアカウント名", class: "block text-xs text-muted" %>
-      <%= form.text_field :x_account, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-    </div>
-  </div>
-
-  <div>
-    <%= form.label :icon, "アイコン", class: "block text-xs text-muted" %>
-    <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
-  </div>
-
-  <div>
-    <span class="block text-xs text-muted">権限</span>
-
-    <%# プレイヤーは全員が持つ。付け外しできないことを画面でも示す。 %>
-    <label class="mr-4 inline-flex items-center gap-1 text-sm text-muted">
-      <%= check_box_tag "person_roles_player_display", "player", true,
-            disabled: true, id: "person_roles_player" %>
-      <%= t("people.roles.player") %>
-    </label>
-
-    <% PersonRole::ROLES.each_key do |role| %>
-      <label class="mr-4 inline-flex items-center gap-1 text-sm">
-        <%= check_box_tag "person[roles][]", role, person.roles.include?(role.to_s), id: "person_roles_#{role}" %>
-        <%= t("people.roles.#{role}") %>
-      </label>
-    <% end %>
-    <%= hidden_field_tag "person[roles][]", "" %>
-
-    <p class="mt-1 text-xs text-muted">プレイヤーはログインした全員が持ちます。外せません。</p>
-  </div>
-
-  <div>
-    <span class="block text-xs text-muted"><%= Group.model_name.human %></span>
-    <%= form.collection_check_boxes :manual_group_ids, Group.all.to_a, :id, :name do |b| %>
-      <label class="mr-4 inline-flex items-center gap-1 text-sm"><%= b.check_box %> <%= b.text %></label>
-    <% end %>
-  </div>
-
-  <div class="flex gap-4">
-    <%= form.submit person.persisted? ? "更新" : "追加", class: "bg-ink px-5 py-2 text-sm text-paper" %>
-    <%= link_to person.persisted? ? "詳細に戻る" : "一覧に戻る",
-          person.persisted? ? person_path(person) : people_path,
-          class: "self-center text-sm text-muted" %>
+  </section>
+  <%= render "people/administration_fields", form:, person: %>
+  <div class="flex flex-wrap gap-3">
+    <%= ui_button(person.persisted? ? "更新" : "追加", type: "submit") %>
+    <%= ui_button_link(person.persisted? ? "詳細に戻る" : "一覧に戻る", href: (person.persisted? ? person_path(person) : people_path), variant: :secondary) %>
   </div>
 <% end %>

--- a/app/views/manage/people/_form.html.erb
+++ b/app/views/manage/people/_form.html.erb
@@ -4,7 +4,7 @@
     <div class="grid gap-5 sm:grid-cols-2">
       <%= ui_field(form, :display_name, label: "表示名", required: true) do |field| %><%= ui_input(form, :display_name, described_by: field[:described_by], required: true) %><% end %>
       <%= ui_field(form, :x_account, label: "X のアカウント名") do |field| %><%= ui_input(form, :x_account, described_by: field[:described_by]) %><% end %>
-      <div class="sm:col-span-2"><%= form.label :icon, "アイコン", class: "mb-1 block text-sm font-bold" %><%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm" %></div>
+      <div class="sm:col-span-2"><%= ui_field(form, :icon, label: "アイコン") do |field| %><%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", aria: { describedby: field[:described_by] }, data: { ui_error_id: (form.field_id(:icon, :error) if person.errors[:icon].any?) }, class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm aria-invalid:border-ui-error aria-invalid:ring-1 aria-invalid:ring-ui-error" %><% end %></div>
     </div>
   </section>
   <%= render "people/administration_fields", form:, person: %>

--- a/app/views/people/_administration_fields.html.erb
+++ b/app/views/people/_administration_fields.html.erb
@@ -1,31 +1,18 @@
 <% roles = local_assigns[:selected_roles] || person.roles %>
 <% group_ids = local_assigns[:selected_group_ids] || person.manual_group_ids %>
-<fieldset class="border border-rule bg-surface p-5">
-  <legend class="px-2 font-display text-sm">管理項目</legend>
-
-  <div>
-    <span class="block text-xs text-muted">権限</span>
-    <label class="mr-4 inline-flex items-center gap-1 text-sm text-muted">
-      <%= check_box_tag "person_roles_player_display", "player", true,
-            disabled: true, id: "person_roles_player" %>
-      <%= t("people.roles.player") %>
-    </label>
-
-    <% PersonRole::ROLES.each_key do |role| %>
-      <label class="mr-4 inline-flex items-center gap-1 text-sm">
-        <%= check_box_tag "person[roles][]", role, roles.include?(role.to_s), id: "person_roles_#{role}" %>
-        <%= t("people.roles.#{role}") %>
-      </label>
-    <% end %>
+<fieldset class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+  <legend class="px-2 font-display text-lg font-bold">管理項目</legend>
+  <div class="space-y-2">
+    <span class="block text-sm font-bold">権限</span>
+    <div class="flex flex-wrap gap-x-5 gap-y-2">
+      <label class="inline-flex min-h-11 items-center gap-2 text-sm text-ui-text-muted"><%= check_box_tag "person_roles_player_display", "player", true, disabled: true, id: "person_roles_player", class: "size-5" %><%= t("people.roles.player") %></label>
+      <% PersonRole::ROLES.each_key do |role| %><label class="inline-flex min-h-11 items-center gap-2 text-sm"><%= check_box_tag "person[roles][]", role, roles.include?(role.to_s), id: "person_roles_#{role}", class: "size-5 accent-ui-action" %><%= t("people.roles.#{role}") %></label><% end %>
+    </div>
     <%= hidden_field_tag "person[roles][]", "" %>
-    <p class="mt-1 text-xs text-muted">プレイヤーはログインした全員が持ちます。外せません。</p>
+    <p class="text-ui-caption text-ui-text-muted">プレイヤーはログインした全員が持ちます。外せません。</p>
   </div>
-
-  <div class="mt-4">
-    <span class="block text-xs text-muted"><%= Group.model_name.human %></span>
-    <%= form.collection_check_boxes :manual_group_ids, Group.all.to_a, :id, :name,
-          checked: group_ids do |group| %>
-      <label class="mr-4 inline-flex items-center gap-1 text-sm"><%= group.check_box %> <%= group.text %></label>
-    <% end %>
+  <div class="mt-5 space-y-2">
+    <span class="block text-sm font-bold"><%= Group.model_name.human %></span>
+    <div class="flex flex-wrap gap-x-5 gap-y-2"><%= form.collection_check_boxes :manual_group_ids, Group.all.to_a, :id, :name, checked: group_ids do |group| %><%= group.label class: "inline-flex min-h-11 items-center gap-2 text-sm" do %><%= group.check_box class: "size-5 accent-ui-action" %><%= group.text %><% end %><% end %></div>
   </div>
 </fieldset>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -1,40 +1,36 @@
 <% content_for :title, "#{@person.display_name} のプロフィール編集" %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-2xl"><%= policy(@person).manage? ? "#{Person.model_name.human}の編集" : "プロフィールの編集" %></h1>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: (policy(@person).manage? ? "#{Person.model_name.human}の編集" : "プロフィールの編集") %>
+  <%= form_with model: @person, class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@person) %>
+    <% if @lost_roles.present? %>
+      <%= render "shared/ui/self_demotion_warning", roles: @lost_roles %>
+      <%= hidden_field_tag :confirm_self_demotion, @lost_roles.join(",") %>
+    <% end %>
 
-<%= form_with model: @person, class: "mt-6 space-y-6" do |form| %>
-  <%= accessible_error_summary(@person) %>
-  <% if @lost_roles.present? %>
-    <%= render "shared/self_demotion_warning", roles: @lost_roles %>
-    <%= hidden_field_tag :confirm_self_demotion, @lost_roles.join(",") %>
-  <% end %>
-
-  <fieldset class="border border-rule bg-surface p-5">
-    <legend class="px-2 font-display text-sm">あなたのこと</legend>
-    <div class="grid gap-4 sm:grid-cols-2">
-      <div>
-        <%= form.label :x_account, "X のアカウント名（@ は不要）", class: "block text-xs text-muted" %>
-        <%= form.text_field :x_account, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
+    <fieldset class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+      <legend class="px-2 font-display text-lg font-bold">あなたのこと</legend>
+      <div class="grid gap-5 sm:grid-cols-2">
+        <%= ui_field(form, :x_account, label: "X のアカウント名（@ は不要）") do |field| %><%= ui_input(form, :x_account, described_by: field[:described_by], autocomplete: "username") %><% end %>
+        <div class="sm:col-span-2">
+          <%= form.label :icon, "アイコン", class: "mb-1 block text-sm font-bold" %>
+          <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm file:mr-3 file:rounded-ui-control file:border-0 file:bg-ui-subtle file:px-3 file:py-1 file:text-ui-text" %>
+        </div>
       </div>
-      <div class="sm:col-span-2">
-        <%= form.label :icon, "アイコン", class: "block text-xs text-muted" %>
-        <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
-      </div>
+    </fieldset>
+
+    <%= render "shared/ui/alias_fields", form:, display_attribute: :display_name, alias_class: PersonAlias %>
+    <% if policy(@person).manage? %>
+      <%= render "people/administration_fields", form:, person: @person, selected_roles: @selected_roles, selected_group_ids: @selected_group_ids %>
+    <% else %>
+      <p class="text-ui-caption text-ui-text-muted"><%= Group.model_name.human %>の所属は管理者が設定します。</p>
+    <% end %>
+
+    <div class="flex flex-wrap gap-3">
+      <%= ui_button(@lost_roles.present? ? t("people.self_demotion.continue") : "保存", type: "submit") %>
+      <%= ui_button_link("詳細に戻る", href: person_path(@person), variant: :secondary) %>
     </div>
-  </fieldset>
-
-  <%= render "shared/alias_fields", form: form, display_attribute: :display_name, alias_class: PersonAlias %>
-
-  <% if policy(@person).manage? %>
-    <%= render "people/administration_fields", form: form, person: @person,
-          selected_roles: @selected_roles, selected_group_ids: @selected_group_ids %>
-  <% else %>
-    <p class="text-xs text-muted"><%= Group.model_name.human %>の所属は管理者が設定します。</p>
   <% end %>
-
-  <div class="flex gap-4">
-    <%= form.submit @lost_roles.present? ? t("people.self_demotion.continue") : "保存",
-          class: "cursor-pointer bg-ink px-6 py-2 text-sm text-paper" %>
-    <%= link_to "詳細に戻る", person_path(@person), class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -14,10 +14,7 @@
       <legend class="px-2 font-display text-lg font-bold">あなたのこと</legend>
       <div class="grid gap-5 sm:grid-cols-2">
         <%= ui_field(form, :x_account, label: "X のアカウント名（@ は不要）") do |field| %><%= ui_input(form, :x_account, described_by: field[:described_by], autocomplete: "username") %><% end %>
-        <div class="sm:col-span-2">
-          <%= form.label :icon, "アイコン", class: "mb-1 block text-sm font-bold" %>
-          <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm file:mr-3 file:rounded-ui-control file:border-0 file:bg-ui-subtle file:px-3 file:py-1 file:text-ui-text" %>
-        </div>
+        <div class="sm:col-span-2"><%= ui_field(form, :icon, label: "アイコン") do |field| %><%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp", aria: { describedby: field[:described_by] }, data: { ui_error_id: (form.field_id(:icon, :error) if @person.errors[:icon].any?) }, class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm file:mr-3 file:rounded-ui-control file:border-0 file:bg-ui-subtle file:px-3 file:py-1 file:text-ui-text aria-invalid:border-ui-error aria-invalid:ring-1 aria-invalid:ring-ui-error" %><% end %></div>
       </div>
     </fieldset>
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,40 +1,17 @@
 <% content_for :title, Person.model_name.human %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-3xl tracking-wide"><%= Person.model_name.human %></h1>
-<% if policy(Person).create? %><p class="mt-4"><%= link_to "新規登録", new_person_path, class: "text-sm text-seal" %></p><% end %>
+<div class="space-y-6">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <%= render "shared/ui/page_header", title: Person.model_name.human %>
+    <% if policy(Person).create? %><%= ui_button_link("新規登録", href: new_person_path) %><% end %>
+  </div>
 
-<ul class="mt-8 grid gap-px border border-rule bg-rule sm:grid-cols-2 lg:grid-cols-3">
-  <% @people.each do |member| %>
-    <li class="bg-surface">
-      <%= link_to person_path(member), class: "flex items-center gap-3 p-4 no-underline text-ink hover:bg-paper" do %>
-        <span class="size-12 shrink-0 overflow-hidden rounded-full bg-paper">
-          <% if member.icon.attached? %>
-            <%= image_tag member.icon.variant(:thumb), alt: "", class: "size-full object-cover" %>
-          <% end %>
-        </span>
-        <span>
-          <span class="block font-display"><%= member.display_name %></span>
-          <% if member.visible_aliases.any? %>
-            <span class="block text-xs text-muted"><%= member.visible_aliases.map(&:name).join("、") %></span>
-          <% end %>
-          <% if current_person.admin? %>
-            <span class="mt-1 block text-xs text-muted">権限: <%= person_role_labels(member).join("、") %></span>
-            <span class="block text-xs text-muted"><%= Group.model_name.human %>: <%= member.groups.map(&:name).join("、").presence || "なし" %></span>
-            <span class="block text-xs text-muted"><%= User.model_name.human %>: <%= member.users.map { |user| "#{user.provider_name}: #{user.email.presence || user.name.presence || "不明"}" }.join("、").presence || "未紐づけ" %></span>
-          <% end %>
-        </span>
-      <% end %>
-      <% if policy(member).update? || policy(member).offer_destroy? %>
-        <div class="flex flex-wrap items-center gap-3 px-4 pb-4 text-xs">
-          <% if policy(member).update? %><%= link_to "編集", edit_person_path(member), class: "text-seal" %><% end %>
-          <%= render "shared/delete_button", record: member, path: person_path(member), label: "削除",
-                aria_label: "#{member.display_name} を削除",
-                confirm: "#{member.display_name} を削除しますか",
-                disabled_aria_label: "自分自身は削除できません",
-                class_name: "min-h-6 text-muted",
-                disabled_class_name: "min-h-6 text-muted opacity-60 cursor-not-allowed" %>
-        </div>
-      <% end %>
-    </li>
+  <% if @people.any? %>
+    <ul class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <% @people.each do |member| %><li><%= render "shared/ui/person_card", person: member %></li><% end %>
+    </ul>
+  <% else %>
+    <%= render "shared/ui/empty_state", title: "まだ#{Person.model_name.human}が登録されていません。" %>
   <% end %>
-</ul>
+</div>

--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -1,3 +1,6 @@
 <% content_for :title, "#{Person.model_name.human}の新規登録" %>
-<h1 class="font-display text-2xl"><%= Person.model_name.human %>の新規登録</h1>
-<%= render "manage/people/form", person: @person %>
+<% content_for :ui_theme, "dark" %>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: "#{Person.model_name.human}の新規登録" %>
+  <%= render "manage/people/form", person: @person %>
+</div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :ui_theme, "dark" %>
 
 <article class="space-y-8">
-  <header class="grid gap-6 rounded-ui-panel border border-ui-outline bg-ui-surface-solid p-5 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:p-7">
+  <header class="grid gap-6 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:p-7">
     <span class="size-24 overflow-hidden rounded-full border border-ui-outline-strong bg-ui-field-solid">
       <% if @person.icon.attached? %><%= image_tag @person.icon.variant(:thumb), alt: "", class: "size-full object-cover" %><% end %>
     </span>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,65 +1,42 @@
 <% content_for :title, @person.display_name %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <div class="flex flex-wrap items-start gap-6">
-    <span class="size-24 shrink-0 overflow-hidden rounded-full border border-rule bg-surface">
-      <% if @person.icon.attached? %>
-        <%= image_tag @person.icon.variant(:thumb), alt: "", class: "size-full object-cover" %>
-      <% end %>
+<article class="space-y-8">
+  <header class="grid gap-6 rounded-ui-panel border border-ui-outline bg-ui-surface-solid p-5 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:p-7">
+    <span class="size-24 overflow-hidden rounded-full border border-ui-outline-strong bg-ui-field-solid">
+      <% if @person.icon.attached? %><%= image_tag @person.icon.variant(:thumb), alt: "", class: "size-full object-cover" %><% end %>
     </span>
-
-    <div class="grow">
-      <h1 class="font-display text-3xl tracking-wide"><%= @person.display_name %></h1>
-      <% if @person.x_account.present? %>
-        <p class="mt-1 text-sm">
-          <%= link_to "@#{@person.x_account}", "https://x.com/#{@person.x_account}",
-                target: "_blank", rel: "noopener", class: "text-seal" %>
-        </p>
-      <% end %>
-      <p class="mt-2 text-xs text-muted">
-        <%= Group.model_name.human %>: <%= @person.groups.map(&:name).join("、").presence || "なし" %>
-      </p>
+    <div class="min-w-0 space-y-2">
+      <%= render "shared/ui/page_header", title: @person.display_name %>
+      <% if @person.x_account.present? %><p><%= link_to "@#{@person.x_account}", "https://x.com/#{@person.x_account}", target: "_blank", rel: "noopener", class: "inline-flex min-h-11 items-center text-ui-action" %></p><% end %>
+      <p class="text-ui-caption text-ui-text-muted"><%= Group.model_name.human %>: <%= @person.groups.map(&:name).join("、").presence || "なし" %></p>
     </div>
-
-    <div class="flex flex-wrap items-baseline gap-3">
-      <% if policy(@person).update? %>
-        <%= link_to "編集", edit_person_path(@person), class: "text-sm text-seal" %>
+    <div class="flex flex-wrap gap-2">
+      <% if policy(@person).update? %><%= ui_button_link("編集", href: edit_person_path(@person), variant: :secondary, size: :small) %><% end %>
+      <% if policy(@person).destroy? %>
+        <%= form_with url: person_path(@person), method: :delete, data: { turbo_confirm: "#{@person.display_name} を削除しますか" } do %><%= ui_button("この#{Person.model_name.human}を削除", variant: :danger, size: :small, type: "submit") %><% end %>
+      <% elsif policy(@person).offer_destroy? %>
+        <%= ui_button("自分自身は削除できません", variant: :secondary, size: :small, disabled: true) %>
       <% end %>
-      <%= render "shared/delete_button", record: @person, path: person_path(@person),
-            label: "この#{Person.model_name.human}を削除",
-            confirm: "#{@person.display_name} を削除しますか",
-            disabled_label: "自分自身は削除できません",
-            class_name: "text-sm text-seal", disabled_class_name: "text-sm text-muted cursor-not-allowed" %>
     </div>
-  </div>
+  </header>
 
   <% if @person.visible_aliases.any? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl">別名</h2>
-      <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-        <% @person.visible_aliases.each do |person_alias| %>
-          <li class="flex items-baseline gap-4 p-3">
-            <span class="font-display"><%= person_alias.name %></span>
-            <span class="text-xs text-muted"><%= person_alias.context %></span>
-          </li>
-        <% end %>
+    <section class="space-y-3" aria-labelledby="aliases-heading">
+      <h2 id="aliases-heading" class="font-display text-xl font-bold">別名</h2>
+      <ul class="divide-y divide-ui-outline rounded-ui-card border border-ui-outline bg-ui-surface-solid">
+        <% @person.visible_aliases.each do |person_alias| %><li class="grid gap-1 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]"><span class="font-bold"><%= person_alias.name %></span><span class="text-ui-caption text-ui-text-muted"><%= person_alias.context %></span></li><% end %>
       </ul>
     </section>
   <% end %>
 
-  <section class="mt-10">
-    <h2 class="font-display text-xl">お気に入り<%= Scenario.model_name.human %></h2>
+  <section class="space-y-3" aria-labelledby="favorites-heading">
+    <h2 id="favorites-heading" class="font-display text-xl font-bold">お気に入り<%= Scenario.model_name.human %></h2>
     <% favorites = @person.favorite_scenarios.order(:title) %>
     <% if favorites.any? %>
-      <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-        <% favorites.each do |scenario| %>
-          <li class="p-3">
-            <%= link_to scenario.title, scenario_path(scenario), class: "text-seal" %>
-          </li>
-        <% end %>
-      </ul>
+      <ul class="grid gap-3 sm:grid-cols-2"><% favorites.each do |scenario| %><li><%= render "shared/ui/card" do %><%= link_to scenario.title, scenario_path(scenario), class: "flex min-h-11 items-center p-4 font-bold text-ui-action" %><% end %></li><% end %></ul>
     <% else %>
-      <p class="mt-3 text-sm text-muted">まだありません。</p>
+      <%= render "shared/ui/empty_state", title: "お気に入り#{Scenario.model_name.human}はまだありません。" %>
     <% end %>
   </section>
 </article>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto max-w-2xl space-y-6">
   <%= render "shared/ui/page_header", title: "新規登録" %>
-  <section class="space-y-5 rounded-ui-panel border border-ui-outline bg-ui-surface-solid p-5 text-sm leading-7 sm:p-7">
+  <section class="space-y-5 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 text-sm leading-7 sm:p-7">
     <p>このサイトの全機能（セッション情報表示・お気に入りシナリオ機能など）を利用するにはGoogleまたはDiscordアカウントでのログインが必要です。以下のステップで登録してください。</p>
     <ol class="list-decimal space-y-2 pl-6"><li>下記のボタンを押してGoogleまたはDiscordでログインする</li><li>プロフィールを提供してよいか認証先に聞かれるので許可する</li><li>Discord連携済みのサーバーに参加していない場合は、管理者に連絡して許可してもらうのを待つ</li></ol>
     <p>なお、Googleアカウントの情報はこのサイト上では管理者以外の人に表示されることはありません。表示名は自由に設定できます。</p>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,37 +1,16 @@
 <% content_for :title, "新規登録" %>
+<% content_for :ui_theme, "dark" %>
 
-<div class="mx-auto max-w-2xl">
-  <h1 class="font-display text-3xl tracking-wide">新規登録</h1>
-
-  <div class="mt-6 space-y-5 border border-rule bg-surface p-6 text-sm leading-7">
-    <p>
-      このサイトの全機能（セッション情報表示・お気に入りシナリオ機能など）を利用するにはGoogleまたはDiscordアカウントでのログインが必要です。以下のステップで登録してください。
-    </p>
-
-    <ol class="list-decimal space-y-1 pl-6">
-      <li>下記のボタンを押してGoogleまたはDiscordでログインする</li>
-      <li>プロフィールを提供してよいか認証先に聞かれるので許可する</li>
-      <li>Discord連携済みのサーバーに参加していない場合は、管理者に連絡して許可してもらうのを待つ</li>
-    </ol>
-
-    <p>
-      なお、Googleアカウントの情報はこのサイト上では管理者以外の人に表示されることはありません。表示名は自由に設定できます。
-    </p>
-
-    <p>
-      Discordでログインすると、連携済みサーバーへの参加状況をBot経由で確認します。他の参加サーバーの情報は取得しません。
-    </p>
-
-    <div class="flex justify-center gap-3">
-      <%# Turbo はフォーム送信を横取りするが、provider への cross-origin リダイレクトを追えない。 %>
-      <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post,
-            params: { origin: request.fullpath },
-            form: { data: { turbo: false } },
-            class: "cursor-pointer bg-ink px-4 py-2 text-paper hover:bg-seal" %>
-      <%= button_to "Discord でログイン", "/auth/discord", method: :post,
-            params: { origin: request.fullpath },
-            form: { data: { turbo: false } },
-            class: "cursor-pointer bg-ink px-4 py-2 text-paper hover:bg-seal" %>
+<div class="mx-auto max-w-2xl space-y-6">
+  <%= render "shared/ui/page_header", title: "新規登録" %>
+  <section class="space-y-5 rounded-ui-panel border border-ui-outline bg-ui-surface-solid p-5 text-sm leading-7 sm:p-7">
+    <p>このサイトの全機能（セッション情報表示・お気に入りシナリオ機能など）を利用するにはGoogleまたはDiscordアカウントでのログインが必要です。以下のステップで登録してください。</p>
+    <ol class="list-decimal space-y-2 pl-6"><li>下記のボタンを押してGoogleまたはDiscordでログインする</li><li>プロフィールを提供してよいか認証先に聞かれるので許可する</li><li>Discord連携済みのサーバーに参加していない場合は、管理者に連絡して許可してもらうのを待つ</li></ol>
+    <p>なお、Googleアカウントの情報はこのサイト上では管理者以外の人に表示されることはありません。表示名は自由に設定できます。</p>
+    <p>Discordでログインすると、連携済みサーバーへの参加状況をBot経由で確認します。他の参加サーバーの情報は取得しません。</p>
+    <div class="grid gap-3 sm:grid-cols-2">
+      <%= form_with url: "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, request.fullpath %><%= ui_button("Google でログイン", type: "submit") %><% end %>
+      <%= form_with url: "/auth/discord", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, request.fullpath %><%= ui_button("Discord でログイン", variant: :secondary, type: "submit") %><% end %>
     </div>
-  </div>
+  </section>
 </div>

--- a/app/views/shared/ui/_alias_fields.html.erb
+++ b/app/views/shared/ui/_alias_fields.html.erb
@@ -1,0 +1,27 @@
+<fieldset class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+  <legend class="px-2 font-display text-lg font-bold text-ui-text">名前</legend>
+  <p class="text-ui-caption text-ui-text-muted">表示名は一覧や詳細で使われ、常に公開されます。</p>
+
+  <div class="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-end">
+    <%= ui_field(form, display_attribute, label: "現在の表示名") do |field| %><%= ui_input(form, display_attribute, described_by: field[:described_by]) %><% end %>
+    <label class="inline-flex min-h-11 items-center gap-2 text-sm text-ui-text-muted"><%= check_box_tag nil, nil, true, disabled: true, class: "size-5" %> 表示</label>
+    <label class="inline-flex min-h-11 items-center gap-2 text-sm text-ui-text-muted"><%= check_box_tag nil, nil, false, disabled: true, class: "size-5" %> 削除</label>
+  </div>
+
+  <div class="mt-4 space-y-4" data-controller="nested-form" data-action="input->nested-form#syncAliasOptions change->nested-form#syncAliasOptions">
+    <template data-nested-form-target="template">
+      <%= form.fields_for :aliases, alias_class.new, child_index: "NEW_RECORD" do |row| %><%= render "shared/ui/alias_row", form:, row: %><% end %>
+    </template>
+    <%= form.fields_for :aliases do |row| %><%= render "shared/ui/alias_row", form:, row: %><% end %>
+    <div data-nested-form-target="anchor"></div>
+    <%= ui_button("名前を足す", variant: :secondary, size: :small, data: { action: "nested-form#add" }) %>
+
+    <div class="pt-2">
+      <%= form.label :display_alias_key, "表示名", class: "mb-1 block text-sm font-bold text-ui-text" %>
+      <%= form.select :display_alias_key,
+            [ [ "#{form.object.public_send(display_attribute)}（現在の表示名）", "" ] ] + form.object.aliases.map { |item| [ item.name, item.selection_key.presence || item.id ] }, {},
+            class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text",
+            data: { nested_form_target: "aliasSelect", base_label: "#{form.object.public_send(display_attribute)}（現在の表示名）" } %>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/shared/ui/_alias_row.html.erb
+++ b/app/views/shared/ui/_alias_row.html.erb
@@ -1,0 +1,16 @@
+<fieldset class="grid gap-3 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid p-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]" data-nested-form-target="aliasRow">
+  <legend class="px-2 text-sm font-bold text-ui-text">別名 <%= row.index.to_i + 1 %></legend>
+  <% selection_key = row.object.selection_key.presence || row.object.id || row.index %>
+  <%= ui_field(row, :name, label: "名前") do |field| %>
+    <%= ui_input(row, :name, described_by: field[:described_by], data: { alias_name: true, selection_key: selection_key }) %>
+  <% end %>
+  <label class="inline-flex min-h-11 items-center gap-2 text-sm text-ui-text"><%= row.check_box :visible, data: { alias_visible: true }, class: "size-5 accent-ui-action" %> 表示</label>
+  <label class="inline-flex min-h-11 items-center gap-2 text-sm text-ui-text"><%= row.check_box :_destroy, data: { alias_destroy: true }, class: "size-5 accent-ui-danger" %> 削除</label>
+  <%= row.hidden_field :id if row.object.persisted? %>
+  <%= row.hidden_field :selection_key, value: selection_key %>
+  <% if row.object.respond_to?(:context) %>
+    <div class="sm:col-start-1">
+      <%= ui_field(row, :context, label: "使用場所") do |field| %><%= ui_input(row, :context, described_by: field[:described_by]) %><% end %>
+    </div>
+  <% end %>
+</fieldset>

--- a/app/views/shared/ui/_person_card.html.erb
+++ b/app/views/shared/ui/_person_card.html.erb
@@ -1,0 +1,34 @@
+<%= render "shared/ui/card", variant: :interactive do %>
+  <article class="flex h-full flex-col p-4">
+    <%= link_to person_path(person), class: "flex min-h-11 items-center gap-3 no-underline" do %>
+      <span class="size-14 shrink-0 overflow-hidden rounded-full border border-ui-outline bg-ui-field-solid">
+        <% if person.icon.attached? %><%= image_tag person.icon.variant(:thumb), alt: "", class: "size-full object-cover" %><% end %>
+      </span>
+      <span class="min-w-0">
+        <span class="block font-display text-lg font-bold text-ui-text"><%= person.display_name %></span>
+        <% if person.visible_aliases.any? %><span class="mt-1 block text-ui-caption text-ui-text-muted"><%= person.visible_aliases.map(&:name).join("、") %></span><% end %>
+      </span>
+    <% end %>
+
+    <% if current_person.admin? %>
+      <dl class="mt-4 grid grid-cols-[4rem_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-ui-outline pt-4 text-ui-caption">
+        <dt class="text-ui-text-muted">権限</dt><dd><%= person_role_labels(person).join("、") %></dd>
+        <dt class="text-ui-text-muted"><%= Group.model_name.human %></dt><dd><%= person.groups.map(&:name).join("、").presence || "なし" %></dd>
+        <dt class="text-ui-text-muted"><%= User.model_name.human %></dt><dd class="break-words"><%= person.users.map { |user| "#{user.provider_name}: #{user.email.presence || user.name.presence || '不明'}" }.join("、").presence || "未紐づけ" %></dd>
+      </dl>
+    <% end %>
+
+    <% if policy(person).update? || policy(person).offer_destroy? %>
+      <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-ui-outline pt-4">
+        <% if policy(person).update? %><%= ui_button_link("編集", href: edit_person_path(person), variant: :secondary, size: :small) %><% end %>
+        <% if policy(person).destroy? %>
+          <%= form_with url: person_path(person), method: :delete, data: { turbo_confirm: "#{person.display_name} を削除しますか" } do %>
+            <%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{person.display_name} を削除" }) %>
+          <% end %>
+        <% elsif policy(person).offer_destroy? %>
+          <%= ui_button("削除", variant: :secondary, size: :small, disabled: true, aria: { label: "自分自身は削除できません" }) %>
+        <% end %>
+      </div>
+    <% end %>
+  </article>
+<% end %>

--- a/app/views/shared/ui/_self_demotion_warning.html.erb
+++ b/app/views/shared/ui/_self_demotion_warning.html.erb
@@ -1,0 +1,7 @@
+<div class="rounded-ui-control border border-ui-error bg-ui-field-solid p-4 text-sm text-ui-error" role="alert" tabindex="-1" autofocus>
+  <h2 class="font-bold"><%= t("people.self_demotion.title") %></h2>
+  <ul class="mt-2 list-disc space-y-1 pl-5">
+    <% roles.each do |role| %><li><%= t("people.self_demotion.consequences.#{role}") %></li><% end %>
+  </ul>
+  <p class="mt-2"><%= t("people.self_demotion.recovery") %></p>
+</div>

--- a/spec/requests/accessibility_spec.rb
+++ b/spec/requests/accessibility_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "Accessibility" do
   end
 
   it "keeps not-yet-migrated content on the legacy surface" do
-    get new_registration_path
+    sign_in_as create(:person)
+    get play_sessions_path
 
     expect(Capybara.string(response.body)).to have_css(
       'main[data-ui-theme="legacy"].bg-paper.text-ink'

--- a/spec/requests/manage/player_role_spec.rb
+++ b/spec/requests/manage/player_role_spec.rb
@@ -29,20 +29,22 @@ RSpec.describe "The player role on the manage screen" do
     expect(person.reload.roles).to eq([ "gm" ])
   end
 
-  # フォームにも「プレイヤー」の文字があるため、一覧行の書式ごと確かめる。
   it "lists プレイヤー as a role for everyone on the member index" do
     person
 
     get people_path
 
-    expect(response.body).to include("権限: プレイヤー")
+    card = Capybara.string(response.body).find("article", text: person.display_name)
+    expect(card).to have_css("dt", text: "権限")
+    expect(card).to have_css("dd", text: "プレイヤー", exact_text: true)
   end
 
   it "lists the stored roles after プレイヤー" do
-    create(:person, display_name: "GM の人", roles: %w[gm])
+    gm = create(:person, display_name: "GM の人", roles: %w[gm])
 
     get people_path
 
-    expect(response.body).to include("権限: プレイヤー、GM")
+    card = Capybara.string(response.body).find("article", text: gm.display_name)
+    expect(card).to have_css("dd", text: "プレイヤー、GM", exact_text: true)
   end
 end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -199,6 +199,9 @@ RSpec.describe "People" do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(person.reload.icon).not_to be_attached
+      document = Capybara.string(response.body)
+      expect(document).to have_css('input[name="person[icon]"][aria-invalid="true"][aria-describedby="person_icon_error"]')
+      expect(document).to have_css("#person_icon_error.text-ui-error")
 
       get people_path
       expect(response).to have_http_status(:ok)

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registrations" do
     expect(discord_form).to include('data-turbo="false"')
     expect(discord_form).to include("Discord でログイン")
 
-    buttons = Capybara.string(response.body).find("div.flex.justify-center.gap-3")
+    buttons = Capybara.string(response.body).find("div.grid.gap-3")
     expect(buttons).to have_button("Google でログイン")
     expect(buttons).to have_button("Discord でログイン")
   end

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Legacy content contrast" do
   it "keeps every not-yet-migrated screen accessible on its legacy surface" do
     skip "Chrome is required for axe checks" unless ENV["CHROME_BINARY"].present?
 
-    visit new_registration_path
-    expect(page).to have_css('main[data-ui-theme="legacy"].bg-paper.text-ink')
-    expect(page).to be_axe_clean
-
     admin = create(:person, roles: %w[admin gm])
     current_user = create(:user, person: admin)
     person = create(:person)
@@ -28,7 +24,6 @@ RSpec.describe "Legacy content contrast" do
     legacy_paths = [
       scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),
       play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
-      people_path, person_path(person), new_person_path, edit_person_path(person),
       authors_path, author_path(author), new_author_path, edit_author_path(author),
       game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),
       manage_groups_path, manage_group_path(group), edit_manage_group_path(group),

--- a/spec/system/people_responsive_spec.rb
+++ b/spec/system/people_responsive_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Responsive people and registration screens" do
+  it "keeps registration and every person screen accessible at supported widths" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      visit new_registration_path
+      expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+      expect(page).to be_axe_clean
+    end
+
+    admin = create(:person, roles: %w[admin gm], display_name: "管理者の長い表示名")
+    person = create(:person, display_name: "長い表示名でもカードからはみ出さないメンバー")
+    person.person_aliases.create!(name: "公開する別名", context: "長い名前のコミュニティ", visible: true)
+    create(:group, name: "長い名前の所属グループ")
+    user = create(:user, person: admin)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      [ people_path, person_path(person), new_person_path, edit_person_path(person) ].each do |path|
+        visit path
+        expect(page).to have_css('main[data-ui-theme="dark"]')
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+        expect(page).to be_axe_clean
+      end
+      save_screenshot("people-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## Summary

- migrate person list, detail, create, and edit screens to Obsidian Glass
- add reusable person card, alias fields, alias row, and self-demotion warning components
- migrate registration guidance and provider actions to the dark interface
- move these screens from the legacy contrast audit to full axe coverage

## Verification

- `bin/rspec`: 665 examples, 0 failures
- `prek run --all-files`: passed
- Chromium and axe system spec: passed at 320px, 768px, and 1280px
- visually checked the person edit screen at 320px, 768px, and 1280px
