### PR TITLE
Redesign scenario forms

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -14,8 +14,11 @@ module UiHelper
     password: :password_field,
     search: :search_field,
     telephone: :telephone_field,
-    url: :url_field
+    url: :url_field,
+    number: :number_field
   }.freeze
+
+  CONTROL_CLASSES = "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text placeholder:text-ui-text-muted focus:border-ui-focus focus:outline-none focus:ring-2 focus:ring-ui-focus/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-ui-error aria-invalid:ring-1 aria-invalid:ring-ui-error".freeze
 
   def ui_button(label, variant: :primary, size: :medium, type: "button", disabled: false, id: nil, data: {}, aria: {})
     render "shared/ui/button",
@@ -63,7 +66,7 @@ module UiHelper
   end
 
   def ui_input(form, attribute, type: :text, described_by: nil, disabled: false, required: false, id: nil,
-    placeholder: nil, autocomplete: nil, inputmode: nil, data: {}, aria: {})
+    placeholder: nil, autocomplete: nil, inputmode: nil, min: nil, max: nil, step: nil, data: {}, aria: {})
     error_id = form.field_id(attribute, :error) if form.object&.errors&.[](attribute)&.any?
     aria = aria.to_h.stringify_keys
     aria["describedby"] = [ aria["describedby"], described_by, error_id ].compact.flat_map { |ids| ids.to_s.split }.uniq.join(" ").presence
@@ -73,12 +76,15 @@ module UiHelper
       required:,
       data:,
       aria:,
-      class: "min-h-11 w-full rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text placeholder:text-ui-text-muted focus:border-ui-focus focus:outline-none focus:ring-2 focus:ring-ui-focus/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-ui-error aria-invalid:ring-1 aria-invalid:ring-ui-error"
+      class: CONTROL_CLASSES
     }
     input_options[:id] = id if id
     input_options[:placeholder] = placeholder if placeholder
     input_options[:autocomplete] = autocomplete if autocomplete
     input_options[:inputmode] = inputmode if inputmode
+    input_options[:min] = min if min
+    input_options[:max] = max if max
+    input_options[:step] = step if step
 
     render "shared/ui/input",
       form:,
@@ -86,4 +92,56 @@ module UiHelper
       input_method: INPUT_TYPES.fetch(type),
       input_options:
   end
+
+  def ui_textarea(form, attribute, described_by: nil, rows: 4, required: false, disabled: false, id: nil, data: {}, aria: {})
+    options = ui_control_options(form, attribute, described_by:, required:, disabled:, id:, data:, aria:)
+    render "shared/ui/textarea", form:, attribute:, rows:, input_options: options
+  end
+
+  def ui_select(form, attribute, choices, described_by: nil, include_blank: nil, required: false, disabled: false,
+    id: nil, data: {}, aria: {})
+    options = ui_control_options(form, attribute, described_by:, required:, disabled:, id:, data:, aria:)
+    render "shared/ui/select", form:, attribute:, choices:, select_options: { include_blank: }, input_options: options
+  end
+
+  def ui_checkbox(form, attribute, label:, checked_value: "1", unchecked_value: "0", disabled: false, id: nil,
+    data: {}, aria: {})
+    render "shared/ui/checkbox", form:, attribute:, label:, checked_value:, unchecked_value:, disabled:, id:, data:, aria:
+  end
+
+  def ui_collection_checkboxes(form, attribute, collection, value_method:, text_method:)
+    form.collection_check_boxes(attribute, collection, value_method, text_method) do |builder|
+      render "shared/ui/collection_checkbox", builder:
+    end
+  end
+
+  def ui_file_input(form, attribute, accept:, described_by: nil)
+    error_id = form.field_id(attribute, :error) if form.object&.errors&.[](attribute)&.any?
+    form.file_field attribute, accept:, data: { ui_error_id: error_id }.compact,
+      aria: { describedby: [ described_by, error_id ].compact.join(" ").presence },
+      class: "block min-h-11 w-full cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-field-solid text-sm text-ui-text file:mr-3 file:min-h-11 file:border-0 file:bg-ui-subtle file:px-3 file:py-2 file:font-bold file:text-ui-text hover:file:bg-ui-action hover:file:text-ui-on-action"
+  end
+
+  def ui_radio(name, value, label:, checked:, id:, required: false, disabled: false, data: {}, aria: {})
+    render "shared/ui/radio", name:, value:, label:, checked:, id:, required:, disabled:, data:, aria:
+  end
+
+  def ui_error_summary(record)
+    render "shared/ui/error_summary", record:
+  end
+
+  def ui_repeatable_fields(form, association:, legend:, hint:, row_partial:, new_record:, add_label: "行を足す")
+    render "shared/ui/repeatable_fields", form:, association:, legend:, hint:, row_partial:, new_record:, add_label:
+  end
+
+  private
+    def ui_control_options(form, attribute, described_by:, required:, disabled:, id:, data:, aria:)
+      error_id = form.field_id(attribute, :error) if form.object&.errors&.[](attribute)&.any?
+      aria = aria.to_h.stringify_keys
+      aria["describedby"] = [ aria["describedby"], described_by, error_id ].compact.flat_map { |ids| ids.to_s.split }.uniq.join(" ").presence
+      data = data.to_h.merge(ui_error_id: error_id).compact
+      options = { required:, disabled:, data:, aria:, class: CONTROL_CLASSES }
+      options[:id] = id if id
+      options
+    end
 end

