### PR TITLE
Redesign the scenario detail page

### DIFF
--- a/app/views/scenarios/_favorite_button.html.erb
+++ b/app/views/scenarios/_favorite_button.html.erb
@@ -1,11 +1,13 @@
 <span id="favorite_<%= scenario.id %>">
   <% if policy(scenario).favourite? %>
     <% if current_person.favourite?(scenario) %>
-      <%= button_to "お気に入りを外す", scenario_favorite_path(scenario), method: :delete,
-            class: "cursor-pointer border border-seal px-3 py-1.5 text-xs text-seal" %>
+      <%= form_with url: scenario_favorite_path(scenario), method: :delete do %>
+        <%= ui_button("お気に入りを外す", variant: :secondary, size: :small, type: "submit") %>
+      <% end %>
     <% else %>
-      <%= button_to "お気に入りに入れる", scenario_favorite_path(scenario),
-            class: "cursor-pointer border border-rule px-3 py-1.5 text-xs text-muted hover:border-seal hover:text-seal" %>
+      <%= form_with url: scenario_favorite_path(scenario) do %>
+        <%= ui_button("お気に入りに入れる", variant: :secondary, size: :small, type: "submit") %>
+      <% end %>
     <% end %>
   <% end %>
 </span>

--- a/app/views/scenarios/_gm_supplementary_info.html.erb
+++ b/app/views/scenarios/_gm_supplementary_info.html.erb
@@ -1,13 +1,12 @@
 <% if policy(scenario).show_gm_supplementary_info? %>
-  <section class="mt-10">
-    <h2 class="font-display text-xl"><%= scenario.game_master_label %>からの補足情報</h2>
-    <dl class="mt-3 grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
-      <dt class="text-muted">参加可能キャラの制限</dt>
-      <dd><%= auto_link_urls(scenario.character_restriction.presence || "制限なし") %></dd>
-      <dt class="text-muted">キャラシ提出期限</dt>
-      <dd><%= character_sheet_deadline_label(scenario) %></dd>
-      <dt class="text-muted">キャラシ提出期限の補足</dt>
-      <dd><%= auto_link_urls(scenario.character_sheet_deadline_note.presence || "補足なし") %></dd>
-    </dl>
+  <section class="mt-10 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+    <h2 class="font-display text-xl font-bold"><%= scenario.game_master_label %>からの補足情報</h2>
+    <div class="mt-4">
+      <%= render "shared/ui/definition_list", items: [
+        { term: "参加可能キャラの制限", description: auto_link_urls(scenario.character_restriction.presence || "制限なし") },
+        { term: "キャラシ提出期限", description: character_sheet_deadline_label(scenario) },
+        { term: "キャラシ提出期限の補足", description: auto_link_urls(scenario.character_sheet_deadline_note.presence || "補足なし") }
+      ] %>
+    </div>
   </section>
 <% end %>

--- a/app/views/scenarios/_play_session_history.html.erb
+++ b/app/views/scenarios/_play_session_history.html.erb
@@ -2,13 +2,13 @@
 <% sessions = policy_scope(PlaySession).where(scenario: scenario).includes(participations: :person).newest_first %>
 <% if sessions.any? %>
   <section class="mt-10">
-    <h2 class="font-display text-xl"><%= PlaySession.model_name.human %>履歴</h2>
-    <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
+    <h2 class="font-display text-xl font-bold"><%= PlaySession.model_name.human %>履歴</h2>
+    <ul class="mt-4 divide-y divide-ui-outline overflow-hidden rounded-ui-card border border-ui-outline bg-ui-surface-solid text-sm">
       <% sessions.each do |session| %>
         <li>
