### PR TITLE
Redesign play session screens

### DIFF
--- a/app/views/play_sessions/index.html.erb
+++ b/app/views/play_sessions/index.html.erb
@@ -1,35 +1,22 @@
 <% content_for :title, "#{PlaySession.model_name.human}一覧" %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-3xl tracking-wide">
-  <%= PlaySession.model_name.human %>一覧<span class="ml-2 text-base text-muted">（全<%= @play_sessions.size %>件）</span>
-</h1>
-<% if policy(PlaySession).create? %><p class="mt-4"><%= link_to "新規登録", new_play_session_path, class: "text-sm text-seal" %></p><% end %>
+<div class="space-y-6">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <div>
+      <%= render "shared/ui/page_header", title: safe_join([
+        "#{PlaySession.model_name.human}一覧",
+        tag.span("（全#{@play_sessions.size}件）", class: "ml-2 text-base font-normal text-ui-text-muted")
+      ]) %>
+    </div>
+    <% if policy(PlaySession).create? %><%= ui_button_link("新規登録", href: new_play_session_path) %><% end %>
+  </div>
 
-<ul class="mt-8 divide-y divide-rule border border-rule bg-surface">
-  <% @play_sessions.each do |session| %>
-    <li>
-      <%= link_to play_session_path(session), class: "flex flex-wrap items-baseline gap-x-4 gap-y-1 p-4 no-underline text-ink hover:bg-paper" do %>
-        <span class="font-mono text-xs text-muted"><%= play_session_schedule(session) %>（<%= play_session_status_label(session) %>）</span>
-        <span class="font-display text-lg"><%= session.scenario.title %></span>
-        <span class="ml-auto text-xs text-muted">
-          <%= session.participations.map { |p| "#{participation_role_label(p)}: #{p.person.display_name}" }.join("、") %>
-        </span>
-      <% end %>
-      <% if policy(session).update? || policy(session).destroy? %>
-        <div class="flex flex-wrap items-center justify-end gap-3 px-4 pb-3 text-xs">
-          <% if policy(session).update? %><%= link_to "編集", edit_play_session_path(session), class: "text-seal" %><% end %>
-          <%= render "shared/delete_button", record: session, path: play_session_path(session), label: "削除",
-                aria_label: "#{session.scenario.title} の#{PlaySession.model_name.human}を削除",
-                confirm: "#{session.scenario.title} の#{PlaySession.model_name.human}を削除しますか",
-                class_name: "min-h-6 text-muted" %>
-        </div>
-      <% end %>
-    </li>
+  <% if @play_sessions.any? %>
+    <ul class="grid gap-4 md:grid-cols-2">
+      <% @play_sessions.each do |play_session| %><li><%= render "shared/ui/play_session_card", play_session: %></li><% end %>
+    </ul>
+  <% else %>
+    <%= render "shared/ui/empty_state", title: "見られる#{PlaySession.model_name.human}がまだありません。" %>
   <% end %>
-</ul>
-
-<% if @play_sessions.empty? %>
-  <p class="mt-8 border border-rule bg-surface p-8 text-center text-sm text-muted">
-    見られる<%= PlaySession.model_name.human %>がまだありません。
-  </p>
-<% end %>
+</div>

--- a/app/views/play_sessions/show.html.erb
+++ b/app/views/play_sessions/show.html.erb
@@ -1,76 +1,78 @@
 <% content_for :title, "#{@play_session.scenario.title}の#{PlaySession.model_name.human}" %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <nav class="text-xs text-muted">
-    <%= link_to "#{PlaySession.model_name.human}一覧", play_sessions_path, class: "text-muted" %> ／
-    <%= @play_session.scenario.title %>
+<article class="space-y-10">
+  <nav class="text-ui-caption text-ui-text-muted" aria-label="パンくずリスト">
+    <%= link_to "#{PlaySession.model_name.human}一覧", play_sessions_path, class: "text-ui-action underline" %>
+    <span aria-hidden="true">／</span> <span aria-current="page"><%= @play_session.scenario.title %></span>
   </nav>
 
-  <div class="mt-6 flex flex-wrap items-baseline justify-between gap-4">
-    <h1 class="font-display text-3xl leading-tight tracking-wide">
-      <%= link_to @play_session.scenario.title, scenario_path(@play_session.scenario), class: "text-ink" %>
-    </h1>
-    <div class="flex flex-wrap items-baseline gap-4">
-      <% if policy(@play_session).update? %>
-        <%= link_to "編集", edit_play_session_path(@play_session), class: "text-sm text-seal" %>
-      <% end %>
-      <%= render "shared/delete_button", record: @play_session, path: play_session_path(@play_session),
-            label: "この#{PlaySession.model_name.human}を削除",
-            confirm: "#{@play_session.scenario.title} の#{PlaySession.model_name.human}を削除しますか",
-            class_name: "text-sm text-seal" %>
+  <header class="flex flex-wrap items-start justify-between gap-4">
+    <div class="min-w-0">
+      <%= render "shared/ui/page_header", title: @play_session.scenario.title %>
+      <p class="mt-2"><%= link_to "#{Scenario.model_name.human}詳細を見る", scenario_path(@play_session.scenario), class: "inline-flex min-h-11 items-center text-sm font-bold text-ui-action" %></p>
     </div>