--- a/app/views/manage/scenarios/_edit.html.erb
+++ b/app/views/manage/scenarios/_edit.html.erb
@@ -1,0 +1,14 @@
+<%= render "shared/ui/page_header", title: "#{scenario.title}の編集" %>
+<div class="mt-6 flex flex-wrap items-center gap-3">
+  <%= form_with url: refresh_booth_image_scenario_path(scenario), method: :post do %>
+    <%= ui_button "BOOTH画像を更新", variant: :secondary, type: "submit" %>
+  <% end %>
+  <% if scenario.booth_image.attached? %><%= render "shared/ui/badge", label: "取得済み" %><% end %>
+  <% if scenario.jacket.attached? %>
+    <%= form_with url: jacket_scenario_path(scenario), method: :delete,
+          data: { turbo_confirm: "ジャケット画像を削除しますか" } do %>
+      <%= ui_button "ジャケット画像を削除", variant: :danger, type: "submit" %>
+    <% end %>
+  <% end %>
+</div>
+<%= render "manage/scenarios/form", scenario: %>

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -1,133 +1,48 @@
-<%= form_with model: scenario, class: "mt-6 space-y-8" do |form| %>
-  <%= accessible_error_summary(scenario) %>
-
-  <fieldset class="border border-rule bg-surface p-5">
-    <legend class="px-2 font-display text-sm">基本</legend>
-
-    <div class="space-y-4">
-      <div>
-        <%= form.label :title, "#{Scenario.model_name.human}名", class: "block text-xs text-muted" %>
-        <%= form.text_field :title, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-
-      <div>
-        <%= form.label :game_system_ids, GameSystem.model_name.human, class: "block text-xs text-muted" %>
-        <%= form.collection_check_boxes :game_system_ids, GameSystem.all, :id, :name do |b| %>
-          <label class="mr-4 inline-flex items-center gap-1 text-sm">
-            <%= b.check_box %> <%= b.text %>
-          </label>
-        <% end %>
-      </div>
-
-      <div>
-        <%= form.label :author_ids, Author.model_name.human, class: "block text-xs text-muted" %>
-        <%= form.collection_check_boxes :author_ids, Author.all, :id, :name do |b| %>
-          <label class="mr-4 inline-flex items-center gap-1 text-sm">
-            <%= b.check_box %> <%= b.text %>
-          </label>
-        <% end %>
-      </div>
-
-      <div>
-        <%= form.label :jacket, "ジャケット画像", class: "block text-xs text-muted" %>
-        <%= form.file_field :jacket, accept: "image/png,image/jpeg,image/webp", class: "mt-1 text-sm" %>
-      </div>
+<%= form_with model: scenario, class: "mt-8 space-y-8" do |form| %>
+  <%= ui_error_summary(scenario) %>
+  <fieldset class="rounded-ui-surface border border-ui-outline bg-ui-surface-solid p-4 sm:p-6">
+    <legend class="px-2 font-display text-lg font-bold text-ui-text">基本</legend>
+    <div class="space-y-5">
+      <%= ui_field(form, :title, label: "#{Scenario.model_name.human}名", required: true) do |field| %><%= ui_input(form, :title, described_by: field[:described_by], required: true) %><% end %>
+      <fieldset><legend class="text-sm font-bold text-ui-text"><%= GameSystem.model_name.human %></legend><div class="mt-2 flex flex-wrap gap-2"><%= ui_collection_checkboxes(form, :game_system_ids, GameSystem.all, value_method: :id, text_method: :name) %></div></fieldset>
+      <fieldset><legend class="text-sm font-bold text-ui-text"><%= Author.model_name.human %></legend><div class="mt-2 flex flex-wrap gap-2"><%= ui_collection_checkboxes(form, :author_ids, Author.all, value_method: :id, text_method: :name) %></div></fieldset>
+      <%= ui_field(form, :jacket, label: "ジャケット画像") do |field| %><%= ui_file_input(form, :jacket, accept: "image/png,image/jpeg,image/webp", described_by: field[:described_by]) %><% end %>
     </div>
   </fieldset>
 
