### PR TITLE
Prelink Discord accounts before first sign-in

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,6 +12,7 @@ class PeopleController < ApplicationController
 
   def edit
     authorize @person, :update?
+    prepare_discord_members
   end
 
   def update
@@ -23,6 +24,7 @@ class PeopleController < ApplicationController
     if @person.update(person_params)
       redirect_to person_path(@person), notice: "プロフィールを更新しました"
     else
+      prepare_discord_members
       render :edit, status: :unprocessable_content
     end
   end
@@ -60,6 +62,7 @@ class PeopleController < ApplicationController
       @selected_roles = Array(person_params[:roles]).compact_blank
       @selected_group_ids = Array(person_params[:manual_group_ids]).compact_blank.map(&:to_i)
       @person.assign_attributes(person_params.except(:roles, :manual_group_ids))
+      prepare_discord_members
       render :edit, status: :unprocessable_content
     end
 
@@ -68,8 +71,35 @@ class PeopleController < ApplicationController
       permitted = [ :display_name, :display_alias_key, :x_account, :icon,
         { aliases_attributes: [ [ :id, :name, :context, :visible, :position, :selection_key, :_destroy ] ],
           person_aliases_attributes: [ [ :id, :name, :context, :visible, :position, :_destroy ] ] } ]
+      permitted.prepend(:discord_uid) if policy(@person).manage?
       permitted << { roles: [], manual_group_ids: [] } if policy(@person).manage?
       params.expect(person: permitted)
+    end
+
+    def prepare_discord_members
+      return unless policy(@person).manage?
+
+      guild_ids = @person.groups.where.not(discord_guild_id: nil).unscope(:order).pluck(:discord_guild_id).uniq
+      return if guild_ids.empty?
+
+      client = DiscordGuildMemberClient.new
+      members = guild_ids.flat_map { |guild_id| client.guild_members(guild_id) }.uniq { |member| member.fetch("id") }
+      unavailable_uids = Person.where.not(id: @person.id).where.not(discord_uid: nil).pluck(:discord_uid)
+      unavailable_uids.concat(User.where(provider: "discord").pluck(:uid))
+      members.reject! { |member| unavailable_uids.include?(member.fetch("id")) && member.fetch("id") != @person.discord_uid }
+      @discord_member_options = members.sort_by { |member| member.fetch("display_name").downcase }.map do |member|
+        display_name = member.fetch("display_name")
+        username = member.fetch("username")
+        label = display_name == username ? display_name : "#{display_name} (@#{username})"
+        [ label, member.fetch("id") ]
+      end
+      if @person.discord_uid.present? && @discord_member_options.none? { |_label, uid| uid == @person.discord_uid }
+        @discord_member_options.unshift([ "現在のDiscordアカウント", @person.discord_uid ])
+      end
+    rescue DiscordGuildMemberClient::GuildMembersPermissionError
+      @discord_members_error = "Discordの参加者一覧を取得するにはGUILD_MEMBERS privileged intentが必要です。"
+    rescue DiscordGuildMemberClient::Error
+      @discord_members_error = "Discordの参加者一覧を取得できませんでした。時間をおいて再度お試しください。"
     end
 
     def admin_person_params

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -18,6 +18,8 @@ class PeopleController < ApplicationController
   def update
     authorize @person, :update?
 
+    return render_invalid_discord_uid unless discord_uid_selection_valid?
+
     @lost_roles = roles_lost_by_role_change
     return render_role_change_warning if @lost_roles.any?
 
@@ -64,6 +66,26 @@ class PeopleController < ApplicationController
       @person.assign_attributes(person_params.except(:roles, :manual_group_ids))
       prepare_discord_members
       render :edit, status: :unprocessable_content
