### PR TITLE
Redesign user and site setting screens

### DIFF
--- a/app/views/manage/site_settings/edit.html.erb
+++ b/app/views/manage/site_settings/edit.html.erb
@@ -1,21 +1,13 @@
 <% content_for :title, SiteSetting.model_name.human %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-2xl"><%= SiteSetting.model_name.human %></h1>
-
-<%= form_with model: @site_setting, url: manage_site_setting_path, method: :patch, class: "mt-6 space-y-6" do |form| %>
-  <%= accessible_error_summary(@site_setting) %>
-
-  <div>
-    <%= form.label :google_analytics_measurement_id, "Google Analytics 測定 ID", class: "block text-sm font-bold" %>
-    <%= form.text_field :google_analytics_measurement_id,
-          placeholder: "G-XXXXXXXXXX",
-          autocomplete: "off",
-          class: "mt-2 w-full max-w-md border border-rule bg-paper px-3 py-2" %>
-    <p class="mt-2 text-sm text-muted">未入力にすると Google Analytics を無効にします。</p>
-  </div>
-
-  <div class="flex gap-4">
-    <%= form.submit "更新", class: "cursor-pointer border border-ink bg-ink px-4 py-2 text-paper" %>
-    <%= link_to "詳細に戻る", manage_site_setting_path, class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: SiteSetting.model_name.human %>
+  <%= form_with model: @site_setting, url: manage_site_setting_path, method: :patch, class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@site_setting) %>
+    <div class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+      <%= ui_field(form, :google_analytics_measurement_id, label: "Google Analytics 測定 ID", description: "未入力にすると Google Analytics を無効にします。") do |field| %><%= ui_input(form, :google_analytics_measurement_id, described_by: field[:described_by], placeholder: "G-XXXXXXXXXX", autocomplete: "off") %><% end %>
+    </div>
+    <div class="flex flex-wrap gap-3"><%= ui_button("更新", type: "submit") %><%= ui_button_link("詳細に戻る", href: manage_site_setting_path, variant: :secondary) %></div>
+  <% end %>
+</div>

--- a/app/views/manage/site_settings/show.html.erb
+++ b/app/views/manage/site_settings/show.html.erb
@@ -1,13 +1,7 @@
 <% content_for :title, SiteSetting.model_name.human %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <div class="flex flex-wrap items-baseline justify-between gap-4">
-    <h1 class="font-display text-2xl"><%= SiteSetting.model_name.human %></h1>
-    <%= link_to "編集", edit_manage_site_setting_path, class: "text-sm text-seal" %>
-  </div>
-
-  <dl class="mt-6 grid grid-cols-[12rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 text-sm">
-    <dt class="text-muted">Google Analytics 測定 ID</dt>
-    <dd><%= @site_setting.google_analytics_measurement_id.presence || "無効" %></dd>
-  </dl>
+<article class="space-y-6">
+  <div class="flex flex-wrap items-end justify-between gap-4"><%= render "shared/ui/page_header", title: SiteSetting.model_name.human %><%= ui_button_link("編集", href: edit_manage_site_setting_path, variant: :secondary) %></div>
+  <dl class="grid gap-x-5 gap-y-3 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 text-sm sm:grid-cols-[14rem_minmax(0,1fr)]"><dt class="text-ui-text-muted">Google Analytics 測定 ID</dt><dd class="break-all font-mono"><%= @site_setting.google_analytics_measurement_id.presence || "無効" %></dd></dl>
 </article>

--- a/app/views/manage/users/edit.html.erb
+++ b/app/views/manage/users/edit.html.erb
@@ -1,24 +1,15 @@
 <% content_for :title, "#{@user.provider_name} #{User.model_name.human}の編集" %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-2xl"><%= @user.provider_name %> <%= User.model_name.human %>の編集</h1>
