### PR TITLE
Show the character sheet deadline before its note

### DIFF
--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -19,7 +19,7 @@
       <%= ui_field(form, :duration_max_hours, label: "目安時間（時間・最大）") do |field| %><%= ui_input(form, :duration_max_hours, type: :number, step: 0.5, min: 0.5, described_by: field[:described_by]) %><% end %>
       <%= ui_field(form, :character_restriction, label: "参加可能キャラの制限") do |field| %><%= ui_input(form, :character_restriction, described_by: field[:described_by]) %><% end %>
       <%= ui_field(form, :character_sheet_deadline, label: "キャラシ提出期限") do |field| %><%= ui_select(form, :character_sheet_deadline, Scenario.character_sheet_deadlines.keys.map { |key| [ t("scenarios.character_sheet_deadlines.#{key}"), key ] }, include_blank: "未設定", described_by: field[:described_by]) %><% end %>
-      <%= ui_field(form, :character_sheet_deadline_note, label: "キャラシ提出期限の補足", description: "選択肢に当てはまらない場合に書きます。入力すると選択肢より優先して表示されます。") do |field| %><%= ui_input(form, :character_sheet_deadline_note, described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :character_sheet_deadline_note, label: "キャラシ提出期限の補足", description: "選択肢に当てはまらない場合は、上で「備考参照」を選んでからここに書きます。詳細画面では選択肢とこの補足の両方が出ます。") do |field| %><%= ui_input(form, :character_sheet_deadline_note, described_by: field[:described_by]) %><% end %>
     </div>
   </fieldset>
 

--- a/app/views/manage/scenarios/_form.html.erb
+++ b/app/views/manage/scenarios/_form.html.erb
@@ -18,8 +18,8 @@
       <%= ui_field(form, :duration_min_hours, label: "目安時間（時間・最小）") do |field| %><%= ui_input(form, :duration_min_hours, type: :number, step: 0.5, min: 0.5, described_by: field[:described_by]) %><% end %>
       <%= ui_field(form, :duration_max_hours, label: "目安時間（時間・最大）") do |field| %><%= ui_input(form, :duration_max_hours, type: :number, step: 0.5, min: 0.5, described_by: field[:described_by]) %><% end %>
       <%= ui_field(form, :character_restriction, label: "参加可能キャラの制限") do |field| %><%= ui_input(form, :character_restriction, described_by: field[:described_by]) %><% end %>
-      <%= ui_field(form, :character_sheet_deadline_note, label: "キャラシ提出期限の補足", description: "選択肢に当てはまらない場合に書きます。入力すると選択肢より優先して表示されます。") do |field| %><%= ui_input(form, :character_sheet_deadline_note, described_by: field[:described_by]) %><% end %>
       <%= ui_field(form, :character_sheet_deadline, label: "キャラシ提出期限") do |field| %><%= ui_select(form, :character_sheet_deadline, Scenario.character_sheet_deadlines.keys.map { |key| [ t("scenarios.character_sheet_deadlines.#{key}"), key ] }, include_blank: "未設定", described_by: field[:described_by]) %><% end %>
+      <%= ui_field(form, :character_sheet_deadline_note, label: "キャラシ提出期限の補足", description: "選択肢に当てはまらない場合に書きます。入力すると選択肢より優先して表示されます。") do |field| %><%= ui_input(form, :character_sheet_deadline_note, described_by: field[:described_by]) %><% end %>
     </div>
   </fieldset>
 

--- a/spec/requests/manage/scenarios_spec.rb
+++ b/spec/requests/manage/scenarios_spec.rb
@@ -1,6 +1,20 @@
 require "rails_helper"
 
 RSpec.describe "Manage::Scenarios" do
+  # 補足は「選択肢に当てはまらない場合」の話なので、選択肢より後に出さないと読めない。
+  it "puts the character sheet deadline before the note that qualifies it" do
+    sign_in_as create(:person, roles: %w[gm])
+
+    get new_scenario_path
+
+    deadline = response.body.index(%(for="scenario_character_sheet_deadline"))
+    note = response.body.index(%(for="scenario_character_sheet_deadline_note"))
+
+    expect(deadline).to be_present
+    expect(note).to be_present
+    expect(deadline).to be < note
+  end
+
   describe "without a signed-in editor" do
     it "answers 404 to an anonymous visitor" do
       get scenario_order_index_path


### PR DESCRIPTION
The scenario form put 「キャラシ提出期限の補足」 above 「キャラシ提出期限」. The note describes itself as「選択肢に当てはまらない場合に書きます」, so it was asking about choices the reader had not been shown yet.

Swapped the two fields. A request spec pins the order by the label `for` attributes, so putting the note back on top fails.

## Verification

- [x] `bin/rspec` — 681 examples, 0 failures, with `CHROME_BINARY` set
- [x] `prek run --all-files`

Checked the rest of the form: `recommendation_note` and `preparation_note` are standalone body fields, not notes qualifying a preceding input, so their positions are fine.