+    end
+
+    def render_invalid_discord_uid
+      @selected_roles = Array(person_params[:roles]).compact_blank
+      @selected_group_ids = Array(person_params[:manual_group_ids]).compact_blank.map(&:to_i)
+      @person.assign_attributes(person_params.except(:roles, :manual_group_ids))
+      render :edit, status: :unprocessable_content
+    end
+
+    def discord_uid_selection_valid?
+      return true unless policy(@person).manage? && params[:person]&.key?(:discord_uid)
+
+      uid = params[:person][:discord_uid].presence
+      return true unless uid
+
+      prepare_discord_members
+      return true if @discord_member_options&.any? { |_label, candidate_uid| candidate_uid == uid }
+
+      @person.errors.add(:discord_uid, "は所属するDiscordサーバーの未使用の参加者から選んでください")
+      false
     end
 
     # グループ所属はここでは受け取らない。管理画面（管理者のみ）で扱う。

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,6 +21,8 @@ class Person < ApplicationRecord
   has_many :participations, dependent: :restrict_with_error
 
   validates :display_name, presence: true
+  validates :discord_uid, uniqueness: true, format: { with: /\A\d{17,20}\z/ }, allow_nil: true
+  normalizes :discord_uid, with: ->(value) { value.presence }
   validates :icon,
     content_type: { in: [ :png, :jpeg, :webp ], spoofing_protection: true },
     size: { less_than: 5.megabytes },

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -29,6 +29,7 @@ class Person < ApplicationRecord
     if: -> { attachment_changes.key?("icon") }
   validate :keeps_at_least_one_admin
   validate :roles_are_known
+  validate :discord_uid_is_available
 
   default_scope { order(:display_name) }
 
@@ -80,6 +81,15 @@ class Person < ApplicationRecord
   end
 
   private
+    def discord_uid_is_available
+      return if discord_uid.blank?
+
+      discord_user = User.find_by(provider: "discord", uid: discord_uid)
+      return if discord_user.nil? || (id.present? && discord_user.person_id == id)
+
+      errors.add(:discord_uid, "は別のアカウントで使用されています")
+    end
+
     def roles_are_known
       return if @unknown_roles.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,9 @@ class User < ApplicationRecord
     uid = auth.uid.to_s
     user = find_by(provider:, uid:)
     user ||= find_by(google_uid: uid) if provider == "google_oauth2"
-    user ||= new(provider:, uid:, person: (Person.find_by(discord_uid: uid) if provider == "discord"))
+    prelinked_person = Person.find_by(discord_uid: uid) if provider == "discord"
+    user ||= new(provider:, uid:)
+    user.person ||= prelinked_person
     user.provider = provider
     user.uid = uid
     user.google_uid = user.uid if provider == "google_oauth2"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
     uid = auth.uid.to_s
     user = find_by(provider:, uid:)
     user ||= find_by(google_uid: uid) if provider == "google_oauth2"
-    user ||= new(provider:, uid:)
+    user ||= new(provider:, uid:, person: (Person.find_by(discord_uid: uid) if provider == "discord"))
     user.provider = provider
     user.uid = uid
     user.google_uid = user.uid if provider == "google_oauth2"

--- a/app/services/discord_guild_member_client.rb
+++ b/app/services/discord_guild_member_client.rb
@@ -3,6 +3,7 @@ require "json"
 
 class DiscordGuildMemberClient
   Error = Class.new(StandardError)
+  GuildMembersPermissionError = Class.new(Error)
   API_ORIGIN = "https://discord.com"
   USER_AGENT = "DiscordBot (https://github.com/karia/trpg-scenario-session-catalog, 1.0)"
   RATE_LIMIT_KEY = "discord:guild-member:rate-limited"
@@ -18,33 +19,87 @@ class DiscordGuildMemberClient
     raise ArgumentError, "invalid Discord ID" unless [ guild_id, user_id ].all? { |id| id.to_s.match?(/\A\d{17,20}\z/) }
 
     key = "discord:guild-member:#{guild_id}:#{user_id}"
