### PR TITLE
Shrink the scenario sort selector

### DIFF
--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -56,7 +56,7 @@
     <% end %>
 
     <% if @scenarios.any? %>
-      <%= form_with url: root_path, method: :get, class: "grid gap-2 sm:grid-cols-[auto_minmax(12rem,24rem)_auto] sm:items-center sm:justify-end" do |form| %>
+      <%= form_with url: root_path, method: :get, class: "grid gap-2 sm:grid-cols-[auto_auto_auto] sm:items-center sm:justify-end" do |form| %>
         <% @listing.params(order: nil).each do |key, value| %><% Array(value).each do |item| %><%= hidden_field_tag key.to_s.end_with?("_ids") ? "#{key}[]" : key, item, id: nil %><% end %><% end %>
         <%= label_tag :order, "並び順", class: "text-sm font-bold text-ui-text" %><%= select_tag :order, scenario_order_options(@listing), class: "min-h-11 min-w-0 rounded-ui-control border border-ui-outline-strong bg-ui-field-solid px-3 py-2 text-base text-ui-text" %><%= ui_button("並べ替える", size: :small, type: "submit") %>
       <% end %>

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe "Responsive scenario lists" do
     end
 
     sort_button = find_button("並べ替える")
+    sort_select = find_field("並び順")
+    expect(sort_select.rect.width).to be < 200
     expect(page.evaluate_script("getComputedStyle(arguments[0]).paddingLeft", sort_button)).to eq("12px")
     expect(sort_button.rect.width).to be < 160
     purchase_links = all("td div.gap-x-2 a", visible: :visible)


### PR DESCRIPTION
## What

Size the scenario sort selector to its content at wider viewports.

## Why

The previous grid track stretched the selector to 24rem despite its short options.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `CHROME_BINARY=... bin/rspec spec/system/scenario_list_responsive_spec.rb spec/system/cross_screen_audit_spec.rb`
- [x] `DISABLE_BOOTSNAP=1 bin/ci`

## Related

Closes #143

ADR-0002