-  </div>
+    <div class="flex flex-wrap gap-2">
+      <% if policy(@play_session).update? %><%= ui_button_link("編集", href: edit_play_session_path(@play_session), variant: :secondary, size: :small) %><% end %>
+      <% if policy(@play_session).destroy? %>
+        <%= form_with url: play_session_path(@play_session), method: :delete, data: { turbo_confirm: "#{@play_session.scenario.title} の#{PlaySession.model_name.human}を削除しますか" } do %>
+          <%= ui_button("この#{PlaySession.model_name.human}を削除", variant: :danger, size: :small, type: "submit") %>
+        <% end %>
+      <% end %>
+    </div>
+  </header>
 
-  <dl class="mt-6 grid grid-cols-[6rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 font-mono text-sm">
-    <dt class="text-muted">日時</dt>
-    <dd class="space-y-4">
+  <section aria-labelledby="schedule-heading">
+    <h2 id="schedule-heading" class="font-display text-xl font-bold">日時と録画</h2>
+    <div class="mt-4 grid gap-4 md:grid-cols-2">
       <% if @play_session.session_schedules.empty? %>
-        日程未定（<%= play_session_status_label(@play_session) %>）
+        <%= render "shared/ui/card" do %><p class="p-5 text-sm text-ui-text-muted">日程未定（<%= play_session_status_label(@play_session) %>）</p><% end %>
       <% end %>
       <% @play_session.session_schedules.each_with_index do |schedule, index| %>
-        <section data-session-schedule>
-          <p><%= play_session_schedule_time(schedule) %><%= "（#{play_session_status_label(@play_session)}）" if index == @play_session.session_schedules.size - 1 %></p>
-          <div class="mt-2 space-y-2 font-sans">
-            <% schedule.recording_links.each do |recording| %>
-              <%= render "shared/video_link", title: "録画", url: recording.url,
-                    link_text: recording.url, rel: "noopener", show_url: false %>
+        <%= render "shared/ui/card" do %>
+          <section class="p-5" data-session-schedule>
+            <p class="font-bold"><%= play_session_schedule_time(schedule) %></p>
+            <% if index == @play_session.session_schedules.size - 1 %><p class="mt-2"><%= render "shared/ui/badge", label: play_session_status_label(@play_session), variant: :accent %></p><% end %>
+            <% if schedule.recording_links.any? %>
+              <div class="mt-4 grid gap-4">
+                <% schedule.recording_links.each do |recording| %><%= render "shared/ui/video_link", title: "録画", url: recording.url, link_text: recording.url, rel: "noopener", show_url: false %><% end %>
+              </div>
             <% end %>
-          </div>
-        </section>
+          </section>
+        <% end %>
       <% end %>
-    </dd>
+    </div>
     <% if @play_session.cocofolia_url.present? && policy(@play_session).show_cocofolia_url? %>
-      <dt class="text-muted">ココフォリア</dt>
-      <dd class="font-sans">
-        <%= link_to @play_session.cocofolia_url, @play_session.cocofolia_url,
-              target: "_blank", rel: "noopener", class: "text-seal" %>
-      </dd>
+      <div class="mt-4 rounded-ui-control border border-ui-outline bg-ui-surface-solid p-4">
+        <p class="text-sm font-bold text-ui-text-muted">ココフォリア</p>
+        <%= link_to @play_session.cocofolia_url, @play_session.cocofolia_url, target: "_blank", rel: "noopener", class: "mt-1 block text-sm text-ui-action" %>
+      </div>
     <% end %>
-  </dl>
+  </section>
 
-  <section class="mt-10">
-    <h2 class="font-display text-xl">参加者</h2>
-    <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-      <% @play_session.participations.each do |participation| %>
-        <li class="flex flex-wrap items-baseline gap-x-4 gap-y-1 p-3">
-          <span class="w-24 shrink-0 font-mono text-xs text-muted"><%= participation_role_label(participation) %></span>
-          <span class="font-display"><%= participation.person.display_name %></span>
-          <% if participation.character_name.present? %>
-            <span class="text-muted"><%= participation.character_name %></span>
-          <% end %>
-          <% if participation.character_sheet_url.present? %>
-            <%= link_to participation.character_sheet_url, participation.character_sheet_url,
-                  target: "_blank", rel: "noopener", class: "ml-auto text-xs text-seal" %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+  <section aria-labelledby="participants-heading">
+    <h2 id="participants-heading" class="font-display text-xl font-bold">参加者</h2>
+    <% if @play_session.participations.any? %>
+      <ul class="mt-4 grid gap-3 md:grid-cols-2">
+        <% @play_session.participations.each do |participation| %>
+          <li><%= render "shared/ui/card" do %>
+            <div class="grid gap-2 p-4 sm:grid-cols-[6rem_minmax(0,1fr)]">
+              <span class="text-ui-caption font-bold text-ui-text-muted"><%= participation_role_label(participation) %></span>
+              <div class="min-w-0">
+                <p class="font-bold"><%= participation.person.display_name %></p>
+                <% if participation.character_name.present? %><p class="mt-1 text-sm text-ui-text-muted"><%= participation.character_name %></p><% end %>
+                <% if participation.character_sheet_url.present? %><%= link_to participation.character_sheet_url, participation.character_sheet_url, target: "_blank", rel: "noopener", class: "mt-2 block text-ui-caption text-ui-action" %><% end %>
+              </div>
+            </div>
+          <% end %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="mt-4"><%= render "shared/ui/empty_state", title: "参加者はまだ登録されていません。" %></div>
+    <% end %>
   </section>
 
   <% if @play_session.note.present? %>