-          <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-3 no-underline text-ink hover:bg-paper" do %>
-            <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）</span>
-            <span class="ml-auto text-xs text-muted">
+          <%= link_to play_session_path(session), class: "flex min-h-11 flex-wrap items-baseline gap-x-4 gap-y-1 p-4 no-underline text-ui-text hover:bg-ui-subtle" do %>
+            <span class="text-ui-caption text-ui-text-muted"><%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）</span>
+            <span class="sm:ml-auto text-ui-caption text-ui-text-muted">
               <%= session.participations.map { |p| p.person.display_name }.join("、") %>
             </span>
           <% end %>

--- a/app/views/scenarios/_preparation_note.html.erb
+++ b/app/views/scenarios/_preparation_note.html.erb
@@ -1,19 +1,17 @@
 <% if scenario.preparation_note.present? %>
-  <section class="mt-10" id="preparation_note_<%= scenario.id %>">
-    <h2 class="font-display text-xl">プレーヤー向け事前情報</h2>
+  <section class="mt-10 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6" id="preparation_note_<%= scenario.id %>">
+    <h2 class="font-display text-xl font-bold">プレーヤー向け事前情報</h2>
 
     <% if policy(scenario).show_preparation_note? %>
       <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(scenario.preparation_note) %></p>
-      <%= button_to "プレーヤー向け事前情報を閉じる", scenario_spoiler_reveal_path(scenario), method: :delete,
-            class: "mt-3 cursor-pointer border border-rule px-4 py-3 text-sm text-muted" %>
+      <div class="mt-4"><%= form_with url: scenario_spoiler_reveal_path(scenario), method: :delete do %><%= ui_button("プレーヤー向け事前情報を閉じる", variant: :secondary, type: "submit") %><% end %></div>
     <% elsif policy(scenario).reveal_preparation_note? %>
-      <p class="mt-3 text-sm text-muted">
+      <p class="mt-3 text-sm text-ui-text-muted">
         本編のネタバレはありませんが、購入しないとわからない情報等を含みます。<%= scenario.game_master_label %>から許可があった場合のみ開いてください。
       </p>
-      <%= button_to "プレーヤー向け事前情報を見る", scenario_spoiler_reveal_path(scenario),
-            class: "mt-3 cursor-pointer redacted px-4 py-3 text-sm" %>
+      <div class="mt-4"><%= form_with url: scenario_spoiler_reveal_path(scenario) do %><%= ui_button("プレーヤー向け事前情報を見る", type: "submit") %><% end %></div>
     <% else %>
-      <p class="mt-3 redacted px-4 py-3 text-sm"><%= scenario.game_master_label %>が許可したログイン済<%= Person.model_name.human %>のみ表示可能です。</p>
+      <p class="mt-3 rounded-ui-control bg-ui-field-solid px-4 py-3 text-sm text-ui-text-muted"><%= scenario.game_master_label %>が許可したログイン済<%= Person.model_name.human %>のみ表示可能です。</p>
     <% end %>
   </section>
 <% end %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -1,124 +1,58 @@
 <% content_for :title, @scenario.title %>
-<% set_meta_tags description: scenario_description(@scenario),
-     og: { title: @scenario.title, description: scenario_description(@scenario), type: "article" } %>
+<% content_for :ui_theme, "dark" %>
+<% set_meta_tags description: scenario_description(@scenario), og: { title: @scenario.title, description: scenario_description(@scenario), type: "article" } %>
 <% content_for :head, scenario_json_ld(@scenario) %>
 
 <article>
-  <nav class="text-xs text-muted">
-    <%= link_to "#{Scenario.model_name.human}一覧", root_path, class: "text-muted" %> ／ <%= @scenario.title %>
+  <nav class="text-ui-caption text-ui-text-muted" aria-label="パンくずリスト">
+    <%= link_to "#{Scenario.model_name.human}一覧", root_path, class: "text-ui-action" %>
+    <span aria-hidden="true">／</span> <span aria-current="page"><%= @scenario.title %></span>
   </nav>
