### PR TITLE
Preserve Discord memberships during API failures

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,10 +45,10 @@ class User < ApplicationRecord
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + DISCORD_SYNC_DEADLINE
     memberships = groups.index_with do |group|
       remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      remaining.positive? && Timeout.timeout(remaining) { client.member?(group.discord_guild_id, uid) }
+      Timeout.timeout(remaining) { client.member?(group.discord_guild_id, uid) } if remaining.positive?
     rescue DiscordGuildMemberClient::Error, Timeout::Error => error
       Rails.logger.warn("Discord guild membership check failed: #{error.class}")
-      false
+      nil
     end
 
     with_lock do
@@ -63,7 +63,7 @@ class User < ApplicationRecord
         membership = person.group_memberships.find_by(group:)
         if member
           person.group_memberships.create!(group:, discord_managed: true) unless membership
-        elsif membership&.discord_managed?
+        elsif member == false && membership&.discord_managed?
           membership.destroy!
         end
       end

--- a/app/services/discord_guild_member_client.rb
+++ b/app/services/discord_guild_member_client.rb
@@ -6,6 +6,8 @@ class DiscordGuildMemberClient
   API_ORIGIN = "https://discord.com"
   USER_AGENT = "DiscordBot (https://github.com/karia/trpg-scenario-session-catalog, 1.0)"
   RATE_LIMIT_KEY = "discord:guild-member:rate-limited"
+  RESULT_TTL = 1.minute
+  RECENT_RESULT_TTL = 10.minutes
 
   def initialize(bot_token: ENV.fetch("DISCORD_BOT_TOKEN"), cache: Rails.cache)
     @bot_token = bot_token
@@ -15,19 +17,31 @@ class DiscordGuildMemberClient
   def member?(guild_id, user_id)
     raise ArgumentError, "invalid Discord ID" unless [ guild_id, user_id ].all? { |id| id.to_s.match?(/\A\d{17,20}\z/) }
 
+    key = "discord:guild-member:#{guild_id}:#{user_id}"
+    recent_key = "#{key}:recent"
+    cached = @cache.read(key)
+    return cached unless cached.nil?
+
     raise Error, "Discord API is rate limited" if @cache.exist?(RATE_LIMIT_KEY)
 
-    @cache.fetch("discord:guild-member:#{guild_id}:#{user_id}", expires_in: 1.minute) do
-      response = request("/api/v10/guilds/#{guild_id}/members/#{user_id}")
-      if response.is_a?(Net::HTTPSuccess)
-        true
-      elsif response.is_a?(Net::HTTPNotFound)
-        false
-      else
-        remember_rate_limit(response) if response.is_a?(Net::HTTPTooManyRequests)
-        raise Error, "Discord API returned #{response.code}"
-      end
+    response = request("/api/v10/guilds/#{guild_id}/members/#{user_id}")
+    result = if response.is_a?(Net::HTTPSuccess)
+      true
+    elsif response.is_a?(Net::HTTPNotFound)
+      false
+    else
+      remember_rate_limit(response) if response.is_a?(Net::HTTPTooManyRequests)
+      raise Error, "Discord API returned #{response.code}"
     end
+    @cache.write(key, result, expires_in: RESULT_TTL)
+    @cache.write(recent_key, result, expires_in: RECENT_RESULT_TTL)
+    result
+  rescue Error
+    recent = @cache.read(recent_key)
+    raise if recent.nil?
+
+    @cache.write(key, recent, expires_in: RESULT_TTL)
+    recent
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,14 +139,15 @@ RSpec.describe User do
       expect { user.sync_discord_groups!(client:) }.to change(GroupMembership, :count).by(-1)
     end
 
-    it "fails closed when Discord cannot confirm a managed membership" do
+    it "keeps a Discord-managed membership when Discord cannot confirm it" do
       person = create(:person)
       user = create(:user, provider: "discord", uid: user_id, person:)
       group = create(:group, discord_guild_id: "12345678901234567#{8}")
       person.group_memberships.create!(group:, discord_managed: true)
       allow(client).to receive(:member?).and_raise(DiscordGuildMemberClient::Error)
 