-  <fieldset class="border border-rule bg-surface p-5">
-    <legend class="px-2 font-display text-sm">遊ぶときの条件</legend>
-
-    <div class="grid gap-4 sm:grid-cols-2">
-      <div>
-        <%= form.label :player_count_min, "PL人数（最小・必須）", class: "block text-xs text-muted" %>
-        <%= form.number_field :player_count_min, min: 1, required: true,
-              class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :player_count_max, "PL人数（最大）", class: "block text-xs text-muted" %>
-        <p class="text-xs text-muted">人数が固定なら最小と同じ値を入れる。上限が無ければ空欄。</p>
-        <%= form.number_field :player_count_max, min: 1, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :duration_min_hours, "目安時間（時間・最小）", class: "block text-xs text-muted" %>
-        <%= form.number_field :duration_min_hours, step: 0.5, min: 0.5,
-              class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :duration_max_hours, "目安時間（時間・最大）", class: "block text-xs text-muted" %>
-        <%= form.number_field :duration_max_hours, step: 0.5, min: 0.5,
-              class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :character_restriction, "参加可能キャラの制限", class: "block text-xs text-muted" %>
-        <%= form.text_field :character_restriction, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :character_sheet_deadline_note, "キャラシ提出期限の補足", class: "block text-xs text-muted" %>
-        <p class="text-xs text-muted">選択肢に当てはまらない場合はここに書く。書くと選択肢より優先して表示される。</p>
-        <%= form.text_field :character_sheet_deadline_note, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-      <div>
-        <%= form.label :character_sheet_deadline, "キャラシ提出期限", class: "block text-xs text-muted" %>
-        <%= form.select :character_sheet_deadline,
-              Scenario.character_sheet_deadlines.keys.map { |k| [ t("scenarios.character_sheet_deadlines.#{k}"), k ] },
-              { include_blank: "未設定" }, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
+  <fieldset class="rounded-ui-surface border border-ui-outline bg-ui-surface-solid p-4 sm:p-6">
+    <legend class="px-2 font-display text-lg font-bold text-ui-text">遊ぶときの条件</legend>
+    <div class="grid gap-5 md:grid-cols-2">
+      <%= ui_field(form, :player_count_min, label: "PL人数（最小）", required: true) do |field| %><%= ui_input(form, :player_count_min, type: :number, min: 1, required: true, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :player_count_max, label: "PL人数（最大）", description: "人数が固定なら最小と同じ値を入れます。上限が無ければ空欄にします。") do |field| %><%= ui_input(form, :player_count_max, type: :number, min: 1, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :duration_min_hours, label: "目安時間（時間・最小）") do |field| %><%= ui_input(form, :duration_min_hours, type: :number, step: 0.5, min: 0.5, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :duration_max_hours, label: "目安時間（時間・最大）") do |field| %><%= ui_input(form, :duration_max_hours, type: :number, step: 0.5, min: 0.5, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :character_restriction, label: "参加可能キャラの制限") do |field| %><%= ui_input(form, :character_restriction, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :character_sheet_deadline_note, label: "キャラシ提出期限の補足", description: "選択肢に当てはまらない場合に書きます。入力すると選択肢より優先して表示されます。") do |field| %><%= ui_input(form, :character_sheet_deadline_note, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :character_sheet_deadline, label: "キャラシ提出期限") do |field| %><%= ui_select(form, :character_sheet_deadline, Scenario.character_sheet_deadlines.keys.map { |key| [ t("scenarios.character_sheet_deadlines.#{key}"), key ] }, include_blank: "未設定", described_by: field[:described_by]) %><% end %>
     </div>
   </fieldset>
 
