### PR TITLE
Redesign master management screens

### DIFF
--- a/app/views/manage/groups/edit.html.erb
+++ b/app/views/manage/groups/edit.html.erb
@@ -1,33 +1,12 @@
 <% content_for :title, "#{@record.name} の編集" %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-2xl"><%= @record.name %> の編集</h1>
-
-<%= form_with model: [ :manage, @record ], class: "mt-6 space-y-4 border border-rule bg-surface p-5" do |form| %>
-  <%= accessible_error_summary(@record) %>
-
-  <div>
-    <%= form.label :name, "名前", class: "block text-xs text-muted" %>
-    <%= form.text_field :name, class: "mt-1 w-64 border border-rule bg-paper px-3 py-2 text-sm" %>
-  </div>
-
-  <div>
-    <%= form.label :discord_guild_id, "DiscordサーバーID", class: "block text-xs text-muted" %>
-    <%= form.text_field :discord_guild_id, inputmode: "numeric", autocomplete: "off",
-          aria: { describedby: "discord-guild-id-help" },
-          class: "mt-1 w-64 border border-rule bg-paper px-3 py-2 font-mono text-sm" %>
-    <p id="discord-guild-id-help" class="mt-1 text-xs text-muted">未設定ならDiscordからの自動参加を行いません。</p>
-  </div>
-
-  <div>
-    <span class="block text-xs text-muted">手動で所属させる人物</span>
-    <%= form.collection_check_boxes :manual_person_ids, Person.order(:display_name), :id, :display_name do |b| %>
-      <label class="mr-4 inline-flex items-center gap-1 text-sm"><%= b.check_box %> <%= b.text %></label>
-    <% end %>
-    <p class="mt-1 text-xs text-muted">Discordから自動所属した人物を選ぶと、退会後も残る手動所属へ切り替えます。</p>
-  </div>
-
-  <div class="flex gap-4">
-    <%= form.submit "更新", class: "bg-ink px-5 py-2 text-sm text-paper" %>
-    <%= link_to "詳細に戻る", manage_group_path(@record), class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: "#{@record.name} の編集" %>
+  <%= form_with model: [ :manage, @record ], class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@record) %>
+    <%= render "shared/ui/card" do %><div class="grid gap-5 p-5 sm:grid-cols-2 sm:p-6"><%= ui_field(form, :name, label: "名前", required: true) do |field| %><%= ui_input(form, :name, described_by: field[:described_by], required: true) %><% end %><%= ui_field(form, :discord_guild_id, label: "DiscordサーバーID", description: "未設定ならDiscordからの自動参加を行いません。") do |field| %><%= ui_input(form, :discord_guild_id, described_by: field[:described_by], inputmode: "numeric", autocomplete: "off") %><% end %></div><% end %>
+    <fieldset class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6"><legend class="px-2 font-display text-lg font-bold">手動で所属させる人物</legend><p class="text-ui-caption text-ui-text-muted">Discordから自動所属した人物を選ぶと、退会後も残る手動所属へ切り替えます。</p><div class="mt-4 grid gap-2 sm:grid-cols-2"><%= form.collection_check_boxes :manual_person_ids, Person.order(:display_name), :id, :display_name do |b| %><%= b.label class: "flex min-h-11 min-w-0 items-center gap-3 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-sm" do %><%= b.check_box class: "size-5 shrink-0 accent-ui-action" %><span class="min-w-0 break-words"><%= b.text %></span><% end %><% end %></div></fieldset>
+    <div class="flex flex-wrap gap-3"><%= ui_button("更新", type: "submit") %><%= ui_button_link("詳細に戻る", href: manage_group_path(@record), variant: :secondary) %></div>
+  <% end %>
+</div>

--- a/app/views/manage/groups/show.html.erb
+++ b/app/views/manage/groups/show.html.erb
@@ -1,33 +1,25 @@
 <% content_for :title, @record.name %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <div class="flex flex-wrap items-baseline justify-between gap-4">