-    recent_key = "#{key}:recent"
-    cached = @cache.read(key)
-    return cached unless cached.nil?
-
-    raise Error, "Discord API is rate limited" if @cache.exist?(RATE_LIMIT_KEY)
-
-    response = request("/api/v10/guilds/#{guild_id}/members/#{user_id}")
-    result = if response.is_a?(Net::HTTPSuccess)
-      true
-    elsif response.is_a?(Net::HTTPNotFound)
-      false
-    else
-      remember_rate_limit(response) if response.is_a?(Net::HTTPTooManyRequests)
-      raise Error, "Discord API returned #{response.code}"
+    cached_result(key) do
+      ensure_not_rate_limited!
+      response = request("/api/v10/guilds/#{guild_id}/members/#{user_id}")
+      if response.is_a?(Net::HTTPSuccess)
+        true
+      elsif response.is_a?(Net::HTTPNotFound)
+        false
+      else
+        handle_error_response(response)
+      end
     end
-    @cache.write(key, result, expires_in: RESULT_TTL)
-    @cache.write(recent_key, result, expires_in: RECENT_RESULT_TTL)
-    result
-  rescue Error
-    recent = @cache.read(recent_key)
-    raise if recent.nil?
+  end
 
-    @cache.write(key, recent, expires_in: RESULT_TTL)
-    recent
+  def guild_members(guild_id)
+    raise ArgumentError, "invalid Discord ID" unless guild_id.to_s.match?(/\A\d{17,20}\z/)
+
+    cached_result("discord:guild-members:#{guild_id}") do
+      fetch_guild_members(guild_id)
+    end
   end
 
   private
+    def cached_result(key)
+      cached = @cache.read(key)
+      return cached unless cached.nil?
+
+      result = yield
+      @cache.write(key, result, expires_in: RESULT_TTL)
+      @cache.write("#{key}:recent", result, expires_in: RECENT_RESULT_TTL)
+      result
+    rescue Error
+      recent = @cache.read("#{key}:recent")
+      raise if recent.nil?
+
+      @cache.write(key, recent, expires_in: RESULT_TTL)
+      recent
+    end
+
+    def fetch_guild_members(guild_id)
+      members = []
+      after = nil
+      loop do
+        ensure_not_rate_limited!
+        path = "/api/v10/guilds/#{guild_id}/members?limit=1000"
+        path += "&after=#{after}" if after
+        response = request(path)
+        handle_error_response(response) unless response.is_a?(Net::HTTPSuccess)
+        page = parse_guild_members(response.body)
+        members.concat(page)
+        break if page.size < 1_000
+
+        after = page.last.fetch("id")
+      end
+      members
+    end
+
+    def parse_guild_members(body)
+      JSON.parse(body).map do |member|
+        user = member.fetch("user")
+        {
+          "id" => user.fetch("id"),
+          "username" => user.fetch("username"),
+          "display_name" => member["nick"].presence || user["global_name"].presence || user.fetch("username"),
+          "avatar" => user["avatar"]
+        }
+      end
+    rescue JSON::ParserError, KeyError, TypeError => error
+      raise Error, "Discord API returned invalid guild members: #{error.message}"
+    end
+
+    def ensure_not_rate_limited!
+      raise Error, "Discord API is rate limited" if @cache.exist?(RATE_LIMIT_KEY)
+    end
+
+    def handle_error_response(response)
+      raise GuildMembersPermissionError, "Discord guild members permission is missing" if response.is_a?(Net::HTTPForbidden)
+
+      remember_rate_limit(response) if response.is_a?(Net::HTTPTooManyRequests)
+      raise Error, "Discord API returned #{response.code}"
+    end
+
     def request(path)
       uri = URI.join(API_ORIGIN, path)
       http = Net::HTTP.new(uri.host, uri.port)

--- a/app/views/people/_administration_fields.html.erb
+++ b/app/views/people/_administration_fields.html.erb
@@ -1,5 +1,7 @@
 <% roles = local_assigns[:selected_roles] || person.roles %>
 <% group_ids = local_assigns[:selected_group_ids] || person.manual_group_ids %>