-  <fieldset class="border border-rule bg-surface p-5">
-    <legend class="px-2 font-display text-sm">評価と本文</legend>
-
-    <div class="space-y-4">
-      <% [ [ :gm_experienced, "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}経験" ],
-           [ :pl_experienced, "PL経験" ], [ :read, "シナリオ既読" ] ].each do |attribute, label| %>
-        <fieldset>
-          <legend class="text-xs text-muted"><%= label %></legend>
-          <div class="mt-1 flex gap-4 text-sm">
-            <label class="inline-flex items-center gap-2">
-              <%= radio_button_tag "scenario_status[#{attribute}]", "1", @scenario_status.public_send(attribute), required: true %> あり
-            </label>
-            <label class="inline-flex items-center gap-2">
-              <%= radio_button_tag "scenario_status[#{attribute}]", "0", !@scenario_status.public_send(attribute), required: true %> なし
-            </label>
-          </div>
-        </fieldset>
+  <fieldset class="rounded-ui-surface border border-ui-outline bg-ui-surface-solid p-4 sm:p-6">
+    <legend class="px-2 font-display text-lg font-bold text-ui-text">評価と本文</legend>
+    <div class="space-y-5">
+      <% [ [ :gm_experienced, "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}経験" ], [ :pl_experienced, "PL経験" ], [ :read, "シナリオ既読" ] ].each do |attribute, label| %>
+        <fieldset><legend class="text-sm font-bold text-ui-text"><%= label %></legend><div class="mt-1 flex flex-wrap gap-2">
+          <%= ui_radio "scenario_status[#{attribute}]", "1", label: "あり", checked: @scenario_status.public_send(attribute), id: "scenario_status_#{attribute}_yes", required: true %>
+          <%= ui_radio "scenario_status[#{attribute}]", "0", label: "なし", checked: !@scenario_status.public_send(attribute), id: "scenario_status_#{attribute}_no", required: true %>
+        </div></fieldset>
       <% end %>
-
-      <p class="text-xs text-muted">
-        並び順は<%= link_to "#{Scenario.model_name.human}の並び順", scenario_order_index_path, class: "text-seal" %>で決めます。
-      </p>
-
-      <div>
-        <%= form.label :synopsis, "あらすじ", class: "block text-xs text-muted" %>
-        <%= form.text_area :synopsis, rows: 4, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-
-      <div>
-        <%= form.label :recommendation_note, "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}からのオススメポイント", class: "block text-xs text-muted" %>
-        <p class="text-xs text-muted"><%= Person.model_name.human %>にだけ見せる。未登録のログインユーザーと未ログインには出さない。</p>
-        <%= form.text_area :recommendation_note, rows: 4, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
-
-      <div>
-        <%= form.label :preparation_note, "#{Scenario.model_name.human}準備情報", class: "block text-xs text-muted" %>
-        <p class="text-xs text-muted">ネタバレを含む。公開エリアには出さない。</p>
-        <%= form.text_area :preparation_note, rows: 4, class: "mt-1 w-full border border-rule bg-paper px-3 py-2" %>
-      </div>
+      <p class="text-ui-caption text-ui-text-muted">並び順は<%= link_to "#{Scenario.model_name.human}の並び順", scenario_order_index_path, class: "text-ui-action underline" %>で決めます。</p>
+      <%= ui_field(form, :synopsis, label: "あらすじ") do |field| %><%= ui_textarea(form, :synopsis, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :recommendation_note, label: "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}からのオススメポイント", description: "#{Person.model_name.human}にだけ見せます。未登録のログインユーザーと未ログインには表示しません。") do |field| %><%= ui_textarea(form, :recommendation_note, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :preparation_note, label: "#{Scenario.model_name.human}準備情報", description: "ネタバレを含みます。公開エリアには表示しません。") do |field| %><%= ui_textarea(form, :preparation_note, described_by: field[:described_by]) %><% end %>
     </div>
   </fieldset>
 