-    <h1 class="font-display text-3xl"><%= @record.name %></h1>
-    <div class="flex flex-wrap items-baseline gap-4">
-      <%= link_to "編集", edit_manage_group_path(@record), class: "text-sm text-seal" %>
-      <%= render "shared/delete_button", record: @record, path: manage_group_path(@record),
-            label: "この#{Group.model_name.human}を削除",
-            confirm: "#{@record.name} を削除しますか", class_name: "text-sm text-seal" %>
+<article class="space-y-8">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <%= render "shared/ui/page_header", title: @record.name %>
+    <div class="flex flex-wrap gap-2">
+      <%= ui_button_link("編集", href: edit_manage_group_path(@record), variant: :secondary, size: :small) %>
+      <% if policy(@record).destroy? %><%= form_with url: manage_group_path(@record), method: :delete, data: { turbo_confirm: "#{@record.name} を削除しますか" } do %><%= ui_button("この#{Group.model_name.human}を削除", variant: :danger, size: :small, type: "submit") %><% end %><% end %>
     </div>
   </div>
 
-  <dl class="mt-6 grid grid-cols-[10rem_1fr] gap-x-4 gap-y-2 border-t border-rule pt-4 text-sm">
-    <dt class="text-muted">DiscordサーバーID</dt>
-    <dd class="font-mono"><%= @record.discord_guild_id.presence || "未設定" %></dd>
-  </dl>
+  <%= render "shared/ui/card" do %><dl class="grid gap-3 p-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:p-6"><dt class="font-bold text-ui-text-muted">DiscordサーバーID</dt><dd class="break-all font-mono"><%= @record.discord_guild_id.presence || "未設定" %></dd></dl><% end %>
 
-  <section class="mt-8">
-    <h2 class="font-display text-xl"><%= Person.model_name.human %></h2>
+  <section class="space-y-3">
+    <h2 class="font-display text-xl font-bold"><%= Person.model_name.human %></h2>
     <% if @record.people.any? %>
-      <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-        <% @record.people.order(:display_name).each do |person| %>
-          <li class="p-3"><%= link_to person.display_name, person_path(person), class: "text-seal" %></li>
-        <% end %>
-      </ul>
+      <%= render "shared/ui/card" do %><ul class="divide-y divide-ui-outline"><% @record.people.order(:display_name).each do |person| %><li><%= link_to person.display_name, person_path(person), class: "flex min-h-11 items-center break-words px-4 py-3 font-bold text-ui-action sm:px-5" %></li><% end %></ul><% end %>
     <% else %>
-      <p class="mt-3 text-sm text-muted">まだいません。</p>
+      <%= render "shared/ui/empty_state", title: "まだいません。" %>
     <% end %>
   </section>
 
-  <p class="mt-8"><%= link_to "一覧に戻る", manage_groups_path, class: "text-sm text-muted" %></p>
+  <div><%= ui_button_link("一覧に戻る", href: manage_groups_path, variant: :secondary) %></div>
 </article>

--- a/app/views/manage/masters/_index.html.erb
+++ b/app/views/manage/masters/_index.html.erb
@@ -1,17 +1,27 @@
 <% content_for :title, title %>
-<h1 class="font-display text-2xl"><%= title %></h1>
-<% if local_assigns[:new_path] && policy(records.model).create? %><p class="mt-4"><%= link_to "新規登録", new_path, class: "text-sm text-seal" %></p><% end %>
+<% content_for :ui_theme, "dark" %>
 
-<ul class="mt-6 divide-y divide-rule border border-rule bg-surface text-sm">
-  <% records.each do |item| %>
-    <li class="flex items-center justify-between p-3">
-      <span><%= item.name %></span>
-      <span class="flex gap-1 text-xs">
-        <%= link_to "詳細", record_path.call(item), class: "inline-flex min-h-6 items-center px-1 text-seal" %>
-        <% if policy(item).update? %><%= link_to "編集", edit_path.call(item), class: "inline-flex min-h-6 items-center px-1 text-seal" %><% end %>
-        <%= render "shared/delete_button", record: item, path: record_path.call(item), label: "削除",
-              aria_label: "#{item.name} を削除", confirm: "#{item.name} を削除しますか" %>
-      </span>
-    </li>
+<div class="space-y-6">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <%= render "shared/ui/page_header", title: %>
+    <% if local_assigns[:new_path] && policy(records.model).create? %><%= ui_button_link("新規登録", href: new_path) %><% end %>
+  </div>
+  <% if records.any? %>
+    <ul class="grid gap-3">
+      <% records.each do |item| %>
+        <li><%= render "shared/ui/card" do %>
+          <div class="flex min-w-0 flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+            <p class="min-w-0 break-words font-bold text-ui-text"><%= item.name %></p>
+            <div class="flex flex-wrap gap-2">
+              <%= ui_button_link("詳細", href: record_path.call(item), variant: :secondary, size: :small) %>
+              <% if policy(item).update? %><%= ui_button_link("編集", href: edit_path.call(item), variant: :secondary, size: :small) %><% end %>
+              <% if policy(item).destroy? %><%= form_with url: record_path.call(item), method: :delete, data: { turbo_confirm: "#{item.name} を削除しますか" } do %><%= ui_button("削除", variant: :danger, size: :small, type: "submit", aria: { label: "#{item.name} を削除" }) %><% end %><% end %>
+            </div>
+          </div>
+        <% end %></li>
+      <% end %>
+    </ul>
+  <% else %>
+    <%= render "shared/ui/empty_state", title: "まだ登録されていません。", description: local_assigns[:new_path] ? "新規登録から追加できます。" : nil %>
   <% end %>