-<p class="mt-2 font-mono text-xs"><%= @user.email.presence || "メールアドレス不明" %></p>
-
-<%= form_with model: [ :manage, @user ], class: "mt-6 space-y-4 border border-rule bg-surface p-5" do |form| %>
-  <%= accessible_error_summary(@user) %>
-  <% if @lost_roles.present? %>
-    <%= render "shared/self_demotion_warning", roles: @lost_roles %>
-    <%= hidden_field_tag :confirm_self_demotion, @lost_roles.join(",") %>
+<div class="space-y-6">
+  <div><%= render "shared/ui/page_header", title: "#{@user.provider_name} #{User.model_name.human}の編集" %><p class="mt-2 break-all font-mono text-sm text-ui-text-muted"><%= @user.email.presence || "メールアドレス不明" %></p></div>
+  <%= form_with model: [ :manage, @user ], class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@user) %>
+    <% if @lost_roles.present? %><%= render "shared/ui/self_demotion_warning", roles: @lost_roles %><%= hidden_field_tag :confirm_self_demotion, @lost_roles.join(",") %><% end %>
+    <div class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
+      <%= form.label :person_id, "紐づけ先", class: "mb-1 block text-sm font-bold" %>
+      <%= form.collection_select :person_id, Person.order(:display_name), :id, :display_name, { include_blank: "未紐づけ" }, class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text" %>
+    </div>
+    <div class="flex flex-wrap gap-3"><%= ui_button(@lost_roles.present? ? t("people.self_demotion.continue") : "更新", type: "submit") %><%= ui_button_link("詳細に戻る", href: manage_user_path(@user), variant: :secondary) %></div>
   <% end %>
-
-  <div>
-    <%= form.label :person_id, "紐づけ先", class: "block text-xs text-muted" %>
-    <%= form.collection_select :person_id, Person.order(:display_name), :id, :display_name,
-          { include_blank: "未紐づけ" }, class: "mt-1 border border-rule bg-paper px-3 py-2 text-sm" %>
-  </div>
-
-  <div class="flex gap-4">
-    <%= form.submit @lost_roles.present? ? t("people.self_demotion.continue") : "更新",
-          class: "bg-ink px-5 py-2 text-sm text-paper" %>
-    <%= link_to "詳細に戻る", manage_user_path(@user), class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/manage/users/index.html.erb
+++ b/app/views/manage/users/index.html.erb
@@ -1,28 +1,30 @@
 <% content_for :title, "#{User.model_name.human}の紐づけ" %>
-<h1 class="font-display text-2xl"><%= User.model_name.human %>の紐づけ</h1>
-<p class="mt-2 text-sm text-muted">紐づくまで、その<%= User.model_name.human %>は公開エリアしか見られません。</p>
+<% content_for :ui_theme, "dark" %>
 