-
-  <div class="mt-6 grid gap-8 sm:grid-cols-[16rem_1fr]">
-    <div class="aspect-3/4 overflow-hidden border border-rule bg-surface">
+  <div class="mt-6 grid gap-6 md:grid-cols-[minmax(13rem,18rem)_minmax(0,1fr)] md:gap-8">
+    <div class="mx-auto aspect-3/4 w-full max-w-72 overflow-hidden rounded-ui-card border border-ui-outline bg-ui-field-solid md:mx-0">
       <% if @scenario.jacket.attached? %>
-        <%= image_tag @scenario.jacket.variant(:cover), alt: "#{@scenario.title} のジャケット画像",
-              class: "h-full w-full object-contain" %>
+        <%= image_tag @scenario.jacket.variant(:cover), alt: "#{@scenario.title} のジャケット画像", class: "h-full w-full object-contain" %>
       <% elsif @scenario.booth_image.attached? %>
-        <%= image_tag @scenario.booth_image.variant(:cover), alt: "#{@scenario.title} のBOOTH商品画像",
-              class: "h-full w-full object-contain" %>
-      <% else %>
-        <span class="flex h-full items-center justify-center font-display text-sm text-muted">画像なし</span>
-      <% end %>
+        <%= image_tag @scenario.booth_image.variant(:cover), alt: "#{@scenario.title} のBOOTH商品画像", class: "h-full w-full object-contain" %>
+      <% else %><span class="flex h-full items-center justify-center text-sm text-ui-text-muted">画像なし</span><% end %>
     </div>
-
-    <div>
-      <h1 class="font-display text-3xl leading-tight tracking-wide"><%= @scenario.title %></h1>
-      <p class="mt-2 text-sm text-muted">
-        <%= @scenario.authors.map(&:name).join("、").presence || "#{Author.model_name.human}未設定" %>
-      </p>
-
-      <div class="mt-3 flex flex-wrap items-center gap-4">
+    <div class="min-w-0">
+      <h1 class="font-display text-3xl font-bold leading-tight tracking-wide"><%= @scenario.title %></h1>
+      <p class="mt-2 text-sm text-ui-text-muted"><%= @scenario.authors.map(&:name).join("、").presence || "#{Author.model_name.human}未設定" %></p>
+      <div class="mt-4 flex flex-wrap items-center gap-2">
         <%= render "scenarios/favorite_button", scenario: @scenario %>
-        <% if policy(@scenario).update? %>
-          <%= link_to "編集", edit_scenario_path(@scenario), class: "text-sm text-seal" %>
+        <% if policy(@scenario).update? %><%= ui_button_link("編集", href: edit_scenario_path(@scenario), variant: :secondary, size: :small) %><% end %>
+        <% if policy(@scenario).destroy? %>
+          <%= form_with url: scenario_path(@scenario), method: :delete, data: { turbo_confirm: "#{@scenario.title} を削除しますか" } do %>
+            <%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "この#{Scenario.model_name.human}を削除" }) %>
+          <% end %>
         <% end %>
-        <%= render "shared/delete_button", record: @scenario, path: scenario_path(@scenario),
-              label: "この#{Scenario.model_name.human}を削除",
-              confirm: "#{@scenario.title} を削除しますか", class_name: "text-sm text-seal" %>
       </div>