-</ul>
+</div>

--- a/app/views/manage/masters/edit.html.erb
+++ b/app/views/manage/masters/edit.html.erb
@@ -1,23 +1,16 @@
 <% content_for :title, "#{@record.name} の編集" %>
+<% content_for :ui_theme, "dark" %>
 
-<h1 class="font-display text-2xl"><%= @record.name %> の編集</h1>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: "#{@record.name} の編集" %>
+  <%= form_with model: @record, class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@record) %>
+    <%= render "shared/ui/alias_fields", form:, display_attribute: :name, alias_class: @record.class.reflect_on_association(:aliases).klass %>
 
-<%= form_with model: @record, class: "mt-6 space-y-4 border border-rule bg-surface p-5" do |form| %>
-  <%= accessible_error_summary(@record) %>
+    <% if @record.is_a?(GameSystem) %>
+      <%= render "shared/ui/card" do %><div class="p-5 sm:p-6"><%= ui_field(form, :game_master_label, label: "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}の呼称", description: "未指定の場合は「#{GameSystem::DEFAULT_GAME_MASTER_LABEL}」と表示します。") do |field| %><div class="max-w-48"><%= ui_input(form, :game_master_label, described_by: field[:described_by], placeholder: GameSystem::DEFAULT_GAME_MASTER_LABEL) %></div><% end %></div><% end %>
+    <% end %>
 
-  <%= render "shared/alias_fields", form: form, display_attribute: :name,
-        alias_class: @record.class.reflect_on_association(:aliases).klass %>
-
-  <% if @record.is_a?(GameSystem) %>
-    <div>
-      <%= form.label :game_master_label, "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}の呼称", class: "block text-xs text-muted" %>
-      <%= form.text_field :game_master_label, placeholder: GameSystem::DEFAULT_GAME_MASTER_LABEL, class: "mt-1 w-32 border border-rule bg-paper px-3 py-2 text-sm" %>
-      <p class="mt-1 text-xs text-muted">未指定の場合は「<%= GameSystem::DEFAULT_GAME_MASTER_LABEL %>」と表示します。</p>
-    </div>
+    <div class="flex flex-wrap gap-3"><%= ui_button("更新", type: "submit") %><%= ui_button_link("詳細に戻る", href: url_for(action: :show, id: @record), variant: :secondary) %></div>
   <% end %>
-
-  <div class="flex gap-4">
-    <%= form.submit "更新", class: "bg-ink px-5 py-2 text-sm text-paper" %>
-    <%= link_to "詳細に戻る", url_for(action: :show, id: @record), class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/manage/masters/new.html.erb
+++ b/app/views/manage/masters/new.html.erb
@@ -1,13 +1,10 @@
 <% content_for :title, "#{@record.model_name.human}の新規登録" %>
