### PR TITLE
Move logout into the account menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,35 +37,35 @@
             <% else %>
               <span class="text-ui-text-muted">未登録</span>
             <% end %>
-            <%= button_to "ログアウト", session_path, method: :delete, form: { class: "contents" },
-              class: "min-h-11 cursor-pointer rounded-ui-control px-2 text-ui-text-muted underline hover:text-ui-text" %>
-            <% if current_person %>
-              <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#close">
+            <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#close">
                 <button type="button" aria-controls="account-menu" aria-expanded="false"
                         data-dropdown-target="button" data-action="dropdown#toggle"
                         class="min-h-11 cursor-pointer rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid px-3 py-2 font-bold text-ui-text hover:bg-ui-subtle">
                   メニュー
                 </button>
-                <% account_items = [
-                  { label: Scenario.model_name.human, path: scenarios_path },
-                  { label: PlaySession.model_name.human, path: play_sessions_path },
-                  { label: Person.model_name.human, path: people_path },
-                  { label: GameSystem.model_name.human, path: game_systems_path },
-                  { label: Author.model_name.human, path: authors_path }
-                ] %>
-                <% account_items << { label: "#{Scenario.model_name.human}の並び順", path: scenario_order_index_path } if policy(Scenario).reorder? %>
-                <% if current_person.admin? %>
+                <% account_items = [] %>
+                <% if current_person %>
                   <% account_items.concat([
-                    { label: Group.model_name.human, path: manage_groups_path },
-                    { label: User.model_name.human, path: manage_users_path },
-                    { label: SiteSetting.model_name.human, path: manage_site_setting_path }
+                    { label: Scenario.model_name.human, path: scenarios_path },
+                    { label: PlaySession.model_name.human, path: play_sessions_path },
+                    { label: Person.model_name.human, path: people_path },
+                    { label: GameSystem.model_name.human, path: game_systems_path },
+                    { label: Author.model_name.human, path: authors_path }
                   ]) %>
+                  <% account_items << { label: "#{Scenario.model_name.human}の並び順", path: scenario_order_index_path } if policy(Scenario).reorder? %>
+                  <% if current_person.admin? %>
+                    <% account_items.concat([
+                      { label: Group.model_name.human, path: manage_groups_path },
+                      { label: User.model_name.human, path: manage_users_path },
+                      { label: SiteSetting.model_name.human, path: manage_site_setting_path }
+                    ]) %>
+                  <% end %>
                 <% end %>
+                <% account_items << { label: "ログアウト", path: session_path, method: :delete, variant: :danger } %>
                 <%= render "shared/ui/navigation", id: "account-menu", label: "#{User.model_name.human}メニュー",
                   items: account_items, hidden: true,
                   data: { dropdown_target: "menu" } %>
-              </div>
-            <% end %>
+            </div>
           <% else %>
             <%= ui_button_link("新規登録", href: new_registration_path(origin: request.fullpath), variant: :secondary, size: :small) %>
             <%# Google は管理者しか使わなくなったため、ヘッダーには出さず新規登録ページにだけ残す。 %>

--- a/app/views/shared/ui/_navigation.html.erb
+++ b/app/views/shared/ui/_navigation.html.erb
@@ -2,8 +2,14 @@
       data: local_assigns.fetch(:data, {}),
       class: "absolute top-full right-0 z-[var(--z-ui-overlay)] mt-2 grid w-[min(18rem,calc(100vw-2rem))] gap-1 rounded-ui-control border border-ui-outline-strong bg-ui-surface-solid p-2 shadow-ui-surface" do %>
   <% items.each do |item| %>
-    <% current = item.fetch(:current) { current_page?(item[:path]) } %>
-    <%= link_to item[:label], item[:path], aria: { current: ("page" if current) },
-      class: "inline-flex min-h-11 items-center rounded-ui-control px-3 py-2 text-sm font-bold no-underline #{current ? 'bg-ui-action text-ui-on-action' : 'text-ui-text hover:bg-ui-subtle'}" %>
+    <% if item[:method] %>
+      <% variant_classes = item[:variant] == :danger ? "text-ui-error hover:bg-ui-subtle" : "text-ui-text hover:bg-ui-subtle" %>
+      <%= button_to item[:label], item[:path], method: item[:method], form: { class: "contents" },
+        class: "inline-flex min-h-11 w-full cursor-pointer items-center rounded-ui-control px-3 py-2 text-sm font-bold #{variant_classes}" %>
+    <% else %>
+      <% current = item.fetch(:current) { current_page?(item[:path]) } %>
+      <%= link_to item[:label], item[:path], aria: { current: ("page" if current) },
+        class: "inline-flex min-h-11 items-center rounded-ui-control px-3 py-2 text-sm font-bold no-underline #{current ? 'bg-ui-action text-ui-on-action' : 'text-ui-text hover:bg-ui-subtle'}" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/requests/manage/navigation_spec.rb
+++ b/spec/requests/manage/navigation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Manage navigation" do
   end
 
   describe "the header" do
-    it "puts the menu after the profile and sign-out controls and uses a popover" do
+    it "puts the menu after the profile and sign-out at the bottom of the popover" do
       person = create(:person)
       sign_in_as person
 
@@ -79,7 +79,7 @@ RSpec.describe "Manage navigation" do
       expect(page).to have_css('nav#account-menu[hidden][aria-label="アカウントメニュー"]', visible: :all)
       expect(page).to have_css("nav#account-menu.rounded-ui-control.bg-ui-surface-solid", visible: :all)
       expect(response.body.index(person.display_name)).to be < response.body.index("account-menu")
-      expect(response.body.index("ログアウト")).to be < response.body.index("account-menu")
+      expect(page).to have_css("nav#account-menu > form:last-child button.text-ui-error", text: "ログアウト", visible: :all)
     end
 
     it "offers the manage area to an editor" do

--- a/spec/requests/sign_in_button_spec.rb
+++ b/spec/requests/sign_in_button_spec.rb
@@ -73,5 +73,6 @@ RSpec.describe "The sign-in button" do
 
     expect(response.body).not_to include('action="/auth/discord"')
     expect(response.body).not_to include(new_registration_path)
+    expect(Capybara.string(response.body)).to have_button("ログアウト", visible: :all)
   end
 end

--- a/spec/system/application_shell_spec.rb
+++ b/spec/system/application_shell_spec.rb
@@ -56,8 +56,14 @@ RSpec.describe "Application shell" do
         page.current_window.resize_to(width, 900)
         visit root_path
         expect_right_aligned(width, "ログイン済み")
+        expect(page).to have_no_css('header nav[aria-label="主要"] > form')
 
-        click_button "ログアウト"
+        click_button "メニュー"
+        account_menu = find("#account-menu")
+        expect(account_menu.all("a, button").last.text).to eq("ログアウト")
+        expect(account_menu).to have_css("button.text-ui-error", text: "ログアウト")
+
+        account_menu.click_button "ログアウト"
         expect(page).to have_link("新規登録")
       end
     ensure


### PR DESCRIPTION
## What

Move logout to the final account-menu item and style it as a danger action.

## Why

Keeping logout out of the header prevents signed-in actions from wrapping on narrow phones and reduces accidental activation beside navigation items.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `CHROME_BINARY=... bin/rspec spec/system/application_shell_spec.rb spec/system/cross_screen_audit_spec.rb spec/requests/sign_in_button_spec.rb`
- [x] `DISABLE_BOOTSNAP=1 bin/ci`

## Related

Closes #142

ADR-0002