-
-      <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
-        <dt class="text-muted"><%= GameSystem.model_name.human %></dt>
-        <dd class="font-sans"><%= @scenario.game_systems.map(&:name).join("／").presence || "未設定" %></dd>
-        <dt class="text-muted"><%= @scenario.game_master_label %>経験</dt>
-        <dd class="font-sans"><%= @scenario.gm_experienced? ? "☑#{@scenario.game_master_label}経験あり" : "#{@scenario.game_master_label}経験なし" %></dd>
-        <dt class="text-muted">人数</dt>
-        <dd><%= player_count_label(@scenario) %></dd>
-        <dt class="text-muted">目安時間</dt>
-        <dd><%= duration_label(@scenario) %></dd>
-      </dl>
-      <p class="mt-3 text-xs text-muted">
-        この情報は<%= @scenario.game_master_label %>が独自判断で記載しており、<%= Scenario.model_name.human %>公式の案内と異なる場合があります
-      </p>
+      <div class="mt-6 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5">
+        <%= render "shared/ui/definition_list", items: [
+          { term: GameSystem.model_name.human, description: @scenario.game_systems.map(&:name).join("／").presence || "未設定" },
+          { term: "#{@scenario.game_master_label}経験", description: @scenario.gm_experienced? ? "☑#{@scenario.game_master_label}経験あり" : "#{@scenario.game_master_label}経験なし" },
+          { term: "人数", description: player_count_label(@scenario) }, { term: "目安時間", description: duration_label(@scenario) }
+        ] %>
+        <p class="mt-4 border-t border-ui-outline pt-4 text-ui-caption text-ui-text-muted">この情報は<%= @scenario.game_master_label %>が独自判断で記載しており、<%= Scenario.model_name.human %>公式の案内と異なる場合があります</p>
+      </div>
     </div>
   </div>
-
-  <% if @scenario.synopsis.present? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl">あらすじ</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.synopsis) %></p>
-    </section>
-  <% end %>
-
-  <% if @scenario.recommendation_note.present? && policy(@scenario).show_recommendation_note? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl"><%= @scenario.game_master_label %>からのオススメポイント</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.recommendation_note) %></p>
-    </section>
-  <% end %>
-
+  <% if @scenario.synopsis.present? %><section class="mt-10"><h2 class="font-display text-xl font-bold">あらすじ</h2><p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.synopsis) %></p></section><% end %>
+  <% if @scenario.recommendation_note.present? && policy(@scenario).show_recommendation_note? %><section class="mt-10"><h2 class="font-display text-xl font-bold"><%= @scenario.game_master_label %>からのオススメポイント</h2><p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@scenario.recommendation_note) %></p></section><% end %>
   <%= render "scenarios/gm_supplementary_info", scenario: @scenario %>
-
   <% if @scenario.purchase_links.any? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl">入手先</h2>
-      <ul class="mt-3 space-y-1 text-sm">
-        <% @scenario.purchase_links.each do |link| %>
-          <li>
-            <% if link.url.present? %>
-              <%= link_to link.label, link.url, target: "_blank", rel: "noopener nofollow", class: "text-seal" %>
-              <%= link_to link.url, link.url, target: "_blank", rel: "noopener nofollow",
-                    class: "font-mono text-xs text-muted" %>
-            <% else %>
-              <span><%= link.label %></span>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </section>
+    <section class="mt-10"><h2 class="font-display text-xl font-bold">入手先</h2><ul class="mt-4 grid gap-3 text-sm">
+      <% @scenario.purchase_links.each do |link| %><li class="rounded-ui-control border border-ui-outline bg-ui-surface-solid p-4"><% if link.url.present? %><div class="grid gap-1"><%= link_to link.label, link.url, target: "_blank", rel: "noopener nofollow", class: "font-bold text-ui-action" %><%= link_to link.url, link.url, target: "_blank", rel: "noopener nofollow", class: "text-ui-caption text-ui-text-muted" %></div><% else %><span><%= link.label %></span><% end %></li><% end %>
+    </ul></section>
   <% end %>
-
   <% if @scenario.stream_links.any? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl">おすすめの配信</h2>