-<h1 class="font-display text-2xl"><%= @record.model_name.human %>の新規登録</h1>
-<%= form_with model: @record, class: "mt-6 space-y-4 border border-rule bg-surface p-5" do |form| %>
-  <%= accessible_error_summary(@record) %>
-  <div>
-    <%= form.label :name, "名前", class: "block text-xs text-muted" %>
-    <%= form.text_field :name, class: "mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm" %>
-  </div>
-  <div class="flex gap-4">
-    <%= form.submit "登録", class: "bg-ink px-5 py-2 text-sm text-paper" %>
-    <%= link_to "一覧に戻る", polymorphic_path(@record.class), class: "self-center text-sm text-muted" %>
-  </div>
-<% end %>
+<% content_for :ui_theme, "dark" %>
+<div class="space-y-6">
+  <%= render "shared/ui/page_header", title: "#{@record.model_name.human}の新規登録" %>
+  <%= form_with model: @record, class: "space-y-6" do |form| %>
+    <%= accessible_error_summary(@record) %>
+    <%= render "shared/ui/card" do %><div class="p-5 sm:p-6"><%= ui_field(form, :name, label: "名前", required: true) do |field| %><%= ui_input(form, :name, described_by: field[:described_by], required: true) %><% end %></div><% end %>
+    <div class="flex flex-wrap gap-3"><%= ui_button("登録", type: "submit") %><%= ui_button_link("一覧に戻る", href: polymorphic_path(@record.class), variant: :secondary) %></div>
+  <% end %>
+</div>

--- a/app/views/manage/masters/show.html.erb
+++ b/app/views/manage/masters/show.html.erb
@@ -1,40 +1,32 @@
 <% content_for :title, @record.name %>
+<% content_for :ui_theme, "dark" %>
 
-<article>
-  <div class="flex flex-wrap items-baseline justify-between gap-4">
-    <h1 class="font-display text-3xl"><%= @record.name %></h1>
-    <div class="flex flex-wrap items-baseline gap-4">
-      <% if policy(@record).update? %>
-        <%= link_to "編集", url_for(action: :edit, id: @record), class: "text-sm text-seal" %>
-      <% end %>
-      <%= render "shared/delete_button", record: @record, path: url_for(action: :show, id: @record),
-            label: "この#{@record.model_name.human}を削除",
-            confirm: "#{@record.name} を削除しますか", class_name: "text-sm text-seal" %>
+<article class="space-y-8">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <%= render "shared/ui/page_header", title: @record.name %>
+    <div class="flex flex-wrap gap-2">
+      <% if policy(@record).update? %><%= ui_button_link("編集", href: url_for(action: :edit, id: @record), variant: :secondary, size: :small) %><% end %>
+      <% if policy(@record).destroy? %><%= form_with url: url_for(action: :show, id: @record), method: :delete, data: { turbo_confirm: "#{@record.name} を削除しますか" } do %><%= ui_button("この#{@record.model_name.human}を削除", variant: :danger, size: :small, type: "submit") %><% end %><% end %>
     </div>
   </div>
 
-  <% if @record.visible_aliases.any? %>
-    <p class="mt-3 text-sm text-muted">別名: <%= @record.visible_aliases.map(&:name).join("、") %></p>
-  <% end %>
-
-  <% if @record.is_a?(GameSystem) %>
-    <p class="mt-3 text-sm text-muted"><%= GameSystem::DEFAULT_GAME_MASTER_LABEL %>の呼称: <%= @record.game_master_label.presence || "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}（未指定）" %></p>
+  <%= render "shared/ui/card" do %>
+    <dl class="grid gap-4 p-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:p-6">
+      <dt class="font-bold text-ui-text-muted">別名</dt><dd class="break-words"><%= @record.visible_aliases.map(&:name).join("、").presence || "未設定" %></dd>
+      <% if @record.is_a?(GameSystem) %><dt class="font-bold text-ui-text-muted"><%= GameSystem::DEFAULT_GAME_MASTER_LABEL %>の呼称</dt><dd><%= @record.game_master_label.presence || "#{GameSystem::DEFAULT_GAME_MASTER_LABEL}（未指定）" %></dd><% end %>
+    </dl>
   <% end %>
 
   <% if @record.respond_to?(:scenarios) %>
-    <section class="mt-8">
-      <h2 class="font-display text-xl"><%= Scenario.model_name.human %></h2>
+    <section class="space-y-3">
+      <h2 class="font-display text-xl font-bold"><%= Scenario.model_name.human %></h2>
       <% if @record.scenarios.any? %>
-        <ul class="mt-3 divide-y divide-rule border border-rule bg-surface text-sm">
-          <% @record.scenarios.order(:title).each do |scenario| %>
-            <li class="p-3"><%= link_to scenario.title, scenario_path(scenario), class: "text-seal" %></li>
-          <% end %>
-        </ul>
+        <%= render "shared/ui/card" do %><ul class="divide-y divide-ui-outline"><% @record.scenarios.order(:title).each do |scenario| %><li><%= link_to scenario.title, scenario_path(scenario), class: "flex min-h-11 items-center break-words px-4 py-3 font-bold text-ui-action sm:px-5" %></li><% end %></ul><% end %>
       <% else %>