-      expect { user.sync_discord_groups!(client:) }.to change(GroupMembership, :count).by(-1)
+      expect { user.sync_discord_groups!(client:) }.not_to change(GroupMembership, :count)
+      expect(person.group_memberships.find_by(group:)).to be_discord_managed
     end
 
     it "enforces one deadline across all configured guilds" do
@@ -162,6 +163,18 @@ RSpec.describe User do
       expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).to be < 0.04
       expect(client).to have_received(:member?).once
       expect(user.reload.person).to be_nil
+    end
+
+    it "keeps unchecked Discord-managed memberships after the deadline" do
+      stub_const("User::DISCORD_SYNC_DEADLINE", 0.01.seconds)
+      person = create(:person)
+      user = create(:user, provider: "discord", uid: user_id, person:)
+      group = create(:group, discord_guild_id: "12345678901234567#{8}")
+      person.group_memberships.create!(group:, discord_managed: true)
+      allow(client).to receive(:member?) { sleep 0.02; false }
+
+      expect { user.sync_discord_groups!(client:) }.not_to change(GroupMembership, :count)
+      expect(person.group_memberships.find_by(group:)).to be_discord_managed
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -80,13 +80,15 @@ RSpec.describe "Sessions" do
     it "signs in a linked Discord user when fetching guilds fails" do
       person = create(:person)
       user = create(:user, provider: "discord", uid: "23456789012345678#{9}", person:)
-      create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
+      group = create(:group, discord_guild_id: "12345678901234567#{8}")
+      membership = person.group_memberships.create!(group:, discord_managed: true)
       allow(discord_client).to receive(:member?)
         .and_raise(DiscordGuildMemberClient::Error, "Discord API returned 503")
 
       sign_in_with_discord
 
       expect(session[:user_id]).to eq(user.id)
+      expect(GroupMembership.exists?(membership.id)).to be(true)
       expect(response).to redirect_to(root_path)
     end
 

--- a/spec/services/discord_guild_member_client_spec.rb
+++ b/spec/services/discord_guild_member_client_spec.rb
@@ -88,4 +88,35 @@ RSpec.describe DiscordGuildMemberClient do
     expect { described_class.new(bot_token: "bot-token").member?(guild_id, user_id) }
       .to raise_error(DiscordGuildMemberClient::Error, "Discord API returned 503")
   end
+
+  it "uses a recent successful result during a short API outage" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    success = Net::HTTPOK.new("1.1", "200", "OK")
+    unavailable = Net::HTTPServiceUnavailable.new("1.1", "503", "Unavailable")
+    http = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:request).twice.and_return(success, unavailable)
+    client = described_class.new(bot_token: "bot-token", cache:)
+
+    expect(client.member?(guild_id, user_id)).to be(true)
+    travel 61.seconds
+    expect(client.member?(guild_id, user_id)).to be(true)
+    expect(client.member?(guild_id, user_id)).to be(true)
+    expect(http).to have_received(:request).twice
+  end
+
+  it "uses a recent non-member result during a short API outage" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    not_found = Net::HTTPNotFound.new("1.1", "404", "Not Found")
+    unavailable = Net::HTTPServiceUnavailable.new("1.1", "503", "Unavailable")
+    allow_any_instance_of(Net::HTTP).to receive(:request).and_return(not_found, unavailable)
+    client = described_class.new(bot_token: "bot-token", cache:)
+
+    expect(client.member?(guild_id, user_id)).to be(false)
+    travel 61.seconds
+    expect(client.member?(guild_id, user_id)).to be(false)
+  end
 end


### PR DESCRIPTION
## What

- Preserve Discord-managed group memberships when guild membership cannot be determined.
- Reuse recent confirmed membership results during short Discord API outages.

## Why

Discord API failures must not revoke session visibility.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #151