-    <section class="mt-10">
-      <h2 class="font-display text-xl">メモ</h2>
-      <p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@play_session.note) %></p>
-    </section>
+    <section aria-labelledby="note-heading"><h2 id="note-heading" class="font-display text-xl font-bold">メモ</h2><p class="mt-3 whitespace-pre-line leading-relaxed"><%= auto_link_urls(@play_session.note) %></p></section>
   <% end %>
 </article>

--- a/app/views/shared/ui/_play_session_card.html.erb
+++ b/app/views/shared/ui/_play_session_card.html.erb
@@ -1,0 +1,22 @@
+<%= render "shared/ui/card", variant: :interactive do %>
+  <article class="flex h-full flex-col">
+    <%= link_to play_session_path(play_session), class: "block space-y-3 p-5 no-underline" do %>
+      <div class="flex flex-wrap items-center gap-2">
+        <%= render "shared/ui/badge", label: play_session_status_label(play_session), variant: :accent %>
+        <span class="text-ui-caption text-ui-text-muted"><%= play_session_schedule(play_session) %></span>
+      </div>
+      <h2 class="font-display text-lg font-bold leading-snug text-ui-text"><%= play_session.scenario.title %></h2>
+      <p class="text-ui-caption text-ui-text-muted"><%= play_session.participations.map { |participation| "#{participation_role_label(participation)}: #{participation.person.display_name}" }.join("、") %></p>
+    <% end %>
+    <% if policy(play_session).update? || policy(play_session).destroy? %>
+      <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-ui-outline px-5 py-4">
+        <% if policy(play_session).update? %><%= ui_button_link("編集", href: edit_play_session_path(play_session), variant: :secondary, size: :small) %><% end %>
+        <% if policy(play_session).destroy? %>
+          <%= form_with url: play_session_path(play_session), method: :delete, data: { turbo_confirm: "#{play_session.scenario.title} の#{PlaySession.model_name.human}を削除しますか" } do %>
+            <%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{play_session.scenario.title} の#{PlaySession.model_name.human}を削除" }) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </article>
+<% end %>

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Legacy content contrast" do
 
     legacy_paths = [
       new_scenario_path, edit_scenario_path(scenario),
-      play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
+      new_play_session_path, edit_play_session_path(play_session),
       people_path, person_path(person), new_person_path, edit_person_path(person),
       authors_path, author_path(author), new_author_path, edit_author_path(author),
       game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),

--- a/spec/system/play_sessions_responsive_spec.rb
+++ b/spec/system/play_sessions_responsive_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Responsive play session screens" do
+  it "reflows the list and detail at supported viewport widths" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    editor = create(:person, roles: %w[gm], display_name: "進行役の長い表示名")
+    player = create(:person, display_name: "参加者の長い表示名")
+    scenario = create(:scenario, title: "狭い画面でも読める長いシナリオ名")
+    play_session = create(:play_session, scenario:, note: "セッションについての長いメモ")
+    schedule = create(:session_schedule, play_session:, scheduled_on: Date.new(2026, 8, 24))
+    create(:recording_link, session_schedule: schedule, url: "https://example.com/recordings/a-very-long-address")
+    create(:participation, play_session:, person: editor, role: :gm)
+    create(:participation, play_session:, person: player, role: :player,
+      character_name: "長い名前のキャラクター", character_sheet_url: "https://example.com/characters/a-very-long-address")
+    user = create(:user, person: editor)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      { list: play_sessions_path, detail: play_session_path(play_session) }.each do |screen, path|
+        visit path
+        expect(page).to have_css('main[data-ui-theme="dark"]')
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
+        expect(page).to be_axe_clean
+        save_screenshot("play-session-#{screen}-#{width}.png") if ENV["VISUAL_REVIEW"]
+      end
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## What

Migrate the play session list and detail screens to Obsidian Glass and add a reusable play session card.

## Why

Complete task 6 of the UI redesign plan on top of the scenario detail components from #123.

## Verification

- [x] `bin/rspec` (665 examples, 0 failures)
- [x] `prek run --all-files`
- [x] Full axe and horizontal overflow checks for list and detail at 320px, 768px, and 1280px

## Related

Depends on #123.

[ADR-0002](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/adr/0002-user-interface-design.md) / [UI redesign task 6](https://github.com/karia/trpg-scenario-session-catalog/blob/main/docs/plans/2026-08-22-ui-redesign.md)