### PR TITLE
Preserve scenario filter panel state

### DIFF
--- a/app/javascript/controllers/filter_panel_controller.js
+++ b/app/javascript/controllers/filter_panel_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  preserveOpenState(event) {
+    const replacement = event.detail.newFrame.querySelector(`[data-filter-panel-key="${this.element.dataset.filterPanelKey}"]`)
+
+    if (replacement) replacement.open = this.element.open
+  }
+}

--- a/app/views/shared/ui/_filter_panel.html.erb
+++ b/app/views/shared/ui/_filter_panel.html.erb
@@ -1,4 +1,6 @@
-<details class="group rounded-ui-surface border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface">
+<details class="group rounded-ui-surface border border-ui-outline bg-ui-surface-solid supports-[backdrop-filter:blur(1px)]:bg-ui-surface supports-[backdrop-filter:blur(1px)]:backdrop-blur-ui-surface"
+         data-controller="filter-panel" data-filter-panel-key="<%= local_assigns.fetch(:key, "default") %>"
+         data-action="turbo:before-frame-render@document->filter-panel#preserveOpenState">
   <summary class="flex min-h-11 cursor-pointer items-center justify-between px-4 py-3 text-sm font-bold text-ui-text marker:content-none">
     <%= title %><span aria-hidden="true" class="text-ui-text-muted group-open:rotate-180">⌄</span>
   </summary>

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe "Responsive scenario lists" do
+  it "keeps the filter panel open while authors are added and removed" do
+    skip "Chrome is required for Turbo interaction checks" unless ENV["CHROME_BINARY"].present?
+
+    author = create(:author, name: "追加する作者")
+    create(:scenario, title: "作者で探せるシナリオ", authors: [ author ])
+
+    visit root_path
+    find("summary", text: "絞り込み").click
+    fill_in "作者を追加", with: author.name
+    find_field("作者を追加").send_keys(:tab)
+
+    expect(page).to have_css("details[open]", text: "絞り込み")
+    expect(page).to have_css(%(a[aria-label="#{author.name}を解除"]))
+
+    find(%(a[aria-label="#{author.name}を解除"])).click
+
+    expect(page).to have_css("details[open]", text: "絞り込み")
+    expect(page).to have_no_css(%(a[aria-label="#{author.name}を解除"]))
+  end
+
   it "reflows both list modes and ordering without horizontal controls" do
     skip "Chrome is required for viewport and axe checks" unless ENV["CHROME_BINARY"].present?
 


### PR DESCRIPTION
## What

Preserve the expanded filter panel across Turbo Frame updates.

## Why

Adding or removing authors should not collapse the multi-select filter controls.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `CHROME_BINARY=... bin/rspec spec/system/scenario_list_responsive_spec.rb spec/system/cross_screen_audit_spec.rb`
- [x] `DISABLE_BOOTSNAP=1 bin/ci`

## Related

Closes #141

ADR-0002