-      <div class="mt-3" data-controller="video-disclosure"
-           data-action="turbo:before-cache@document->video-disclosure#reset">
-        <button type="button" aria-controls="scenario_<%= @scenario.id %>_streams" aria-expanded="false"
-                data-video-disclosure-target="openButton" data-action="video-disclosure#open"
-                class="border border-rule bg-surface px-4 py-2 text-sm text-seal">
-          おすすめ配信を開く
-        </button>
-        <div id="scenario_<%= @scenario.id %>_streams" hidden data-video-disclosure-target="content"
-             class="border border-rule bg-surface p-4">
-          <ul class="space-y-1 text-sm">
-            <% @scenario.stream_links.each do |link| %>
-              <li class="space-y-2">
-                <%= render "shared/video_link", title: link.label.presence || link.url, url: link.url,
-                      link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %>
-              </li>
-            <% end %>
-          </ul>
-          <div class="mt-4 border-t border-rule pt-3 text-right">
-            <button type="button" data-video-disclosure-target="closeButton" data-action="video-disclosure#close"
-                    class="border border-rule bg-paper px-4 py-2 text-sm text-seal">
-              おすすめ配信を閉じる
-            </button>
-          </div>
-        </div>
-      </div>
-    </section>
+    <section class="mt-10"><h2 class="font-display text-xl font-bold">おすすめの配信</h2><div class="mt-4">
+      <%= render "shared/ui/disclosure", open_label: "おすすめ配信を開く", close_label: "おすすめ配信を閉じる", content_id: "scenario_#{@scenario.id}_streams" do %>
+        <ul class="grid gap-4"><% @scenario.stream_links.each do |link| %><li><%= render "shared/ui/video_link", title: link.label.presence || link.url, url: link.url, link_text: link.label.presence || link.url, rel: "noopener nofollow", show_url: true %></li><% end %></ul>
+      <% end %>
+    </div></section>
   <% end %>
-
   <%= render "scenarios/play_session_history", scenario: @scenario %>
   <%= render "scenarios/preparation_note", scenario: @scenario %>
 </article>

--- a/app/views/shared/ui/_definition_list.html.erb
+++ b/app/views/shared/ui/_definition_list.html.erb
@@ -1,0 +1,6 @@
+<dl class="grid grid-cols-[minmax(7rem,auto)_minmax(0,1fr)] gap-x-4 gap-y-3 text-sm">
+  <% items.each do |item| %>
+    <dt class="font-bold text-ui-text-muted"><%= item.fetch(:term) %></dt>
+    <dd class="min-w-0 text-ui-text"><%= item.fetch(:description) %></dd>
+  <% end %>
+</dl>

--- a/app/views/shared/ui/_disclosure.html.erb
+++ b/app/views/shared/ui/_disclosure.html.erb
@@ -1,0 +1,13 @@
+<div data-controller="video-disclosure" data-action="turbo:before-cache@document->video-disclosure#reset">
+  <%= ui_button(open_label, variant: :secondary, data: {
+    video_disclosure_target: "openButton", action: "video-disclosure#open"
+  }, aria: { controls: content_id, expanded: false }) %>
+  <div id="<%= content_id %>" hidden data-video-disclosure-target="content"
+       class="mt-3 rounded-ui-control border border-ui-outline bg-ui-surface-solid p-4 sm:p-5">
+    <%= yield %>
+    <div class="mt-5 border-t border-ui-outline pt-4">
+      <%= ui_button(close_label, variant: :secondary, size: :small,
+        data: { video_disclosure_target: "closeButton", action: "video-disclosure#close" }) %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/ui/_video_link.html.erb
+++ b/app/views/shared/ui/_video_link.html.erb
@@ -1,0 +1,14 @@
+<% if (embed_url = youtube_embed_url(url)) %>
+  <div class="aspect-video overflow-hidden rounded-ui-control bg-black">
+    <%= tag.iframe title:, src: embed_url, class: "h-full w-full", loading: "lazy",
+          allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+          allowfullscreen: true %>
+  </div>
+<% else %>
+  <div class="grid gap-1">
+    <%= link_to link_text, url, target: "_blank", rel:, class: "font-bold text-ui-action" %>
+    <% if show_url %>
+      <%= link_to url, url, target: "_blank", rel:, class: "text-ui-caption text-ui-text-muted" %>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Scenarios" do
       expect(page).to have_css(hidden_embed, visible: :all)
       expect(page).to have_button("おすすめ配信を開く")
       expect(page).to have_button("おすすめ配信を閉じる", visible: :all)
