### PR TITLE
Show authors on scenario gallery cards

### DIFF
--- a/app/views/shared/ui/_scenario_card.html.erb
+++ b/app/views/shared/ui/_scenario_card.html.erb
@@ -12,6 +12,7 @@
         </div>
         <div class="space-y-3 p-4">
           <h2 class="font-display text-lg font-bold leading-snug text-ui-text group-hover:text-ui-action"><%= scenario.title %></h2>
+          <p class="text-ui-caption text-ui-text-muted"><%= scenario.authors.map(&:name).join("、").presence || "#{Author.model_name.human}未設定" %></p>
           <p class="text-ui-caption text-ui-text-muted"><%= scenario.game_systems.map(&:name).join("／").presence || "#{GameSystem.model_name.human}未設定" %></p>
           <div class="flex flex-wrap gap-2">
             <%= render "shared/ui/badge", label: (player_count_value(scenario) || "人数未設定") %>

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Responsive scenario lists" do
 
       visit root_path(view: "gallery", author_ids: [ author.id ])
       expect(page).to have_css(".aspect-3\\/4", visible: :visible)
+      expect(find(".aspect-3\\/4").ancestor("article")).to have_text(author.name)
       expect(page.evaluate_script("document.documentElement.scrollWidth <= window.innerWidth")).to be(true)
       expect(page).to be_axe_clean
       save_screenshot("scenario-gallery-#{width}.png") if ENV["VISUAL_REVIEW"]

--- a/spec/system/scenario_list_responsive_spec.rb
+++ b/spec/system/scenario_list_responsive_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe "Responsive scenario lists" do
       save_screenshot("scenario-gallery-#{width}.png") if ENV["VISUAL_REVIEW"]
     end
 
+    scenario_without_author = create(:scenario, title: "作者未設定のシナリオ")
+    visit root_path(view: "gallery")
+    expect(find("article", text: scenario_without_author.title)).to have_text("作者未設定")
+
     sign_in_with_google
     [ 320, 1280 ].each do |width|
       page.current_window.resize_to(width, 900)


### PR DESCRIPTION
## What

Show scenario authors in the jacket gallery cards, including an unset fallback.

## Why

Gallery and table presentations should expose the same author information.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`
- [x] `CHROME_BINARY=... bin/rspec spec/system/scenario_list_responsive_spec.rb spec/system/cross_screen_audit_spec.rb`
- [x] `DISABLE_BOOTSNAP=1 bin/ci`

## Related

Closes #144

ADR-0002