-  <%= render "manage/scenarios/link_fields", form: form, association: :purchase_links, legend: "入手先",
-        hint: "URL は空でもよい。書籍付属など購入方法を書く場合に使う。" %>
-  <%= render "manage/scenarios/link_fields", form: form, association: :stream_links, legend: "おすすめの配信",
-        hint: "URL は必須。" %>
-
-  <div class="flex gap-4">
-    <%= form.submit "保存", class: "bg-ink px-6 py-2 text-sm text-paper" %>
-    <%= link_to scenario.persisted? ? "詳細に戻る" : "一覧に戻る",
-          scenario.persisted? ? scenario_path(scenario) : scenarios_path,
-          class: "self-center text-sm text-muted" %>
+  <%= render "manage/scenarios/link_fields", form:, association: :purchase_links, legend: "入手先", hint: "URLは空でも構いません。書籍付属など購入方法を書く場合に使います。" %>
+  <%= render "manage/scenarios/link_fields", form:, association: :stream_links, legend: "おすすめの配信", hint: "URLは必須です。" %>
+  <div class="flex flex-wrap items-center gap-3">
+    <%= ui_button "保存", type: "submit" %>
+    <%= ui_button_link scenario.persisted? ? "詳細に戻る" : "一覧に戻る", href: scenario.persisted? ? scenario_path(scenario) : scenarios_path, variant: :secondary %>
   </div>
 <% end %>

--- a/app/views/manage/scenarios/_link_fields.html.erb
+++ b/app/views/manage/scenarios/_link_fields.html.erb
@@ -1,20 +1,2 @@
-<fieldset class="border border-rule bg-surface p-5">
-  <legend class="px-2 font-display text-sm"><%= legend %></legend>
-  <p class="text-xs text-muted"><%= hint %></p>
-
-  <div class="mt-3 space-y-3" data-controller="nested-form" data-nested-form-association-value="<%= association %>">
-    <template data-nested-form-target="template">
-      <%= form.fields_for association, association.to_s.classify.constantize.new, child_index: "NEW_RECORD" do |link| %>
-        <%= render "manage/scenarios/link_row", link: link %>
-      <% end %>
-    </template>
-
-    <%= form.fields_for association do |link| %>
-      <%= render "manage/scenarios/link_row", link: link %>
-    <% end %>
-
-    <div data-nested-form-target="anchor"></div>
-
-    <button type="button" data-action="nested-form#add" class="text-sm text-seal">行を足す</button>
-  </div>
-</fieldset>
+<%= ui_repeatable_fields form, association:, legend:, hint:, row_partial: "manage/scenarios/link_row",
+      new_record: association.to_s.classify.constantize.new %>

--- a/app/views/manage/scenarios/_link_row.html.erb
+++ b/app/views/manage/scenarios/_link_row.html.erb
@@ -1,11 +1,7 @@
-<fieldset class="grid gap-2 border border-rule p-3 sm:grid-cols-[10rem_1fr_auto]">
-  <legend class="px-1 text-sm font-bold">リンク <%= link.index.to_i + 1 %></legend>
-  <div><%= link.label :label, "ラベル", class: "block text-xs text-muted" %>
-  <%= link.text_field :label, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %></div>
-  <div><%= link.label :url, "URL", class: "block text-xs text-muted" %>
-  <%= link.url_field :url, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %></div>
-  <label class="inline-flex items-center gap-1 text-xs text-muted">
-    <%= link.check_box :_destroy %> 削除
-  </label>
+<fieldset class="grid min-w-0 gap-4 rounded-ui-control border border-ui-outline p-4 md:grid-cols-[minmax(8rem,0.7fr)_minmax(12rem,1.3fr)_auto] md:items-end">
+  <legend class="px-2 text-sm font-bold text-ui-text">リンク <%= link.index.to_i + 1 %></legend>
+  <%= ui_field(link, :label, label: "ラベル") do |field| %><%= ui_input(link, :label, described_by: field[:described_by]) %><% end %>
+  <%= ui_field(link, :url, label: "URL") do |field| %><%= ui_input(link, :url, type: :url, described_by: field[:described_by]) %><% end %>
+  <%= ui_checkbox(link, :_destroy, label: "削除") %>
   <%= link.hidden_field :id if link.object.persisted? %>
 </fieldset>

