### PR TITLE
Audit signed-out visitor screens

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,8 +67,7 @@
               </div>
             <% end %>
           <% else %>
-            <%= link_to "新規登録", new_registration_path(origin: request.fullpath),
-              class: "inline-flex min-h-11 items-center rounded-ui-control px-2 font-bold text-ui-text underline" %>
+            <%= ui_button_link("新規登録", href: new_registration_path(origin: request.fullpath), variant: :secondary, size: :small) %>
             <%# Google は管理者しか使わなくなったため、ヘッダーには出さず新規登録ページにだけ残す。 %>
             <%# Turbo はフォーム送信を横取りするが、provider への cross-origin リダイレクトを追えない。 %>
             <%= button_to "Discordでログイン", "/auth/discord", method: :post,

--- a/spec/system/cross_screen_audit_spec.rb
+++ b/spec/system/cross_screen_audit_spec.rb
@@ -88,47 +88,25 @@ RSpec.describe "Cross-screen audit" do
   let(:audit) { build_audit_fixtures }
 
   it "gives every screen a large enough target for each control" do
+    offenders = target_size_offenders(signed_out_screens)
     sign_in_as_admin
-
-    offenders = [ 320, 1280 ].flat_map do |width|
-      page.current_window.resize_to(width, 900)
-      every_screen.flat_map do |path|
-        visit path
-        page.evaluate_script(CrossScreenAudit::SMALL_TARGETS).map { |control| "#{path} at #{width}px: #{control}" }
-      end
-    end
+    offenders.concat(target_size_offenders(every_screen))
 
     expect(offenders.uniq).to be_empty, "targets under 44px:\n#{offenders.uniq.join("\n")}"
   end
 
   it "keeps a visible focus indicator on every control the keyboard can reach" do
+    unindicated = focus_offenders(signed_out_screens)
     sign_in_as_admin
-    page.current_window.resize_to(1280, 900)
-
-    unindicated = every_screen.flat_map do |path|
-      visit path
-      start_from_the_top_of(path)
-      walk_with_tab(path).reject { |stop| stop.fetch("indicated") }
-        .map { |stop| "#{path}: #{stop['tag']} #{stop['name']}" }
-    end
+    unindicated.concat(focus_offenders(every_screen))
 
     expect(unindicated.uniq).to be_empty, "controls without a focus indicator:\n#{unindicated.uniq.join("\n")}"
   end
 
   it "starts every screen at the skip link and moves focus into the main landmark" do
+    audit_skip_links(signed_out_screens)
     sign_in_as_admin
-    page.current_window.resize_to(1280, 900)
-
-    every_screen.each do |path|
-      visit path
-      start_from_the_top_of(path)
-      press_tab
-      expect(page).to have_css('a[href="#main-content"]:focus'), path
-      expect(page.evaluate_script("document.activeElement.getBoundingClientRect().top")).to be >= 0, path
-
-      page.driver.browser.action.send_keys(:enter).perform
-      expect(page).to have_css("main#main-content:focus"), path
-    end
+    audit_skip_links(every_screen)
   end
 
   it "opens and closes the account menu from the keyboard alone" do
@@ -149,15 +127,9 @@ RSpec.describe "Cross-screen audit" do
   end
 
   it "draws every list, detail and form action with the shared button component" do
+    actions = named_actions(signed_out_screens)
     sign_in_as_admin
-    page.current_window.resize_to(1280, 900)
-
-    actions = every_screen.flat_map do |path|
-      visit path
-      page.evaluate_script(CrossScreenAudit::NAMED_CONTROLS)
-        .select { |control| CrossScreenAudit::ACTION_LABELS.include?(control.fetch("name")) }
-        .map { |control| control.merge("path" => path) }
-    end
+    actions.concat(named_actions(every_screen))
 
     expect(actions.map { |control| control.fetch("name") }.uniq).to match_array(CrossScreenAudit::ACTION_LABELS)
 
@@ -205,6 +177,54 @@ RSpec.describe "Cross-screen audit" do
   end
 
   private
+    def signed_out_screens
+      [ root_path, new_registration_path ]
+    end
+
+    def target_size_offenders(paths)
+      [ 320, 1280 ].flat_map do |width|
+        page.current_window.resize_to(width, 900)
+        paths.flat_map do |path|
+          visit path
+          page.evaluate_script(CrossScreenAudit::SMALL_TARGETS).map { |control| "#{path} at #{width}px: #{control}" }
+        end
+      end
+    end
+
+    def focus_offenders(paths)
+      page.current_window.resize_to(1280, 900)
+      paths.flat_map do |path|
+        visit path
+        start_from_the_top_of(path)
+        walk_with_tab(path).reject { |stop| stop.fetch("indicated") }
+          .map { |stop| "#{path}: #{stop['tag']} #{stop['name']}" }
+      end
+    end
+
+    def audit_skip_links(paths)
+      page.current_window.resize_to(1280, 900)
+      paths.each do |path|
+        visit path
+        start_from_the_top_of(path)
+        press_tab
+        expect(page).to have_css('a[href="#main-content"]:focus'), path
+        expect(page.evaluate_script("document.activeElement.getBoundingClientRect().top")).to be >= 0, path
+
+        page.driver.browser.action.send_keys(:enter).perform
+        expect(page).to have_css("main#main-content:focus"), path
+      end
+    end
+
+    def named_actions(paths)
+      page.current_window.resize_to(1280, 900)
+      paths.flat_map do |path|
+        visit path
+        page.evaluate_script(CrossScreenAudit::NAMED_CONTROLS)
+          .select { |control| CrossScreenAudit::ACTION_LABELS.include?(control.fetch("name")) }
+          .map { |control| control.merge("path" => path) }
+      end
+    end
+
     def every_screen
       @every_screen ||= begin
         records = audit

--- a/spec/system/cross_screen_audit_spec.rb
+++ b/spec/system/cross_screen_audit_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "Cross-screen audit" do
 
   before do
     skip "Chrome is required for the cross-screen audit" unless ENV["CHROME_BINARY"].present?
+    audit
   end
 
   after do

--- a/spec/system/cross_screen_audit_spec.rb
+++ b/spec/system/cross_screen_audit_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe "Cross-screen audit" do
 
   private
     def signed_out_screens
-      [ root_path, new_registration_path ]
+      [ root_path, root_path(view: "gallery"), new_registration_path ]
     end
 
     def target_size_offenders(paths)


### PR DESCRIPTION
## Summary

- include the public scenario list and registration page in target-size, focus, skip-link, and shared-action audits before signing in
- render the signed-out registration action through the shared button component

Closes #136

## Dependency

Stacked on #139 so newly covered screens use the corrected fail-closed audit. Retarget to `main` after #139 merges.

## Verification

- `bin/rails tailwindcss:build`
- Chrome-backed cross-screen and application-shell specs: 10 examples, 0 failures
- `bin/rspec`: 684 examples, 0 failures
- `prek run --all-files`
- commit-range gitleaks: no leaks