-<ul class="mt-6 divide-y divide-rule border border-rule bg-surface text-sm">
-  <% @users.each do |user| %>
-    <li class="flex flex-wrap items-center justify-between gap-3 p-3">
-      <div>
-        <p class="text-xs font-bold"><%= user.provider_name %></p>
-        <p class="font-mono text-xs"><%= user.email.presence || "メールアドレス不明" %></p>
-        <% if user.name.present? %><p class="text-xs text-muted"><%= user.name %></p><% end %>
-        <p class="text-xs text-muted">初回ログイン <%= l user.created_at, format: :short %></p>
-      </div>
-      <span class="flex shrink-0 gap-1 text-xs">
-        <%= link_to "詳細", manage_user_path(user), class: "inline-flex min-h-6 items-center px-1 text-seal" %>
-        <%= link_to "編集", edit_manage_user_path(user), class: "inline-flex min-h-6 items-center px-1 text-seal" %>
-        <%= render "shared/delete_button", record: user, path: manage_user_path(user), label: "削除",
-              aria_label: "#{user.email.presence || user.provider_name} を削除",
-              confirm: "#{user.email.presence || user.provider_name} を削除しますか",
-              disabled_aria_label: "ログイン中の#{User.model_name.human}は削除できません" %>
-      </span>
-    </li>
+<div class="space-y-6">
+  <div><%= render "shared/ui/page_header", title: "#{User.model_name.human}の紐づけ" %><p class="mt-2 text-sm text-ui-text-muted">紐づくまで、その<%= User.model_name.human %>は公開エリアしか見られません。</p></div>
+  <% if @users.any? %>
+    <ul class="grid gap-4 sm:grid-cols-2">
+      <% @users.each do |user| %>
+        <li><%= render "shared/ui/card" do %>
+          <article class="flex h-full flex-col p-4 sm:p-5">
+            <div class="min-w-0 space-y-1">
+              <p class="text-ui-caption font-bold text-ui-text-muted"><%= user.provider_name %></p>
+              <p class="break-all font-mono text-sm"><%= user.email.presence || "メールアドレス不明" %></p>
+              <% if user.name.present? %><p class="text-ui-caption text-ui-text-muted"><%= user.name %></p><% end %>
+              <p class="text-ui-caption text-ui-text-muted">初回ログイン <%= l user.created_at, format: :short %></p>
+            </div>
+            <div class="mt-auto flex flex-wrap gap-2 border-t border-ui-outline pt-4">
+              <%= ui_button_link("詳細", href: manage_user_path(user), variant: :secondary, size: :small) %>
+              <%= ui_button_link("編集", href: edit_manage_user_path(user), variant: :secondary, size: :small) %>
+              <% if policy(user).destroy? %><%= form_with url: manage_user_path(user), method: :delete, data: { turbo_confirm: "#{user.email.presence || user.provider_name} を削除しますか" } do %><%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{user.email.presence || user.provider_name} を削除" }) %><% end %>
+              <% elsif policy(user).offer_destroy? %><%= ui_button("削除", variant: :secondary, size: :small, disabled: true, aria: { label: "ログイン中の#{User.model_name.human}は削除できません" }) %><% end %>
+            </div>
+          </article>
+        <% end %></li>
+      <% end %>
+    </ul>
+  <% else %>
+    <%= render "shared/ui/empty_state", title: "まだ誰もログインしていません。" %>
   <% end %>
-</ul>
-
-<% if @users.empty? %>
-  <p class="mt-6 border border-rule bg-surface p-6 text-center text-sm text-muted">まだ誰もログインしていません。</p>
-<% end %>
+</div>

--- a/app/views/manage/users/show.html.erb
+++ b/app/views/manage/users/show.html.erb
@@ -1,34 +1,18 @@
 <% content_for :title, @user.email.presence || "#{@user.provider_name} #{User.model_name.human}" %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <div class="flex flex-wrap items-baseline justify-between gap-4">
-    <h1 class="font-display text-2xl"><%= @user.email.presence || "メールアドレス不明" %></h1>
-    <div class="flex flex-wrap items-baseline gap-4">
-      <%= link_to "編集", edit_manage_user_path(@user), class: "text-sm text-seal" %>
-      <%= render "shared/delete_button", record: @user, path: manage_user_path(@user),
-            label: "この#{User.model_name.human}を削除",
-            confirm: "#{@user.email.presence || @user.provider_name} を削除しますか",
-            disabled_label: "ログイン中の#{User.model_name.human}は削除できません",
-            class_name: "text-sm text-seal", disabled_class_name: "text-sm text-muted cursor-not-allowed" %>
-    </div>
+<article class="space-y-6">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <div class="min-w-0 break-all"><%= render "shared/ui/page_header", title: (@user.email.presence || "メールアドレス不明") %></div>
+    <div class="flex flex-wrap gap-2"><%= ui_button_link("編集", href: edit_manage_user_path(@user), variant: :secondary, size: :small) %>
+      <% if policy(@user).destroy? %><%= form_with url: manage_user_path(@user), method: :delete, data: { turbo_confirm: "#{@user.email.presence || @user.provider_name} を削除しますか" } do %><%= ui_button("この#{User.model_name.human}を削除", variant: :danger, size: :small, type: "submit") %><% end %>
+      <% elsif policy(@user).offer_destroy? %><%= ui_button("ログイン中の#{User.model_name.human}は削除できません", variant: :secondary, size: :small, disabled: true) %><% end %></div>
   </div>