+<% discord_member_options = local_assigns[:discord_member_options] %>
+<% discord_members_error = local_assigns[:discord_members_error] %>
 <fieldset class="rounded-ui-card border border-ui-outline bg-ui-surface-solid p-5 sm:p-6">
   <legend class="px-2 font-display text-lg font-bold">管理項目</legend>
   <div class="space-y-2">
@@ -14,5 +16,17 @@
   <div class="mt-5 space-y-2">
     <span class="block text-sm font-bold"><%= Group.model_name.human %></span>
     <div class="flex flex-wrap gap-x-5 gap-y-2"><%= form.collection_check_boxes :manual_group_ids, Group.all.to_a, :id, :name, checked: group_ids do |group| %><%= group.label class: "inline-flex min-h-11 items-center gap-2 text-sm" do %><%= group.check_box class: "size-5 accent-ui-action" %><%= group.text %><% end %><% end %></div>
+  </div>
+  <div class="mt-5">
+    <% if discord_members_error.present? %>
+      <p class="text-sm text-ui-error"><%= discord_members_error %></p>
+    <% elsif !discord_member_options.nil? %>
+      <%= ui_field(form, :discord_uid, label: "Discordアカウント", description: "所属グループのDiscordサーバー参加者から選びます。") do |field| %>
+        <%= ui_select(form, :discord_uid, discord_member_options, include_blank: "紐づけなし", described_by: field[:described_by]) %>
+      <% end %>
+      <% if discord_member_options.empty? %><p class="mt-2 text-sm text-ui-text-muted">新たに紐づけられる参加者はいません。</p><% end %>
+    <% else %>
+      <p class="text-sm text-ui-text-muted">Discordサーバーに紐づいた所属グループがありません。</p>
+    <% end %>
   </div>
 </fieldset>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -19,7 +19,7 @@
 
     <%= render "shared/ui/alias_fields", form:, display_attribute: :display_name, alias_class: PersonAlias %>
     <% if policy(@person).manage? %>
-      <%= render "people/administration_fields", form:, person: @person, selected_roles: @selected_roles, selected_group_ids: @selected_group_ids %>
+      <%= render "people/administration_fields", form:, person: @person, selected_roles: @selected_roles, selected_group_ids: @selected_group_ids, discord_member_options: @discord_member_options, discord_members_error: @discord_members_error %>
     <% else %>
       <p class="text-ui-caption text-ui-text-muted"><%= Group.model_name.human %>の所属は管理者が設定します。</p>
     <% end %>

--- a/db/migrate/20260825190130_add_discord_uid_to_people.rb
+++ b/db/migrate/20260825190130_add_discord_uid_to_people.rb
@@ -1,0 +1,6 @@
+class AddDiscordUidToPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :people, :discord_uid, :string
+    add_index :people, :discord_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_190130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -123,9 +123,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_160000) do
 
   create_table "people", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "discord_uid"
     t.string "display_name", null: false
     t.datetime "updated_at", null: false
     t.string "x_account"
+    t.index ["discord_uid"], name: "index_people_on_discord_uid", unique: true
   end
 
   create_table "person_aliases", force: :cascade do |t|

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Person do
     expect(build(:person, display_name: "")).not_to be_valid
   end
 
+  it "requires a unique valid Discord UID when prelinked" do
+    create(:person, discord_uid: "12345678901234567#{8}")
+
+    expect(build(:person, discord_uid: "12345678901234567#{8}")).not_to be_valid
+    expect(build(:person, discord_uid: "not-an-id")).not_to be_valid
+    expect(build(:person, discord_uid: "")).to be_valid
+  end
+
   describe "roles" do
     it "starts with none" do
       expect(create(:person)).not_to be_admin

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe Person do
     expect(build(:person, discord_uid: "")).to be_valid
   end
 