-      expect(page).to have_css('[data-video-disclosure-target="content"].bg-surface', visible: :all)
+      expect(page).to have_css('[data-video-disclosure-target="content"].bg-ui-surface-solid', visible: :all)
       expect(page).to have_css('[data-controller="video-disclosure"]' \
         '[data-action*="turbo:before-cache@document->video-disclosure#reset"]')
       expect(page).to have_css('[data-video-disclosure-target="closeButton"]', visible: :all)

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Browsing scenarios" do
-  it "goes from the list to a detail page without signing in" do
-    create(
+  it "keeps the scenario detail accessible at supported viewport widths" do
+    scenario = create(
       :scenario,
       title: "カタシロ",
       synopsis: "はじめてのソロシナリオに最適。",
@@ -11,12 +11,16 @@ RSpec.describe "Browsing scenarios" do
       player_count_max: 1,
       duration_min_hours: 2,
       recommendation: 5,
+      recommendation_note: "GMからのおすすめ情報",
+      character_restriction: "新規キャラクターのみ",
       game_systems: [ create(:game_system, name: "CoC 7版") ],
       authors: [ create(:author, name: "ディズム") ]
     )
 
+    scenario.purchase_links.create!(label: "BOOTH", url: "https://example.com/booth")
+    scenario.stream_links.create!(label: "長い名前のおすすめ配信", url: "https://example.com/stream")
+
     visit root_path
-    expect(page).to be_axe_clean if ENV["CHROME_BINARY"].present?
     expect(page).to have_content("シナリオ一覧")
     expect(page).to have_no_content("★")
 
@@ -26,5 +30,42 @@ RSpec.describe "Browsing scenarios" do
     expect(page).to have_content("CoC 7版")
     expect(page).to have_content("2時間")
     expect(page).to have_no_content("ネタバレを含む準備情報")
+
+    if ENV["CHROME_BINARY"].present?
+      [ 320, 768, 1280 ].each do |width|
+        page.current_window.resize_to(width, 900)
+        visit scenario_path(scenario)
+        expect(page).to have_css('main[data-ui-theme="dark"]')
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+        expect(page).to be_axe_clean
+        if width == 320
+          disclosure = find_button("おすすめ配信を開く")
+          expect(disclosure.rect.width).to be >= 44
+          expect(disclosure.rect.height).to be >= 44
+          disclosure.click
+          expect(page).to have_link("長い名前のおすすめ配信", visible: :visible)
+          expect(page).to be_axe_clean
+        end
+        save_screenshot("scenario-detail-#{width}.png") if ENV["VISUAL_REVIEW"]
+      end
+
+      member = create(:person)
+      user = create(:user, person: member)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+        provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+      )
+      visit root_path
+      click_button "Googleでログイン"
+      page.current_window.resize_to(320, 900)
+      visit scenario_path(scenario)
+      expect(page).to have_content("GMからのおすすめ情報")
+      expect(page).to have_content("新規キャラクターのみ")
+      expect(page).to have_button("プレーヤー向け事前情報を見る")
+      expect(page).to be_axe_clean
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
   end
 end

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Legacy content contrast" do
     click_button "Googleでログイン"
 
     legacy_paths = [
-      scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),
+      new_scenario_path, edit_scenario_path(scenario),
       play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
       people_path, person_path(person), new_person_path, edit_person_path(person),
       authors_path, author_path(author), new_author_path, edit_author_path(author),


### PR DESCRIPTION
## What

Migrate the scenario detail page to Obsidian Glass and add definition list, disclosure, and video link UI partials.

## Why

Complete task 4 of the UI redesign plan while preserving authorization and spoiler behavior.

## Verification

- [x] `bin/rspec` (664 examples, 0 failures)
- [x] `prek run --all-files`
- [x] Full axe and horizontal overflow checks at 320px, 768px, and 1280px
- [x] Signed-in restricted content and 320px disclosure interaction

## Related

[ADR-0002](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/adr/0002-user-interface-design.md) / [UI redesign task 4](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/plans/2026-08-22-ui-redesign.md)