--- a/app/views/manage/scenarios/edit.html.erb
+++ b/app/views/manage/scenarios/edit.html.erb
@@ -1,17 +1,3 @@
-<% content_for :title, "#{@scenario.title} の編集" %>
-<h1 class="font-display text-2xl"><%= @scenario.title %> の編集</h1>
-<div class="mt-4 flex items-center gap-4">
-  <%= button_to "BOOTH画像を更新", refresh_booth_image_scenario_path(@scenario),
-        class: "cursor-pointer border border-rule px-4 py-2 text-sm text-seal" %>
-  <% if @scenario.booth_image.attached? %>
-    <span class="text-xs text-muted">取得済み</span>
-  <% end %>
-</div>
-<% if @scenario.jacket.attached? %>
-  <div class="mt-4">
-    <%= button_to "ジャケット画像を削除", jacket_scenario_path(@scenario), method: :delete,
-          form: { data: { turbo_confirm: "ジャケット画像を削除しますか" } },
-          class: "cursor-pointer border border-rule px-4 py-2 text-sm text-seal" %>
-  </div>
-<% end %>
-<%= render "manage/scenarios/form", scenario: @scenario %>
+<% content_for :title, "#{@scenario.title}の編集" %>
+<% content_for :ui_theme, "dark" %>
+<%= render "manage/scenarios/edit", scenario: @scenario %>

--- a/app/views/scenarios/edit.html.erb
+++ b/app/views/scenarios/edit.html.erb
@@ -1,2 +1,3 @@
 <% content_for :title, "#{@scenario.title}の編集" %>
-<%= render template: "manage/scenarios/edit" %>
+<% content_for :ui_theme, "dark" %>
+<%= render "manage/scenarios/edit", scenario: @scenario %>

--- a/app/views/scenarios/new.html.erb
+++ b/app/views/scenarios/new.html.erb
@@ -1,3 +1,4 @@
 <% content_for :title, "#{Scenario.model_name.human}の新規登録" %>
-<h1 class="font-display text-2xl"><%= Scenario.model_name.human %>の新規登録</h1>
+<% content_for :ui_theme, "dark" %>
+<%= render "shared/ui/page_header", title: "#{Scenario.model_name.human}の新規登録" %>
 <%= render "manage/scenarios/form", scenario: @scenario %>

--- a/app/views/shared/ui/_checkbox.html.erb
+++ b/app/views/shared/ui/_checkbox.html.erb
@@ -1,0 +1,7 @@
+<%= form.label attribute, value: checked_value,
+      class: "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-ui-control px-2 py-2 text-sm text-ui-text hover:bg-ui-subtle" do %>
+  <%= form.check_box attribute, { disabled:, id:, data:, aria:,
+        class: "size-5 shrink-0 accent-ui-action focus:ring-2 focus:ring-ui-focus disabled:cursor-not-allowed disabled:opacity-50" },
+        checked_value, unchecked_value %>
+  <span><%= label %></span>
+<% end %>

--- a/app/views/shared/ui/_collection_checkbox.html.erb
+++ b/app/views/shared/ui/_collection_checkbox.html.erb
@@ -1,0 +1,4 @@
+<%= builder.label class: "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-ui-control px-2 py-2 text-sm text-ui-text hover:bg-ui-subtle" do %>
+  <%= builder.check_box class: "size-5 shrink-0 accent-ui-action focus:ring-2 focus:ring-ui-focus" %>
+  <span><%= builder.text %></span>
+<% end %>

--- a/app/views/shared/ui/_error_summary.html.erb
+++ b/app/views/shared/ui/_error_summary.html.erb
@@ -1,0 +1,17 @@
+<% if record.errors.any? %>
+  <div class="rounded-ui-control border border-ui-error bg-ui-surface-solid p-4 text-sm text-ui-error" role="alert"
+       tabindex="-1" data-controller="error-summary">
+    <h2 class="font-bold">入力内容を確認してください</h2>
+    <ul class="mt-2 list-disc space-y-1 pl-5">
+      <% record.errors.each do |error| %>
+        <li>
+          <% if error.attribute == :base %>
+            <%= error.full_message %>
+          <% else %>
+            <%= link_to error.full_message, "#", class: "underline", data: { error_attribute: error.attribute } %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/ui/_field.html.erb
+++ b/app/views/shared/ui/_field.html.erb
@@ -14,6 +14,6 @@
   <%= input %>
 
   <% if error_messages.any? %>
