### PR TITLE
Stabilize legacy contrast browser spec

### DIFF
--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Legacy content contrast" do
 
     visit root_path
     click_button "Googleでログイン"
+    expect(page).to have_link(admin.display_name, href: person_path(admin))
 
     legacy_paths = [
       scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),


### PR DESCRIPTION
## What

Wait for the authenticated header to appear before navigating through legacy screens.

## Why

The OAuth callback navigation could finish after the first `visit`, overwrite the scenario detail navigation, and leave the dark scenario list in the DOM. Waiting for the signed-in profile link synchronizes on the actual callback result before the contrast audit starts.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `bin/ci`
- [x] Legacy contrast system spec passed 20 consecutive times with local Chromium and axe

## Related

Closes #121