-        <p class="mt-3 text-sm text-muted">まだありません。</p>
+        <%= render "shared/ui/empty_state", title: "まだありません。" %>
       <% end %>
     </section>
   <% end %>
 
-  <p class="mt-8"><%= link_to "一覧に戻る", url_for(action: :index), class: "text-sm text-muted" %></p>
+  <div><%= ui_button_link("一覧に戻る", href: url_for(action: :index), variant: :secondary) %></div>
 </article>

--- a/spec/requests/manage/masters_spec.rb
+++ b/spec/requests/manage/masters_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Manage masters" do
       get public_send(edit_path, record), headers: headers
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("input.w-full", count: 2)
+      expect(page).to have_css("fieldset:first-of-type input.w-full", count: 2)
       expect(page).to have_css("input[type=checkbox][disabled]", count: 2)
       expect(page).to have_no_css("input[type=radio]")
       expect(page).to have_select("#{factory}[display_alias_key]", options: [ "既存（現在の表示名）", "別名" ])

--- a/spec/system/legacy_content_contrast_spec.rb
+++ b/spec/system/legacy_content_contrast_spec.rb
@@ -9,9 +9,6 @@ RSpec.describe "Legacy content contrast" do
     person = create(:person)
     scenario = create(:scenario)
     play_session = create(:play_session, scenario:)
-    author = create(:author)
-    game_system = create(:game_system)
-    group = create(:group)
     user = create(:user)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
@@ -20,13 +17,11 @@ RSpec.describe "Legacy content contrast" do
 
     visit root_path
     click_button "Googleでログイン"
+    expect(page).to have_link(admin.display_name, href: person_path(admin))
 
     legacy_paths = [
       scenario_path(scenario), new_scenario_path, edit_scenario_path(scenario),
-      play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session),
-      authors_path, author_path(author), new_author_path, edit_author_path(author),
-      game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),
-      manage_groups_path, manage_group_path(group), edit_manage_group_path(group)
+      play_sessions_path, play_session_path(play_session), new_play_session_path, edit_play_session_path(play_session)
     ]
 
     legacy_paths.each do |path|

--- a/spec/system/master_management_responsive_spec.rb
+++ b/spec/system/master_management_responsive_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Responsive master management screens" do
+  it "keeps author, game system and group management accessible at supported widths" do
+    skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
+
+    admin = create(:person, roles: %w[admin gm], display_name: "管理者")
+    member = create(:person, display_name: "狭い画面でも折り返して表示できる長い人物名")
+    author = create(:author, name: "狭い画面でも折り返して表示できる長い作者名")
+    author.aliases.create!(name: "公開される作者の別名", visible: true)
+    game_system = create(:game_system, name: "狭い画面でも折り返して表示できる長いゲームシステム名")
+    group = create(:group, name: "狭い画面でも折り返して表示できる長いグループ名", people: [ member ])
+    user = create(:user, person: admin)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
+
+    visit root_path
+    click_button "Googleでログイン"
+    expect(page).to have_link(admin.display_name, href: person_path(admin))
+
+    paths = [
+      authors_path, author_path(author), new_author_path, edit_author_path(author),
+      game_systems_path, game_system_path(game_system), new_game_system_path, edit_game_system_path(game_system),
+      manage_groups_path, manage_group_path(group), edit_manage_group_path(group)
+    ]
+
+    [ 320, 768, 1280 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      paths.each do |path|
+        visit path
+        expect(page).to have_css('main[data-ui-theme="dark"]'), path
+        expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true), path
+        expect(page).to be_axe_clean
+      end
+      save_screenshot("master-management-#{width}.png") if ENV["VISUAL_REVIEW"]
+    end
+  ensure
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## Summary
- migrate author, game system, and group management screens to the Obsidian Glass UI
- reuse shared UI controls and the task 8 alias editor without changing legacy partials
- add responsive axe coverage for all task 9 routes at 320, 768, and 1280 px

## Testing
- `bin/rspec` (667 examples)
- `prek run --all-files`
- `CHROME_BINARY=... DISABLE_BOOTSNAP=1 bin/ci`

## Dependency
- Stacked on #124 (`ui-redesign-users-settings`)