-    <p id="<%= error_id %>" class="text-ui-caption text-ui-error"><%= error_messages.join("、") %></p>
+    <p id="<%= error_id %>" class="text-ui-caption text-ui-error" data-error-attribute="<%= attribute %>"><%= error_messages.join("、") %></p>
   <% end %>
 </div>

--- a/app/views/shared/ui/_radio.html.erb
+++ b/app/views/shared/ui/_radio.html.erb
@@ -1,0 +1,6 @@
+<%= tag.label for: id,
+      class: "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-ui-control px-2 py-2 text-sm text-ui-text hover:bg-ui-subtle" do %>
+  <%= radio_button_tag name, value, checked, id:, required:, disabled:, data:, aria:,
+        class: "size-5 shrink-0 accent-ui-action focus:ring-2 focus:ring-ui-focus disabled:cursor-not-allowed disabled:opacity-50" %>
+  <span><%= label %></span>
+<% end %>

--- a/app/views/shared/ui/_repeatable_fields.html.erb
+++ b/app/views/shared/ui/_repeatable_fields.html.erb
@@ -1,0 +1,15 @@
+<fieldset class="rounded-ui-surface border border-ui-outline bg-ui-surface-solid p-4 sm:p-6">
+  <legend class="px-2 font-display text-lg font-bold text-ui-text"><%= legend %></legend>
+  <p class="text-ui-caption text-ui-text-muted"><%= hint %></p>
+
+  <div class="mt-4 space-y-4" data-controller="nested-form" data-nested-form-association-value="<%= association %>">
+    <template data-nested-form-target="template">
+      <%= form.fields_for association, new_record, child_index: "NEW_RECORD" do |fields| %>
+        <%= render row_partial, link: fields %>
+      <% end %>
+    </template>
+    <%= form.fields_for association do |fields| %><%= render row_partial, link: fields %><% end %>
+    <div data-nested-form-target="anchor"></div>
+    <%= ui_button add_label, variant: :secondary, size: :small, data: { action: "nested-form#add" } %>
+  </div>
+</fieldset>

--- a/app/views/shared/ui/_select.html.erb
+++ b/app/views/shared/ui/_select.html.erb
@@ -1,0 +1,1 @@
+<%= form.select attribute, choices, select_options, input_options %>

--- a/app/views/shared/ui/_textarea.html.erb
+++ b/app/views/shared/ui/_textarea.html.erb
@@ -1,0 +1,1 @@
+<%= form.text_area attribute, rows:, **input_options %>

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -59,4 +59,58 @@ RSpec.describe UiHelper, type: :helper do
         end
       end
   end
