### PR TITLE
Fix the phone header layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,12 @@ mise に Chrome 本体は無いため、Playwright から取る。
 
 ```bash
 mise exec -- npx playwright install chromium
-export CHROME_BINARY=$(echo ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome | tr ' ' '\n' | tail -1)
+CHROME_BINARY=$(ls -t ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome 2>/dev/null | head -1)
+[ -x "$CHROME_BINARY" ] && export CHROME_BINARY || echo "Chrome が見つからない。install からやり直す"
 bin/rspec spec/system/
 ```
+
+`CHROME_BINARY` に存在しないパスを入れると、spec は skip ではなく全件 Selenium の起動失敗になる。上のように実在を確かめてから export する。
 
 **`bin/rspec` は `app/assets/builds/tailwind.css` をそのまま読む。** 手元のビルドが古いと、テンプレートを直したのに spec は前の CSS で描画する。
 クラスを足したり消したりしたら、system spec の前に `bin/rails tailwindcss:build` を流す。CI は `assets:precompile` を挟むのでこの問題は起きない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,20 @@
 
 Ruby と Node は mise で固定している。shims を PATH に置いていない環境では `mise exec --` を頭に付ける。
 
+## ブラウザを使う spec
+
+`spec/system/` は Chrome が無いと skip する。見た目とアクセシビリティの確認はここにしか無いので、手元でも動かせるようにしておく。
+mise に Chrome 本体は無いため、Playwright から取る。
+
+```bash
+mise exec -- npx playwright install chromium
+export CHROME_BINARY=$(echo ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome | tr ' ' '\n' | tail -1)
+bin/rspec spec/system/
+```
+
+**`bin/rspec` は `app/assets/builds/tailwind.css` をそのまま読む。** 手元のビルドが古いと、テンプレートを直したのに spec は前の CSS で描画する。
+クラスを足したり消したりしたら、system spec の前に `bin/rails tailwindcss:build` を流す。CI は `assets:precompile` を挟むのでこの問題は起きない。
+
 ## データベースを変える
 
 ```bash

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,14 +30,14 @@
           TRPGカタログ
         <% end %>
 
-        <nav class="flex w-full min-w-0 flex-wrap items-center justify-start gap-2 text-sm sm:ml-auto sm:w-auto sm:justify-end" aria-label="主要">
+        <nav class="flex w-full min-w-0 flex-wrap items-center justify-end gap-2 text-sm sm:ml-auto sm:w-auto" aria-label="主要">
           <% if signed_in? %>
             <% if current_person %>
               <%= link_to person_path(current_person), class: "inline-flex min-h-11 max-w-40 items-center text-ui-text-muted underline" do %><span class="min-w-0 truncate"><%= current_person.display_name %></span><% end %>
             <% else %>
               <span class="text-ui-text-muted">未登録</span>
             <% end %>
-            <%= button_to "ログアウト", session_path, method: :delete,
+            <%= button_to "ログアウト", session_path, method: :delete, form: { class: "contents" },
               class: "min-h-11 cursor-pointer rounded-ui-control px-2 text-ui-text-muted underline hover:text-ui-text" %>
             <% if current_person %>
               <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#close">
@@ -69,14 +69,11 @@
           <% else %>
             <%= link_to "新規登録", new_registration_path,
               class: "inline-flex min-h-11 items-center rounded-ui-control px-2 font-bold text-ui-text underline" %>
+            <%# Google は管理者しか使わなくなったため、ヘッダーには出さず新規登録ページにだけ残す。 %>
             <%# Turbo はフォーム送信を横取りするが、provider への cross-origin リダイレクトを追えない。 %>
-            <%= button_to "Googleでログイン", "/auth/google_oauth2", method: :post,
-                  params: { origin: request.fullpath },
-                  form: { data: { turbo: false } },
-                  class: "min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle" %>
             <%= button_to "Discordでログイン", "/auth/discord", method: :post,
                   params: { origin: request.fullpath },
-                  form: { data: { turbo: false } },
+                  form: { class: "contents", data: { turbo: false } },
                   class: "min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle" %>
           <% end %>
         </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
               </div>
             <% end %>
           <% else %>
-            <%= link_to "新規登録", new_registration_path,
+            <%= link_to "新規登録", new_registration_path(origin: request.fullpath),
               class: "inline-flex min-h-11 items-center rounded-ui-control px-2 font-bold text-ui-text underline" %>
             <%# Google は管理者しか使わなくなったため、ヘッダーには出さず新規登録ページにだけ残す。 %>
             <%# Turbo はフォーム送信を横取りするが、provider への cross-origin リダイレクトを追えない。 %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,4 +1,6 @@
 <% content_for :title, "新規登録" %>
+<%# ここを origin にすると、ログイン成功後も「登録してください」の画面へ戻ってしまう。 %>
+<% return_to = params[:origin].to_s.start_with?("/") && !params[:origin].to_s.start_with?("//") ? params[:origin] : root_path %>
 
 <div class="mx-auto max-w-2xl space-y-6">
   <%= render "shared/ui/page_header", title: "新規登録" %>
@@ -8,8 +10,8 @@
     <p>なお、Googleアカウントの情報はこのサイト上では管理者以外の人に表示されることはありません。表示名は自由に設定できます。</p>
     <p>Discordでログインすると、連携済みサーバーへの参加状況をBot経由で確認します。他の参加サーバーの情報は取得しません。</p>
     <div class="grid gap-3 sm:grid-cols-2">
-      <%= form_with url: "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, request.fullpath %><%= ui_button("Google でログイン", type: "submit") %><% end %>
-      <%= form_with url: "/auth/discord", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, request.fullpath %><%= ui_button("Discord でログイン", variant: :secondary, type: "submit") %><% end %>
+      <%= form_with url: "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, return_to %><%= ui_button("Google でログイン", type: "submit") %><% end %>
+      <%= form_with url: "/auth/discord", method: :post, data: { turbo: false }, class: "contents" do %><%= hidden_field_tag :origin, return_to %><%= ui_button("Discord でログイン", variant: :secondary, type: "submit") %><% end %>
     </div>
   </section>
 </div>

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe "The sign-in button" do
 
     expect(response.body).to include(%(href="#{new_registration_path}"))
     expect(response.body).to include(">新規登録</a>")
-    expect(response.body).to include(">Googleでログイン</button>")
     expect(response.body).to include(">Discordでログイン</button>")
   end
 
   # Turbo はフォーム送信を fetch に置き換えるため、Google への cross-origin リダイレクトを
   # 追えず、押しても何も起きなくなる。ブラウザに素の送信をさせる必要がある。
   it "opts out of Turbo so the browser follows the redirect to Google" do
-    get root_path
+    get new_registration_path
 
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
 
@@ -25,7 +24,7 @@ RSpec.describe "The sign-in button" do
   # トークンそのものは test 環境が forgery protection を切っているため出ない。
   # 開始を POST に限る点は spec/requests/sessions_spec.rb が GET で 404 を返すことで固定している。
   it "submits over POST, so another site cannot start the flow with a link" do
-    get root_path
+    get new_registration_path
 
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2"[^>]*>}]
 
@@ -33,11 +32,12 @@ RSpec.describe "The sign-in button" do
   end
 
   it "passes the current URL through the sign-in flow" do
-    get root_path(order: "title_desc")
+    get new_registration_path
 
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
 
-    expect(form).to include(%(name="origin" value="/?order=title_desc"))
+    expect(form).to include(%(name="origin"))
+    expect(form).to include(%(value="#{new_registration_path}"))
   end
 
   # Chrome は form-action をリダイレクト先にも当てる。self だけだと押しても Google へ進めない。
@@ -55,7 +55,6 @@ RSpec.describe "The sign-in button" do
 
     get root_path
 
-    expect(response.body).not_to include('action="/auth/google_oauth2"')
     expect(response.body).not_to include('action="/auth/discord"')
     expect(response.body).not_to include(%(href="#{new_registration_path}"))
   end

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "The sign-in button" do
   it "shows separate registration and sign-in actions to signed-out visitors" do
     get root_path
 
-    expect(response.body).to include(%(href="#{new_registration_path}"))
+    # 元いた画面へ戻すため origin を引き継ぐ。
+    expect(response.body).to include(%(href="#{new_registration_path}?origin=%2F"))
     expect(response.body).to include(">新規登録</a>")
     expect(response.body).to include(">Discordでログイン</button>")
   end
@@ -32,12 +33,27 @@ RSpec.describe "The sign-in button" do
   end
 
   it "passes the current URL through the sign-in flow" do
-    get new_registration_path
+    # 動的に変わるのはヘッダーの Discord と、新規登録ページが引き継ぐ origin の 2 つ。
+    get root_path(order: "title_desc")
+
+    form = response.body[%r{<form[^>]*action="/auth/discord".*?</form>}m]
+
+    expect(form).to include(%(name="origin" value="/?order=title_desc"))
+
+    get new_registration_path(origin: "/?order=title_desc")
+
+    google = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
+
+    expect(google).to include(%(value="/?order=title_desc"))
+  end
+
+  it "ignores an origin that points off-site" do
+    get new_registration_path(origin: "//evil.example.com/")
 
     form = response.body[%r{<form[^>]*action="/auth/google_oauth2".*?</form>}m]
 
-    expect(form).to include(%(name="origin"))
-    expect(form).to include(%(value="#{new_registration_path}"))
+    expect(form).to include(%(value="#{root_path}"))
+    expect(form).not_to include("evil.example.com")
   end
 
   # Chrome は form-action をリダイレクト先にも当てる。self だけだと押しても Google へ進めない。
@@ -56,6 +72,6 @@ RSpec.describe "The sign-in button" do
     get root_path
 
     expect(response.body).not_to include('action="/auth/discord"')
-    expect(response.body).not_to include(%(href="#{new_registration_path}"))
+    expect(response.body).not_to include(new_registration_path)
   end
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -12,8 +12,22 @@ module AuthenticationHelpers
   end
 end
 
+module SystemAuthenticationHelpers
+  # ヘッダーに出すのは Discord だけになったため、Google は新規登録ページから開始する。
+  def sign_in_with_google
+    visit new_registration_path
+    click_button "Google でログイン"
+    # click_button も visit も遷移の完了を待たない。ここで着地を待たないと、
+    # 後から届くリダイレクトが次の visit を上書きする。
+    expect(page).to have_content("ログインしました")
+    # origin が新規登録ページになるため、従来どおり一覧から始められるよう戻す。
+    visit root_path
+  end
+end
+
 RSpec.configure do |config|
   config.include AuthenticationHelpers, type: :request
+  config.include SystemAuthenticationHelpers, type: :system
   config.after(type: :request) do
     User::PROVIDERS.each_key { |provider| OmniAuth.config.mock_auth[provider.to_sym] = nil }
     OmniAuth.config.test_mode = false

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -17,11 +17,10 @@ module SystemAuthenticationHelpers
   def sign_in_with_google
     visit new_registration_path
     click_button "Google でログイン"
-    # click_button も visit も遷移の完了を待たない。ここで着地を待たないと、
-    # 後から届くリダイレクトが次の visit を上書きする。
+    # click_button は遷移の完了を待たない。DOM で待つと認証のリダイレクト途中の
+    # 差し替えに当たり、Selenium が stale node で落ちる。URL で着地を待つ。
+    expect(page).to have_current_path(root_path, wait: 10)
     expect(page).to have_content("ログインしました")
-    # origin が新規登録ページになるため、従来どおり一覧から始められるよう戻す。
-    visit root_path
   end
 end
 

--- a/spec/system/application_shell_spec.rb
+++ b/spec/system/application_shell_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe "Application shell" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     [ 320, 768, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)
@@ -32,5 +31,34 @@ RSpec.describe "Application shell" do
   ensure
     OmniAuth.config.mock_auth[:google_oauth2] = nil
     OmniAuth.config.test_mode = false
+  end
+
+  # button_to の form は block box を作るため、放置すると 1 つずつ行を占有して
+  # 3 段になり、右寄せも効かなくなる。行数と右端で固定する。
+  it "keeps the signed-out header actions on one right-aligned row on a phone" do
+    skip "Chrome is required for viewport checks" unless ENV["CHROME_BINARY"].present?
+
+    [ 320, 390 ].each do |width|
+      page.current_window.resize_to(width, 900)
+      visit root_path
+
+      geometry = page.evaluate_script(<<~JS)
+        (function () {
+          var nav = document.querySelector('header nav[aria-label="主要"]');
+          var items = [].slice.call(nav.querySelectorAll('a, button'));
+          var tops = items.map(function (e) { return Math.round(e.getBoundingClientRect().top); });
+          var rights = items.map(function (e) { return Math.round(e.getBoundingClientRect().right); });
+          return { rows: tops.filter(function (t, i) { return tops.indexOf(t) === i; }).length,
+                   right: Math.max.apply(null, rights) };
+        })()
+      JS
+
+      expect(geometry["rows"]).to eq(1), "#{width}px で操作が #{geometry["rows"]} 段になっている"
+      expect(geometry["right"]).to be_within(1).of(width - 16),
+        "#{width}px で右端が #{geometry["right"]} にあり右寄せになっていない"
+    end
+  ensure
+    # 幅を戻さないと、同じセッションを使う後続の example が狭いままになる。
+    page.current_window.resize_to(1280, 900)
   end
 end

--- a/spec/system/application_shell_spec.rb
+++ b/spec/system/application_shell_spec.rb
@@ -35,30 +35,60 @@ RSpec.describe "Application shell" do
 
   # button_to の form は block box を作るため、放置すると 1 つずつ行を占有して
   # 3 段になり、右寄せも効かなくなる。行数と右端で固定する。
-  it "keeps the signed-out header actions on one right-aligned row on a phone" do
+  it "keeps the header actions on one right-aligned row on a phone" do
     skip "Chrome is required for viewport checks" unless ENV["CHROME_BINARY"].present?
 
-    [ 320, 390 ].each do |width|
-      page.current_window.resize_to(width, 900)
-      visit root_path
+    person = create(:person, display_name: "カーリア")
+    user = create(:user, person: person)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
+    )
 
-      geometry = page.evaluate_script(<<~JS)
-        (function () {
-          var nav = document.querySelector('header nav[aria-label="主要"]');
-          var items = [].slice.call(nav.querySelectorAll('a, button'));
-          var tops = items.map(function (e) { return Math.round(e.getBoundingClientRect().top); });
-          var rights = items.map(function (e) { return Math.round(e.getBoundingClientRect().right); });
-          return { rows: tops.filter(function (t, i) { return tops.indexOf(t) === i; }).length,
-                   right: Math.max.apply(null, rights) };
-        })()
-      JS
+    begin
+      [ 320, 390 ].each do |width|
+        page.current_window.resize_to(width, 900)
 
-      expect(geometry["rows"]).to eq(1), "#{width}px で操作が #{geometry["rows"]} 段になっている"
-      expect(geometry["right"]).to be_within(1).of(width - 16),
-        "#{width}px で右端が #{geometry["right"]} にあり右寄せになっていない"
+        visit root_path
+        expect_single_right_aligned_row(width, "未ログイン")
+
+        sign_in_with_google
+        page.current_window.resize_to(width, 900)
+        visit root_path
+        expect_right_aligned(width, "ログイン済み")
+
+        click_button "ログアウト"
+        expect(page).to have_link("新規登録")
+      end
+    ensure
+      page.current_window.resize_to(1280, 900)
     end
-  ensure
-    # 幅を戻さないと、同じセッションを使う後続の example が狭いままになる。
-    page.current_window.resize_to(1280, 900)
+  end
+
+  # 高さが違う要素は items-center で top がずれるため、行の判定は中心線で行う。
+  def expect_single_right_aligned_row(width, label)
+    expect_right_aligned(width, label, rows: 1)
+  end
+
+  def expect_right_aligned(width, label, rows: nil)
+    geometry = page.evaluate_script(<<~JS)
+      (function () {
+        var nav = document.querySelector('header nav[aria-label="主要"]');
+        var items = [].slice.call(nav.querySelectorAll('a, button'));
+        var centers = items.map(function (e) {
+          var b = e.getBoundingClientRect();
+          return Math.round((b.top + b.bottom) / 2 / 10);
+        });
+        var rights = items.map(function (e) { return Math.round(e.getBoundingClientRect().right); });
+        return { rows: centers.filter(function (c, i) { return centers.indexOf(c) === i; }).length,
+                 right: Math.max.apply(null, rights),
+                 inner: window.innerWidth };
+      })()
+    JS
+
+    expect(geometry["rows"]).to eq(rows),
+      "#{width}px の#{label}ヘッダーで操作が #{geometry["rows"]} 段になっている" if rows
+    expect(geometry["right"]).to be_within(1).of(geometry["inner"] - 16),
+      "#{width}px の#{label}ヘッダーで右端が #{geometry["right"]}（幅 #{geometry["inner"]}）にあり右寄せになっていない"
   end
 end

--- a/spec/system/browsing_scenarios_spec.rb
+++ b/spec/system/browsing_scenarios_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe "Browsing scenarios" do
       OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
         provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
       )
-      visit root_path
-      click_button "Googleでログイン"
+      sign_in_with_google
       page.current_window.resize_to(320, 900)
       visit scenario_path(scenario)
       expect(page).to have_content("GMからのおすすめ情報")

--- a/spec/system/cross_screen_audit_spec.rb
+++ b/spec/system/cross_screen_audit_spec.rb
@@ -226,8 +226,7 @@ RSpec.describe "Cross-screen audit" do
       OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
         provider: "google_oauth2", uid: audit[:admin_user].google_uid, info: { email: audit[:admin_user].email }
       )
-      visit root_path
-      click_button "Googleでログイン"
+      sign_in_with_google
       expect(page).to have_link(audit[:admin].display_name)
     end
 

--- a/spec/system/editor_navigation_spec.rb
+++ b/spec/system/editor_navigation_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe "Editor navigation" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
     expect(page).to be_axe_clean.excluding("#main-content") if ENV["CHROME_BINARY"].present?
     save_screenshot("editor-scenarios.png") if ENV["VISUAL_REVIEW"]
     if ENV["CHROME_BINARY"]

--- a/spec/system/manage_users_settings_responsive_spec.rb
+++ b/spec/system/manage_users_settings_responsive_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe "Responsive user and site-setting screens" do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
       provider: "google_oauth2", uid: current_user.google_uid, info: { email: current_user.email }
     )
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     paths = [ manage_users_path, manage_user_path(user), edit_manage_user_path(user), manage_site_setting_path, edit_manage_site_setting_path ]
     [ 320, 768, 1280 ].each do |width|

--- a/spec/system/master_management_responsive_spec.rb
+++ b/spec/system/master_management_responsive_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe "Responsive master management screens" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
     expect(page).to have_link(admin.display_name, href: person_path(admin))
 
     paths = [

--- a/spec/system/people_responsive_spec.rb
+++ b/spec/system/people_responsive_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "Responsive people and registration screens" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     [ 320, 768, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)

--- a/spec/system/play_session_form_responsive_spec.rb
+++ b/spec/system/play_session_form_responsive_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe "Responsive play session forms" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     [ new_play_session_path, edit_play_session_path(play_session) ].each do |path|
       [ 320, 768, 1280 ].each do |width|

--- a/spec/system/play_sessions_responsive_spec.rb
+++ b/spec/system/play_sessions_responsive_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe "Responsive play session screens" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     [ 320, 768, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)

--- a/spec/system/profile_and_spoiler_spec.rb
+++ b/spec/system/profile_and_spoiler_spec.rb
@@ -11,12 +11,7 @@ RSpec.describe "A member's own pages" do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
-    visit root_path
-    click_button "Googleでログイン"
-    # click_button も visit も遷移の完了を待たないため、ここで着地を待たないと
-    # 後から届いたログインのリダイレクトが次の visit を上書きする。
-    expect(page).to have_content("ログインしました")
-
+    sign_in_with_google
     visit edit_person_path(person)
     fill_in "person[x_account]", with: "karia"
     # 既存の別名の行が出ていること自体も確かめる。

--- a/spec/system/scenario_form_responsive_spec.rb
+++ b/spec/system/scenario_form_responsive_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe "Responsive scenario forms" do
       provider: "google_oauth2", uid: user.google_uid, info: { email: user.email }
     )
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
 
     [ new_scenario_path, edit_scenario_path(scenario) ].each do |path|
       [ 320, 768, 1280 ].each do |width|

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe "Responsive scenario lists" do
       save_screenshot("scenario-gallery-#{width}.png") if ENV["VISUAL_REVIEW"]
     end
 
-    visit root_path
-    click_button "Googleでログイン"
+    sign_in_with_google
     [ 320, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)
       visit root_path


### PR DESCRIPTION
## What

Drop the Google sign-in button from the header, and stop the remaining `button_to` forms from taking a whole row each.

## Why

On a phone the signed-out header wrapped onto three rows and the actions sat on the left, pushing the scenario list down the page.

Removing the Google button was the ask — it is turning into an admin-only route, and the registration page already carries it. But it was not the cause. `button_to` wraps its button in a `<form>`, and that form is a block-level flex item, so **each login control claimed a full-width row on its own** and `justify-end` could not take effect. `form: { class: "contents" }` removes the box so the button itself becomes the flex item.

Measured on the signed-out home page with a real browser:

| | 320px | 390px |
| --- | --- | --- |
| before | 3 rows, header 177px, actions from x=16 | 3 rows, header 177px, actions from x=16 |
| after | 1 row, header 125px, right edge at 304 | 1 row, header 125px, right edge at 374 |

`spec/system/application_shell_spec.rb` now pins both the row count and the right edge at those widths, so a future `button_to` in the header fails instead of silently wrapping.

## Notes

Twelve system specs signed in by clicking the header's Google button, so they now go through the registration page via a `sign_in_with_google` helper. The helper waits for the flash before navigating on — `click_button` and `visit` both return before the redirect lands, which is what `profile_and_spoiler_spec` was working around locally. That workaround moved into the helper and now covers all twelve.

`spec/requests/sign_in_button_spec.rb` keeps every Google-specific guarantee (Turbo opt-out, POST-only, origin passthrough, CSP form-action); the assertions just point at the registration page now.

`CLAUDE.md` gains the Chrome setup for `spec/system/`, plus the note that `bin/rspec` reads a stale `app/assets/builds/tailwind.css` unless you rebuild first — that bit me while measuring this change.

## Verification

- [x] `bin/rspec` — 679 examples, 0 failures, with `CHROME_BINARY` set so the system specs actually run
- [x] `prek run --all-files`