+  it "rejects a Discord UID already used by an account" do
+    uid = "23456789012345678#{9}"
+    create(:user, provider: "discord", uid:, person: nil)
+
+    expect(build(:person, discord_uid: uid)).not_to be_valid
+  end
+
   describe "roles" do
     it "starts with none" do
       expect(create(:person)).not_to be_admin

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -86,6 +86,20 @@ RSpec.describe User do
       expect(first.name).to eq("Discord User")
       expect { described_class.from_omniauth(auth) }.not_to change(described_class, :count)
     end
+
+    it "links a new Discord account to a prelinked person" do
+      uid = "23456789012345678#{9}"
+      person = create(:person, discord_uid: uid)
+      auth = OmniAuth::AuthHash.new(
+        provider: "discord", uid:, info: { email: "discord@example.com", name: "Discord User" }
+      )
+
+      user = described_class.from_omniauth(auth)
+
+      expect(user.person).to eq(person)
+      expect { user.sync_discord_groups!(client: instance_double(DiscordGuildMemberClient)) }
+        .not_to change(Person, :count)
+    end
   end
 
   describe "#sync_discord_groups!" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe User do
       expect { user.sync_discord_groups!(client: instance_double(DiscordGuildMemberClient)) }
         .not_to change(Person, :count)
     end
+
+    it "links an existing unlinked Discord account to a concurrently prelinked person" do
+      uid = "23456789012345678#{9}"
+      person = create(:person, discord_uid: uid)
+      user = create(:user, provider: "discord", uid:, person: nil)
+      auth = OmniAuth::AuthHash.new(provider: "discord", uid:, info: { name: "Discord User" })
+
+      expect(described_class.from_omniauth(auth)).to eq(user)
+      expect(user.reload.person).to eq(person)
+    end
   end
 
   describe "#sync_discord_groups!" do

--- a/spec/requests/manage/people_spec.rb
+++ b/spec/requests/manage/people_spec.rb
@@ -42,6 +42,54 @@ RSpec.describe "Manage::People" do
   describe "as an admin" do
     before { sign_in_as create(:person, roles: %w[admin], display_name: "カーリア") }
 
+    it "offers unlinked members from the person's Discord guilds" do
+      person = create(:person)
+      group = create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
+      client = instance_double(DiscordGuildMemberClient)
+      allow(DiscordGuildMemberClient).to receive(:new).and_return(client)
+      allow(client).to receive(:guild_members).with(group.discord_guild_id).and_return([
+        { "id" => "23456789012345678#{9}", "display_name" => "Guild Nick", "username" => "username" },
+        { "id" => "34567890123456789#{0}", "display_name" => "Already Linked", "username" => "linked" }
+      ])
+      create(:person, discord_uid: "34567890123456789#{0}")
+
+      get edit_person_path(person)
+
+      page = Capybara.string(response.body)
+      expect(page).to have_select("Discordアカウント", options: [ "紐づけなし", "Guild Nick (@username)" ])
+      expect(page).not_to have_text("Already Linked")
+    end
+
+    it "saves a Discord member selected in person editing" do
+      person = create(:person)
+      group = create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
+      client = instance_double(DiscordGuildMemberClient)
+      allow(DiscordGuildMemberClient).to receive(:new).and_return(client)
+      allow(client).to receive(:guild_members).with(group.discord_guild_id).and_return([])
+
+      patch person_path(person), params: {
+        person: { display_name: person.display_name, roles: [], manual_group_ids: [ group.id ],
+          discord_uid: "23456789012345678#{9}" }
+      }
+
+      expect(response).to redirect_to(person_path(person))
+      expect(person.reload.discord_uid).to eq("23456789012345678#{9}")
+    end
+
+    it "keeps the edit screen available when the guild members intent is missing" do
+      person = create(:person)
+      create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
+      client = instance_double(DiscordGuildMemberClient)
+      allow(DiscordGuildMemberClient).to receive(:new).and_return(client)
+      allow(client).to receive(:guild_members)
+        .and_raise(DiscordGuildMemberClient::GuildMembersPermissionError)
+
+      get edit_person_path(person)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("GUILD_MEMBERS")
+    end
+
     it "limits the icon picker to supported image formats" do
       person = create(:person)
 