+
+  describe "form controls" do
+    let(:scenario) { Scenario.new }
+
+    it "associates textarea and select controls with field descriptions" do
+      textarea = helper.form_with(model: scenario, url: "/") do |form|
+        helper.ui_field(form, :synopsis, description: "公開される本文です") do |field|
+          helper.ui_textarea(form, :synopsis, described_by: field[:described_by])
+        end
+      end
+      select = helper.form_with(model: scenario, url: "/") do |form|
+        helper.ui_field(form, :character_sheet_deadline, description: "期限を選びます") do |field|
+          helper.ui_select(form, :character_sheet_deadline, [ [ "未設定", "" ] ], described_by: field[:described_by])
+        end
+      end
+
+      expect(Capybara.string(textarea)).to have_css('textarea[aria-describedby="scenario_synopsis_description"]')
+      expect(Capybara.string(select)).to have_css('select[aria-describedby="scenario_character_sheet_deadline_description"]')
+    end
+
+    it "renders one associated validation error for a textarea" do
+      scenario.errors.add(:synopsis, "が長すぎます")
+      html = helper.form_with(model: scenario, url: "/") do |form|
+        helper.ui_field(form, :synopsis) do |field|
+          helper.ui_textarea(form, :synopsis, described_by: field[:described_by])
+        end
+      end
+      field = Capybara.string(html)
+
+      expect(field).to have_css('#scenario_synopsis[aria-invalid="true"][aria-describedby="scenario_synopsis_error"]')
+      expect(field).to have_css('#scenario_synopsis_error[data-error-attribute="synopsis"]', count: 1)
+    end
+
+    it "renders semantic checkbox and radio controls with 44px targets" do
+      checkbox = helper.form_with(model: scenario, url: "/") do |form|
+        helper.ui_checkbox(form, :read, label: "既読")
+      end
+      radio = helper.ui_radio("scenario_status[read]", "1", label: "あり", checked: true, id: "status_read_yes")
+
+      expect(Capybara.string(checkbox)).to have_css('label.min-h-11 input[type="checkbox"]')
+      expect(Capybara.string(radio)).to have_css('label.min-h-11 input#status_read_yes[type="radio"][checked]')
+    end
+  end
+
+  describe "#ui_error_summary" do
+    it "keeps accessible error links used by the focus controller" do
+      scenario = Scenario.new
+      scenario.errors.add(:title, "を入力してください")
+      summary = Capybara.string(helper.ui_error_summary(scenario))
+
+      expect(summary).to have_css('[role="alert"][data-controller="error-summary"]')
+      expect(summary).to have_css('a[data-error-attribute="title"]', text: scenario.errors.full_messages.first)
+    end
+  end
 end

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Legacy content contrast" do
     click_button "Googleでログイン"
 
     legacy_paths = [
-      scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),
+      scenario_path(scenario),
       play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
       people_path, person_path(person), new_person_path, edit_person_path(person),
       authors_path, author_path(author), new_author_path, edit_author_path(author),

--- a/spec/system/scenario_form_responsive_spec.rb
+++ b/spec/system/scenario_form_responsive_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Responsive scenario forms" do
+  it "keeps new and edit forms accessible at supported widths" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    editor = create(:person, roles: %w[admin gm])
+    user = create(:user, person: editor)
+    scenario = create(:scenario, title: "編集するシナリオ")
+    scenario.purchase_links.create!(label: "とても長い名前のオンラインストア", url: "https://example.com/item")
+    create(:author, name: "見本作者")
+    create(:game_system, name: "見本システム")
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
+
+    [ new_scenario_path, edit_scenario_path(scenario) ].each do |path|
+      [ 320, 768, 1280 ].each do |width|
+        page.current_window.resize_to(width, 1000)
+        visit path
+        expect(page).to have_css('main[data-ui-theme="dark"]')
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+        expect(page).to be_axe_clean
+        expect(all('form input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]), form textarea, form select, form button').select(&:visible?).all? do |control|
+          control.rect.height >= 44
+        end).to be(true)
+        expect(all('form input[type="checkbox"], form input[type="radio"]').select(&:visible?).all? do |control|
+          control.find(:xpath, "parent::label").rect.height >= 44
+        end).to be(true)
+        save_screenshot("scenario-form-#{path == new_scenario_path ? 'new' : 'edit'}-#{width}.png") if ENV["VISUAL_REVIEW"]
+      end
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## What

Migrate scenario creation and editing to the Obsidian Glass form components. Add shared textarea, select, checkbox, radio, error-summary, and repeatable-field components.

## Why

Complete task 5 of the ADR-0002 UI redesign plan while preserving accessible field-error associations.

## Verification

- [x] `bin/rspec` (669 examples, 0 failures)
- [x] `prek run --all-files`
- [x] Full axe checks at 320px, 768px, and 1280px for new and edit forms
- [x] Visual review at 320px, 768px, and 1280px with no horizontal overflow

`bin/ci` passed tests, lint, and dependency audits. Its working-directory gitleaks step detected a generated `tmp/cache/bootsnap` entry; the required commit-range gitleaks scan reports no leaks.

## Related

- [ADR-0002](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/adr/0002-user-interface-design.md)
- [UI redesign task 5](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/plans/2026-08-22-ui-redesign.md#5-%E3%82%B7%E3%83%8A%E3%83%AA%E3%82%AA%E3%81%AE%E7%99%BB%E9%8C%B2%E3%81%A8%E7%B7%A8%E9%9B%86)