-
-  <dl class="mt-6 grid grid-cols-[7rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 text-sm">
-    <dt class="text-muted">ログイン方法</dt>
-    <dd><%= @user.provider_name %></dd>
-    <dt class="text-muted">表示名</dt>
-    <dd><%= @user.name.presence || "不明" %></dd>
-    <dt class="text-muted">初回ログイン</dt>
-    <dd><%= l @user.created_at, format: :short %></dd>
-    <dt class="text-muted">紐づけ先</dt>
-    <dd>
-      <% if @user.person %>
-        <%= link_to @user.person.display_name, person_path(@user.person), class: "text-seal" %>
-      <% else %>
-        未紐づけ
-      <% end %>
-    </dd>
+  <dl class="grid gap-x-5 gap-y-3 rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 text-sm sm:grid-cols-[8rem_minmax(0,1fr)]">
+    <dt class="text-ui-text-muted">ログイン方法</dt><dd><%= @user.provider_name %></dd>
+    <dt class="text-ui-text-muted">表示名</dt><dd><%= @user.name.presence || "不明" %></dd>
+    <dt class="text-ui-text-muted">初回ログイン</dt><dd><%= l @user.created_at, format: :short %></dd>
+    <dt class="text-ui-text-muted">紐づけ先</dt><dd><% if @user.person %><%= link_to @user.person.display_name, person_path(@user.person), class: "text-ui-action" %><% else %>未紐づけ<% end %></dd>
   </dl>
-
-  <p class="mt-8"><%= link_to "一覧に戻る", manage_users_path, class: "text-sm text-muted" %></p>
+  <%= ui_button_link("一覧に戻る", href: manage_users_path, variant: :secondary) %>
 </article>

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe "Legacy content contrast" do
       play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
       authors_path, author_path(author), new_author_path, edit_author_path(author),
       game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),
-      manage_groups_path, manage_group_path(group), edit_manage_group_path(group),
-      manage_users_path, manage_user_path(user), edit_manage_user_path(user),
-      manage_site_setting_path, edit_manage_site_setting_path
+      manage_groups_path, manage_group_path(group), edit_manage_group_path(group)
     ]
 
     legacy_paths.each do |path|

--- a/spec/system/manage_users_settings_responsive_spec.rb
+++ b/spec/system/manage_users_settings_responsive_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Responsive user and site-setting screens" do
+  it "keeps every migrated management screen accessible at supported widths" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    admin = create(:person, roles: %w[admin], display_name: "管理者")
+    current_user = create(:user, person: admin)
+    user = create(:user, person: create(:person, display_name: "長い名前の紐づけ先メンバー"), email: "long-account-address@example.com")
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: current_user.google_uid, info: { email: current_user.email }
+    )
+    visit root_path
+    click_button "Googleでログイン"
+
+    paths = [ manage_users_path, manage_user_path(user), edit_manage_user_path(user), manage_site_setting_path, edit_manage_site_setting_path ]
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      paths.each do |path|
+        visit path
+        expect(page).to have_css('main[data-ui-theme="dark"]')
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+        expect(page).to be_axe_clean
+      end
+      save_screenshot("manage-users-settings-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## Summary

- migrate account list, detail, and edit screens to Obsidian Glass
- migrate site-setting detail and edit screens to shared dark UI primitives
- replace legacy delete and self-demotion call sites without changing the old shared partials
- move these screens from the legacy contrast audit to full axe coverage

## Dependency

Stacked on #122 because the account edit screen consumes its new self-demotion warning component. Retarget this PR to `main` after #122 merges.

## Verification

- `bin/rspec`: 666 examples, 0 failures
- `prek run --all-files`: passed
- Chromium and axe system spec: passed at 320px, 768px, and 1280px
- verified long account addresses do not cause horizontal overflow