--- a/spec/requests/manage/people_spec.rb
+++ b/spec/requests/manage/people_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe "Manage::People" do
       group = create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
       client = instance_double(DiscordGuildMemberClient)
       allow(DiscordGuildMemberClient).to receive(:new).and_return(client)
-      allow(client).to receive(:guild_members).with(group.discord_guild_id).and_return([])
+      allow(client).to receive(:guild_members).with(group.discord_guild_id).and_return([
+        { "id" => "23456789012345678#{9}", "display_name" => "Guild Member", "username" => "member" }
+      ])
 
       patch person_path(person), params: {
         person: { display_name: person.display_name, roles: [], manual_group_ids: [ group.id ],
@@ -74,6 +76,21 @@ RSpec.describe "Manage::People" do
 
       expect(response).to redirect_to(person_path(person))
       expect(person.reload.discord_uid).to eq("23456789012345678#{9}")
+    end
+
+    it "rejects a Discord UID outside the offered guild members" do
+      person = create(:person)
+      group = create(:group, discord_guild_id: "12345678901234567#{8}", people: [ person ])
+      client = instance_double(DiscordGuildMemberClient, guild_members: [])
+      allow(DiscordGuildMemberClient).to receive(:new).and_return(client)
+
+      patch person_path(person), params: {
+        person: { display_name: person.display_name, roles: [], manual_group_ids: [ group.id ],
+          discord_uid: "23456789012345678#{9}" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(person.reload.discord_uid).to be_nil
     end
 
     it "keeps the edit screen available when the guild members intent is missing" do

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -119,6 +119,16 @@ RSpec.describe "People" do
       expect(person.reload.groups).to be_empty
     end
 
+    it "does not let the person prelink their own Discord account" do
+      sign_in_as person
+
+      patch person_path(person), params: {
+        person: { display_name: "本人", discord_uid: "23456789012345678#{9}" }
+      }
+
+      expect(person.reload.discord_uid).to be_nil
+    end
+
     it "lets an admin change group membership from the admin screen" do
       group = create(:group)
       sign_in_as create(:person, roles: %w[admin])

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe "Sessions" do
       expect(response).to redirect_to(root_path)
     end
 
+    it "uses a prelinked person on their first Discord sign-in" do
+      uid = "23456789012345678#{9}"
+      group = create(:group, discord_guild_id: "12345678901234567#{8}")
+      person = create(:person, discord_uid: uid, groups: [ group ])
+      allow(discord_client).to receive(:member?).with(group.discord_guild_id, uid).and_return(true)
+
+      expect { sign_in_with_discord }.not_to change(Person, :count)
+
+      expect(User.sole.person).to eq(person)
+      expect(session[:user_id]).to eq(User.sole.id)
+    end
+
     it "removes Discord-managed access on the first request after leaving the guild" do
       group = create(:group, discord_guild_id: "12345678901234567#{8}")
       allow(discord_client).to receive(:member?).and_return(true)

--- a/spec/services/discord_guild_member_client_spec.rb
+++ b/spec/services/discord_guild_member_client_spec.rb
@@ -119,4 +119,78 @@ RSpec.describe DiscordGuildMemberClient do
     travel 61.seconds
     expect(client.member?(guild_id, user_id)).to be(false)
   end
+
+  describe "#guild_members" do
+    def json_response(body)
+      response = Net::HTTPOK.new("1.1", "200", "OK")
+      response.body = JSON.generate(body)
+      response.instance_variable_set(:@read, true)
+      response
+    end
+
+    it "uses nick, global name, then username as each display name" do
+      response = json_response([
+        { nick: "Guild Nick", user: { id: user_id, username: "first", global_name: "Global Name", avatar: "a" } },
+        { nick: nil, user: { id: "34567890123456789#{0}", username: "second", global_name: "Second Global", avatar: nil } },
+        { nick: nil, user: { id: "45678901234567890#{1}", username: "third", global_name: nil, avatar: nil } }
+      ])
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+
+      members = described_class.new(bot_token: "bot-token").guild_members(guild_id)
+
+      expect(members.pluck("display_name")).to eq([ "Guild Nick", "Second Global", "third" ])
+      expect(members.first).to include("id" => user_id, "username" => "first")
+    end
+
+    it "fetches another page after a full page" do
+      first_page = 1_000.times.map do |index|
+        id = format("%018d", index + 1)
+        { nick: nil, user: { id:, username: "user#{index}", global_name: nil, avatar: nil } }
+      end
+      final_member = { nick: nil, user: { id: "99999999999999999#{9}", username: "last", global_name: nil, avatar: nil } }
+      responses = [ json_response(first_page), json_response([ final_member ]) ]
+      requests = []
+      allow_any_instance_of(Net::HTTP).to receive(:request) do |_http, request|
+        requests << request
+        responses.shift
+      end
+
+      members = described_class.new(bot_token: "bot-token").guild_members(guild_id)
+
+      expect(members.size).to eq(1_001)
+      expect(requests.map(&:path)).to eq([
+        "/api/v10/guilds/#{guild_id}/members?limit=1000",
+        "/api/v10/guilds/#{guild_id}/members?limit=1000&after=000000000000001000"
+      ])
+    end
+
+    it "raises a specific error when the privileged intent is unavailable" do
+      response = Net::HTTPForbidden.new("1.1", "403", "Forbidden")
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+
+      expect { described_class.new(bot_token: "bot-token").guild_members(guild_id) }
+        .to raise_error(DiscordGuildMemberClient::GuildMembersPermissionError)
+    end
+
+    it "reuses a recent list after an API failure and suppresses the next request" do
+      cache = ActiveSupport::Cache::MemoryStore.new
+      success = json_response([
+        { nick: nil, user: { id: user_id, username: "member", global_name: nil, avatar: nil } }
+      ])
+      unavailable = Net::HTTPServiceUnavailable.new("1.1", "503", "Unavailable")
+      http = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:request).twice.and_return(success, unavailable)
+      client = described_class.new(bot_token: "bot-token", cache:)
+
+      expect(client.guild_members(guild_id).sole.fetch("id")).to eq(user_id)
+      travel 61.seconds
+      expect(client.guild_members(guild_id).sole.fetch("id")).to eq(user_id)
+      expect(client.guild_members(guild_id).sole.fetch("id")).to eq(user_id)
+      expect(http).to have_received(:request).twice
+    end
+  end
 end

--- a/spec/system/cross_screen_audit_spec.rb
+++ b/spec/system/cross_screen_audit_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe "Cross-screen audit" do
 
   before do
     skip "Chrome is required for the cross-screen audit" unless ENV["CHROME_BINARY"].present?
+    discord_client = instance_double(DiscordGuildMemberClient, guild_members: [
+      { "id" => "23456789012345678#{9}", "display_name" => "監査用ニックネーム", "username" => "audit-user" }
+    ])
+    allow(DiscordGuildMemberClient).to receive(:new).and_return(discord_client)
     audit
   end
 
@@ -287,7 +291,8 @@ RSpec.describe "Cross-screen audit" do
         game_system:,
         scenario:,
         play_session:,
-        group: create(:group, name: "折り返しを確かめるための長いグループ名", people: [ member ]),
+        group: create(:group, name: "折り返しを確かめるための長いグループ名",
+          discord_guild_id: "12345678901234567#{8}", people: [ member ]),
         user: create(:user, person: member, email: "audited-account@example.com"),
         admin_user: create(:user, person: admin)
       }


### PR DESCRIPTION
## What

- Let administrators prelink a person to an unclaimed Discord guild member.
- Link the first matching Discord login to the existing person.
- Add paginated guild-member lookup with cached fallback and permission-aware errors.

## Why

Participants should receive their existing person and group access on their first sign-in without creating duplicates.

## Verification

- [x] `bin/rspec`
- [x] `prek run --all-files`

## Related

Closes #152
